### PR TITLE
teamhephy-strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Deis Workflow** is an open source Platform as a Service (PaaS) that adds a developer-friendly layer to any [Kubernetes][k8s-home] cluster, making it easy to deploy and manage applications.
 
-Deis Workflow is the second major release (v2) of the Deis PaaS. If you are looking for the CoreOS-based PaaS visit [https://github.com/deisthree/deis](https://github.com/deisthree/deis).
+Deis Workflow is the second major release (v2) of the Deis PaaS. If you are looking for the CoreOS-based PaaS visit [https://github.com/deis/deis](https://github.com/deis/deis).
 
 To **get started** with **Deis Workflow** please read the [Quick Start Guide](https://deis.com/docs/workflow/quickstart/).
 
@@ -20,22 +20,22 @@ This repository contains the source code for Deis Workflow documentation. If you
 
 Please see below for links and descriptions of each component:
 
-- [controller](https://github.com/deisthree/controller) - Workflow API server
-- [builder](https://github.com/deisthree/builder) - Git server and source-to-image component
-- [dockerbuilder](https://github.com/deisthree/dockerbuilder) - The builder for [Docker](https://www.docker.com/) based applications
-- [slugbuilder](https://github.com/deisthree/slugbuilder) - The builder for [slug/buildpack](https://devcenter.heroku.com/articles/slug-compiler) based applications
-- [slugrunner](https://github.com/deisthree/slugrunner) - The runner for slug/buildpack based applications
-- [fluentd](https://github.com/deisthree/fluentd) - Backend log shipping mechanism for `deis logs`
-- [postgres](https://github.com/deisthree/postgres) - The central database
-- [registry](https://github.com/deisthree/registry) - The Docker registry
-- [logger](https://github.com/deisthree/logger) - The (in-memory) log buffer for `deis logs`
-- [monitor](https://github.com/deisthree/monitor) - The platform monitoring components
-- [router](https://github.com/deisthree/router) - The HTTP/s edge router
-- [minio](https://github.com/deisthree/minio) - The in-cluster, ephemeral, development-only object storage system
-- [nsq](https://github.com/deisthree/nsq) - Realtime distributed messaging platform
-- [workflow-cli](https://github.com/deisthree/workflow-cli) - Workflow CLI `deis`
-- [workflow-e2e](https://github.com/deisthree/workflow-e2e) - End-to-end tests for the entire platform
-- [workflow-manager](https://github.com/deisthree/workflow-manager) - Manage, inspect, and debug a Workflow cluster
+- [controller](https://github.com/teamhephy/controller) - Workflow API server
+- [builder](https://github.com/teamhephy/builder) - Git server and source-to-image component
+- [dockerbuilder](https://github.com/teamhephy/dockerbuilder) - The builder for [Docker](https://www.docker.com/) based applications
+- [slugbuilder](https://github.com/teamhephy/slugbuilder) - The builder for [slug/buildpack](https://devcenter.heroku.com/articles/slug-compiler) based applications
+- [slugrunner](https://github.com/teamhephy/slugrunner) - The runner for slug/buildpack based applications
+- [fluentd](https://github.com/teamhephy/fluentd) - Backend log shipping mechanism for `deis logs`
+- [postgres](https://github.com/teamhephy/postgres) - The central database
+- [registry](https://github.com/teamhephy/registry) - The Docker registry
+- [logger](https://github.com/teamhephy/logger) - The (in-memory) log buffer for `deis logs`
+- [monitor](https://github.com/teamhephy/monitor) - The platform monitoring components
+- [router](https://github.com/teamhephy/router) - The HTTP/s edge router
+- [minio](https://github.com/teamhephy/minio) - The in-cluster, ephemeral, development-only object storage system
+- [nsq](https://github.com/teamhephy/nsq) - Realtime distributed messaging platform
+- [workflow-cli](https://github.com/teamhephy/workflow-cli) - Workflow CLI `deis`
+- [workflow-e2e](https://github.com/teamhephy/workflow-e2e) - End-to-end tests for the entire platform
+- [workflow-manager](https://github.com/teamhephy/workflow-manager) - Manage, inspect, and debug a Workflow cluster
 
 We welcome your input! If you have feedback, please [submit an issue][issues]. If you'd like to participate in development, please read the "Working on Documentation" section below and [submit a pull request][prs].
 
@@ -77,6 +77,6 @@ Then view the documentation on [http://localhost:8000](http://localhost:8000) or
 [k8s-home]: http://kubernetes.io
 [install-k8s]: http://kubernetes.io/gettingstarted/
 [mkdocs]: http://www.mkdocs.org/
-[issues]: https://github.com/deisthree/workflow/issues
-[prs]: https://github.com/deisthree/workflow/pulls
-[v2.18]: https://github.com/deisthree/workflow/releases/tag/v2.18.0
+[issues]: https://github.com/teamhephy/workflow/issues
+[prs]: https://github.com/teamhephy/workflow/pulls
+[v2.18]: https://github.com/teamhephy/workflow/releases/tag/v2.18.0

--- a/charts/workflow/Chart.yaml
+++ b/charts/workflow/Chart.yaml
@@ -1,7 +1,7 @@
 name: workflow
-home: https://github.com/deisthree/workflow
+home: https://github.com/teamhephy/workflow
 version: <Will be populated by the ci before publishing the chart>
-description: Deis Workflow
+description: Hephy Workflow
 maintainers:
-  - name: Deis Team
-    email: engineering@deis.com
+  - name: Team Hephy
+    email: team@teamhephy.com

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -210,7 +210,7 @@ registry-token-refresher:
 
 router:
   dhparam: ""
-  # Any custom router annotations(https://github.com/deisthree/router#annotations)
+  # Any custom router annotations(https://github.com/teamhephy/router#annotations)
   # which need to be applied can be specified as key-value pairs under "deployment_annotations"
   deployment_annotations:
     #<example-key>: <example-value>
@@ -228,5 +228,5 @@ router:
   # service_type: LoadBalancer
 
 workflow-manager:
-  versions_api_url: https://versions.deis.com
-  doctor_api_url: https://doctor.deis.com
+  versions_api_url: https://versions.teamhephy.info
+  doctor_api_url: https://doctor.teamhephy.info

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@
 # names
 #
 site_name: Deis Workflow Documentation
-site_url: https://deis.com/docs/workflow
+site_url: https://teamhephy.com/docs/workflow
 pages:
   - Home: index.md
   - Quick Start:
@@ -131,4 +131,3 @@ extra_javascript:
   - static/js/foundation.offcanvas.js
   - static/js/headroom.min.js
   - static/js/adjustments.js
-google_analytics: ['UA-42867143-3', 'auto']

--- a/src/applications/managing-app-lifecycle.md
+++ b/src/applications/managing-app-lifecycle.md
@@ -89,7 +89,7 @@ When working with an application that has been shared with you, clone the origin
 entry before attempting to `git push` any changes to Deis.
 
 ```
-$ git clone https://github.com/deisthree/example-java-jetty.git
+$ git clone https://github.com/teamhephy/example-java-jetty.git
 Cloning into 'example-java-jetty'... done
 $ cd example-java-jetty
 $ git remote add -f deis ssh://git@local3.deisapp.com:2222/peachy-waxworks.git

--- a/src/applications/using-buildpacks.md
+++ b/src/applications/using-buildpacks.md
@@ -21,7 +21,7 @@ Read more about adding/removing SSH Keys [here](../users/ssh-keys.md#adding-and-
 
 If you do not have an existing application, you can clone an example application that demonstrates the Heroku Buildpack workflow.
 
-    $ git clone https://github.com/deisthree/example-go.git
+    $ git clone https://github.com/teamhephy/example-go.git
     $ cd example-go
 
 

--- a/src/applications/using-docker-images.md
+++ b/src/applications/using-docker-images.md
@@ -8,7 +8,7 @@ This is useful for integrating Deis into Docker-based CI/CD pipelines.
 
 Start by cloning an example application:
 
-    $ git clone https://github.com/deisthree/example-dockerfile-http.git
+    $ git clone https://github.com/teamhephy/example-dockerfile-http.git
     $ cd example-dockerfile-http
 
 Next use your local `docker` client to build the image and push

--- a/src/applications/using-dockerfiles.md
+++ b/src/applications/using-dockerfiles.md
@@ -23,7 +23,7 @@ Read more about adding/removing SSH Keys [here](../users/ssh-keys.md#adding-and-
 
 If you do not have an existing application, you can clone an example application that demonstrates the Dockerfile workflow.
 
-    $ git clone https://github.com/deisthree/helloworld.git
+    $ git clone https://github.com/teamhephy/helloworld.git
     $ cd helloworld
 
 

--- a/src/changelogs/v2.0.0.md
+++ b/src/changelogs/v2.0.0.md
@@ -2,71 +2,71 @@
 
 #### Fixes
 
-- [`db4cd9d`](https://github.com/deisthree/postgres/commit/db4cd9db4df12489ab0d9ff27094322e889ed871) (postgres) - rootfs: always perform an initial backup
-- [`7c89a3c`](https://github.com/deisthree/postgres/commit/7c89a3c290e845fe909faad835b8410ce8bbe6b9) (postgres) - rootfs: enable archive_mode before initial boot
-- [`5910902`](https://github.com/deisthree/controller/commit/591090224719c47b209a1e1e74c1168f16248b92) (controller) - scheduler: cast ports to int before passing them on to k8s
-- [`20ea192`](https://github.com/deisthree/workflow/commit/20ea192cf9537217d010ff1dc5e3f2807d32bce4) (workflow) - health: remove documentation on unused HEALTHCHECK_PORT
-- [`cfdd9ab`](https://github.com/deisthree/charts/commit/cfdd9ab996a49ca119d954d81fc4569bd52ff89c) (charts) - deis-dev/tpl/deis-builder-rc.yaml: make the objectstore-creds secret read-only in builder
+- [`db4cd9d`](https://github.com/deis/postgres/commit/db4cd9db4df12489ab0d9ff27094322e889ed871) (postgres) - rootfs: always perform an initial backup
+- [`7c89a3c`](https://github.com/deis/postgres/commit/7c89a3c290e845fe909faad835b8410ce8bbe6b9) (postgres) - rootfs: enable archive_mode before initial boot
+- [`5910902`](https://github.com/deis/controller/commit/591090224719c47b209a1e1e74c1168f16248b92) (controller) - scheduler: cast ports to int before passing them on to k8s
+- [`20ea192`](https://github.com/deis/workflow/commit/20ea192cf9537217d010ff1dc5e3f2807d32bce4) (workflow) - health: remove documentation on unused HEALTHCHECK_PORT
+- [`cfdd9ab`](https://github.com/deis/charts/commit/cfdd9ab996a49ca119d954d81fc4569bd52ff89c) (charts) - deis-dev/tpl/deis-builder-rc.yaml: make the objectstore-creds secret read-only in builder
 
 
 
 #### Documentation
 
-- [`afc9d2a`](https://github.com/deisthree/registry/commit/afc9d2a54a1248aef380de5b99ce8fd2ce0b0ad8) (registry) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`a807d2a`](https://github.com/deisthree/registry/commit/a807d2a79388944e6a599238ea3d5c0eb09a44ac) (registry) - CHANGELOG.md: add entry for v2.0.0
-- [`55cf8a1`](https://github.com/deisthree/workflow-manager/commit/55cf8a198761e5b6f6710f95a8058a3fe378c261) (workflow-manager) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`f110d04`](https://github.com/deisthree/workflow-manager/commit/f110d0455e3203986f3c5151896f73014d93761f) (workflow-manager) - CHANGELOG.md: add entry for v2.0.0
-- [`a06057d`](https://github.com/deisthree/postgres/commit/a06057df0589f611f30089f0f6ddceec8013416e) (postgres) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`77e2991`](https://github.com/deisthree/postgres/commit/77e2991bdac5d7f0fcca9cbcd201a1b5f27c64aa) (postgres) - CHANGELOG.md: add entry for v2.0.0
-- [`0393a7a`](https://github.com/deisthree/workflow-e2e/commit/0393a7af5760d1e62fb14be0eb55e0ce2450ea32) (workflow-e2e) - README.md: remove beta status
-- [`9214eee`](https://github.com/deisthree/workflow-e2e/commit/9214eeeb1434c0d5e30a656cb1ca86a21f06828e) (workflow-e2e) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`a93420f`](https://github.com/deisthree/workflow-e2e/commit/a93420fd7a3224d69bf396360eeb2a6abb765798) (workflow-e2e) - CHANGELOG.md: add entry for v2.0.0
-- [`d39fcc1`](https://github.com/deisthree/stdout-metrics/commit/d39fcc1a3d73f1b2d4b7d0382caec4b0513a4fcf) (stdout-metrics) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`305c25c`](https://github.com/deisthree/stdout-metrics/commit/305c25c0a508c5872463a37be966c62744925cab) (stdout-metrics) - CHANGELOG.md: add entry for v2.0.0
-- [`1993192`](https://github.com/deisthree/slugrunner/commit/199319218532498bd0ece7afe7454075552f2bbe) (slugrunner) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`8df35f9`](https://github.com/deisthree/slugrunner/commit/8df35f979fdd6ce48202a64312e480df5818db5f) (slugrunner) - CHANGELOG.md: add entry for v2.0.0
-- [`1bbaf04`](https://github.com/deisthree/slugbuilder/commit/1bbaf04c1dbee3dab0881e1816d9dd4c8804616a) (slugbuilder) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`71f7e6c`](https://github.com/deisthree/slugbuilder/commit/71f7e6c62886922a31243fd4eb76f8a41adca170) (slugbuilder) - CHANGELOG.md: add entry for v2.0.0
-- [`eafb142`](https://github.com/deisthree/monitor/commit/eafb142499205c4eb986bbee4047365db93e9c54) (monitor) - README: Update readme to remove beta status
-- [`6b979ed`](https://github.com/deisthree/monitor/commit/6b979edffdd4a8a23aab730817a8025c637b3d2b) (monitor) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`42f91b2`](https://github.com/deisthree/monitor/commit/42f91b22465f9851fc089a4118219805c5bb60e5) (monitor) - README: Add architecture diagram
-- [`477be8b`](https://github.com/deisthree/monitor/commit/477be8b2090770a956ab434866054022da89d3a9) (monitor) - CHANGELOG.md: add entry for v2.0.0
-- [`5afdca3`](https://github.com/deisthree/minio/commit/5afdca35f1dc77e8e55501f40db630b335fa0a05) (minio) - CHANGELOG.md: add entry for v2.0.0
-- [`bce6c31`](https://github.com/deisthree/builder/commit/bce6c31e3905205a4ea5bfce57f9a3130a0e0a22) (builder) - pkg: update help URL to https://deis.com/
-- [`ea6b17a`](https://github.com/deisthree/builder/commit/ea6b17a5c635b87874f7433a998c431c1058eeaa) (builder) - CHANGELOG.md: add entry for v2.0.0
-- [`f37322b`](https://github.com/deisthree/dockerbuilder/commit/f37322b0bffd7c10fa3e66ebdc33e874e633b265) (dockerbuilder) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`66a176b`](https://github.com/deisthree/dockerbuilder/commit/66a176bbecc8e62c0f3948198d9e6868b1160f22) (dockerbuilder) - CHANGELOG.md: add entry for v2.0.0
-- [`e945cb5`](https://github.com/deisthree/fluentd/commit/e945cb57f79fab482c5b835599af2bcc9da3cb51) (fluentd) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`06f6fed`](https://github.com/deisthree/fluentd/commit/06f6fedf6320c08214b97cba26898ef2bf9230cd) (fluentd) - CHANGELOG.md: add entry for v2.0.0
-- [`f7188cd`](https://github.com/deisthree/logger/commit/f7188cd9de9a728a43ecff175bc5f33767051860) (logger) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`9c3019c`](https://github.com/deisthree/logger/commit/9c3019ce68e597f708819189ba706433dd23d67c) (logger) - CHANGELOG.md: add entry for v2.0.0
-- [`07eb015`](https://github.com/deisthree/router/commit/07eb015f6296ae5353d348a48b8ae1dccff648dc) (router) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`7e0eb9d`](https://github.com/deisthree/router/commit/7e0eb9dafb17ea02aaecaf170d74c63c6a4209f4) (router) - CHANGELOG.md: add entry for v2.0.0
-- [`2d08fb5`](https://github.com/deisthree/controller/commit/2d08fb5cce7990e9d432ec8934f3d77ff12d4b94) (controller) - CHANGELOG.md: add entry for v2.0.0
-- [`0babcff`](https://github.com/deisthree/workflow/commit/0babcff98dd1b1a9a0263b943656ea94e0df3cc4) (workflow) - CHANGELOG.md: add entry for v2.0.0
-- [`492d25e`](https://github.com/deisthree/charts/commit/492d25ed32026db10a18fb750bd54f978c904163) (charts) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`3ee1184`](https://github.com/deisthree/charts/commit/3ee1184621a1bd20c78ac132eca41ce8f6a403e4) (charts) - CHANGELOG.md: add entry for v2.0.0
+- [`afc9d2a`](https://github.com/deis/registry/commit/afc9d2a54a1248aef380de5b99ce8fd2ce0b0ad8) (registry) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`a807d2a`](https://github.com/deis/registry/commit/a807d2a79388944e6a599238ea3d5c0eb09a44ac) (registry) - CHANGELOG.md: add entry for v2.0.0
+- [`55cf8a1`](https://github.com/deis/workflow-manager/commit/55cf8a198761e5b6f6710f95a8058a3fe378c261) (workflow-manager) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`f110d04`](https://github.com/deis/workflow-manager/commit/f110d0455e3203986f3c5151896f73014d93761f) (workflow-manager) - CHANGELOG.md: add entry for v2.0.0
+- [`a06057d`](https://github.com/deis/postgres/commit/a06057df0589f611f30089f0f6ddceec8013416e) (postgres) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`77e2991`](https://github.com/deis/postgres/commit/77e2991bdac5d7f0fcca9cbcd201a1b5f27c64aa) (postgres) - CHANGELOG.md: add entry for v2.0.0
+- [`0393a7a`](https://github.com/deis/workflow-e2e/commit/0393a7af5760d1e62fb14be0eb55e0ce2450ea32) (workflow-e2e) - README.md: remove beta status
+- [`9214eee`](https://github.com/deis/workflow-e2e/commit/9214eeeb1434c0d5e30a656cb1ca86a21f06828e) (workflow-e2e) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`a93420f`](https://github.com/deis/workflow-e2e/commit/a93420fd7a3224d69bf396360eeb2a6abb765798) (workflow-e2e) - CHANGELOG.md: add entry for v2.0.0
+- [`d39fcc1`](https://github.com/deis/stdout-metrics/commit/d39fcc1a3d73f1b2d4b7d0382caec4b0513a4fcf) (stdout-metrics) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`305c25c`](https://github.com/deis/stdout-metrics/commit/305c25c0a508c5872463a37be966c62744925cab) (stdout-metrics) - CHANGELOG.md: add entry for v2.0.0
+- [`1993192`](https://github.com/deis/slugrunner/commit/199319218532498bd0ece7afe7454075552f2bbe) (slugrunner) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`8df35f9`](https://github.com/deis/slugrunner/commit/8df35f979fdd6ce48202a64312e480df5818db5f) (slugrunner) - CHANGELOG.md: add entry for v2.0.0
+- [`1bbaf04`](https://github.com/deis/slugbuilder/commit/1bbaf04c1dbee3dab0881e1816d9dd4c8804616a) (slugbuilder) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`71f7e6c`](https://github.com/deis/slugbuilder/commit/71f7e6c62886922a31243fd4eb76f8a41adca170) (slugbuilder) - CHANGELOG.md: add entry for v2.0.0
+- [`eafb142`](https://github.com/deis/monitor/commit/eafb142499205c4eb986bbee4047365db93e9c54) (monitor) - README: Update readme to remove beta status
+- [`6b979ed`](https://github.com/deis/monitor/commit/6b979edffdd4a8a23aab730817a8025c637b3d2b) (monitor) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`42f91b2`](https://github.com/deis/monitor/commit/42f91b22465f9851fc089a4118219805c5bb60e5) (monitor) - README: Add architecture diagram
+- [`477be8b`](https://github.com/deis/monitor/commit/477be8b2090770a956ab434866054022da89d3a9) (monitor) - CHANGELOG.md: add entry for v2.0.0
+- [`5afdca3`](https://github.com/deis/minio/commit/5afdca35f1dc77e8e55501f40db630b335fa0a05) (minio) - CHANGELOG.md: add entry for v2.0.0
+- [`bce6c31`](https://github.com/deis/builder/commit/bce6c31e3905205a4ea5bfce57f9a3130a0e0a22) (builder) - pkg: update help URL to https://deis.com/
+- [`ea6b17a`](https://github.com/deis/builder/commit/ea6b17a5c635b87874f7433a998c431c1058eeaa) (builder) - CHANGELOG.md: add entry for v2.0.0
+- [`f37322b`](https://github.com/deis/dockerbuilder/commit/f37322b0bffd7c10fa3e66ebdc33e874e633b265) (dockerbuilder) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`66a176b`](https://github.com/deis/dockerbuilder/commit/66a176bbecc8e62c0f3948198d9e6868b1160f22) (dockerbuilder) - CHANGELOG.md: add entry for v2.0.0
+- [`e945cb5`](https://github.com/deis/fluentd/commit/e945cb57f79fab482c5b835599af2bcc9da3cb51) (fluentd) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`06f6fed`](https://github.com/deis/fluentd/commit/06f6fedf6320c08214b97cba26898ef2bf9230cd) (fluentd) - CHANGELOG.md: add entry for v2.0.0
+- [`f7188cd`](https://github.com/deis/logger/commit/f7188cd9de9a728a43ecff175bc5f33767051860) (logger) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`9c3019c`](https://github.com/deis/logger/commit/9c3019ce68e597f708819189ba706433dd23d67c) (logger) - CHANGELOG.md: add entry for v2.0.0
+- [`07eb015`](https://github.com/deis/router/commit/07eb015f6296ae5353d348a48b8ae1dccff648dc) (router) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`7e0eb9d`](https://github.com/deis/router/commit/7e0eb9dafb17ea02aaecaf170d74c63c6a4209f4) (router) - CHANGELOG.md: add entry for v2.0.0
+- [`2d08fb5`](https://github.com/deis/controller/commit/2d08fb5cce7990e9d432ec8934f3d77ff12d4b94) (controller) - CHANGELOG.md: add entry for v2.0.0
+- [`0babcff`](https://github.com/deis/workflow/commit/0babcff98dd1b1a9a0263b943656ea94e0df3cc4) (workflow) - CHANGELOG.md: add entry for v2.0.0
+- [`492d25e`](https://github.com/deis/charts/commit/492d25ed32026db10a18fb750bd54f978c904163) (charts) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`3ee1184`](https://github.com/deis/charts/commit/3ee1184621a1bd20c78ac132eca41ce8f6a403e4) (charts) - CHANGELOG.md: add entry for v2.0.0
 
 
 
 #### Maintenance
 
-- [`9cd3013`](https://github.com/deisthree/registry/commit/9cd3013ba05160ffda907217febcb3e351a5e57f) (registry) - README.md: remove beta status
-- [`e798cbd`](https://github.com/deisthree/workflow-manager/commit/e798cbd9c74487caec9a83740bf72441266db6d8) (workflow-manager) - README.md: remove beta status
-- [`779cef7`](https://github.com/deisthree/postgres/commit/779cef742e4e92d09a18eaad5803640a39506e8f) (postgres) - README.md: remove beta status
-- [`382cba2`](https://github.com/deisthree/workflow-e2e/commit/382cba2c9b7409dde474535ab1f3260bd9bd757e) (workflow-e2e) - Dockerfile: update deis CLI to a17f89a
-- [`d059474`](https://github.com/deisthree/slugbuilder/commit/d0594746ff7f8ff7fac27386b5c5b197ff430e09) (slugbuilder) - various: remove beta status
-- [`c3afeb8`](https://github.com/deisthree/minio/commit/c3afeb8d507bc8cef82cac6b2816d443983465fd) (minio) - README.md: remove beta status
-- [`0112844`](https://github.com/deisthree/builder/commit/0112844215e61efdc5ddd249ebef01d446d447d4) (builder) - various: remove beta status
-- [`91e869b`](https://github.com/deisthree/dockerbuilder/commit/91e869bedcb382d0c7514f279e7c850e673c00a4) (dockerbuilder) - various: remove beta status
-- [`bf0cac4`](https://github.com/deisthree/dockerbuilder/commit/bf0cac43af800d8f66677084ff1a2589cf644485) (dockerbuilder) - various: remove beta status
-- [`e618f9d`](https://github.com/deisthree/router/commit/e618f9d292a34871cd7d614f0789b5a051605ae8) (router) - README.md: remove beta status
-- [`816a36b`](https://github.com/deisthree/controller/commit/816a36b00650859de24f436f4552c0868a8a2c21) (controller) - requirements: update codecov to 2.0.5
-- [`db57962`](https://github.com/deisthree/controller/commit/db57962df9f2cf36792a5570b368164a86d9ed6b) (controller) - README: remove references to beta in README
-- [`4bb866f`](https://github.com/deisthree/controller/commit/4bb866f9673c3bcdc4aa07b3bf9009bef4df4385) (controller) - version: update platform version to 2.0.0
-- [`5f2c4d9`](https://github.com/deisthree/workflow/commit/5f2c4d9c23aff05fa5f507404e78d467866b27e2) (workflow) - various: remove beta status
-- [`095035d`](https://github.com/deisthree/workflow/commit/095035daa47dcf8b2b4e0f600c27e52edc11eaef) (workflow) - docs: update version to v2.0.0
-- [`15d5ce7`](https://github.com/deisthree/charts/commit/15d5ce7e19597fc80ec9f315ebb87a83790ab9fe) (charts) - workflow-rc2: releasing workflow-rc2(-e2e) and router-rc2
-- [`4e06347`](https://github.com/deisthree/charts/commit/4e0634712ad6293c1426c74c9ddf92916cbc1498) (charts) - workflow-rc2: releasing workflow-rc2(-e2e) and router-rc2- final images
-- [`7933ec4`](https://github.com/deisthree/charts/commit/7933ec4e5b741077513c7d9b2813018fd155d74e) (charts) - various: remove beta status
-- [`0301216`](https://github.com/deisthree/charts/commit/030121653f31982b161822b2cf212c5d89026fc7) (charts) - workflow-v2.0.0: releasing workflow-v2.0.0
+- [`9cd3013`](https://github.com/deis/registry/commit/9cd3013ba05160ffda907217febcb3e351a5e57f) (registry) - README.md: remove beta status
+- [`e798cbd`](https://github.com/deis/workflow-manager/commit/e798cbd9c74487caec9a83740bf72441266db6d8) (workflow-manager) - README.md: remove beta status
+- [`779cef7`](https://github.com/deis/postgres/commit/779cef742e4e92d09a18eaad5803640a39506e8f) (postgres) - README.md: remove beta status
+- [`382cba2`](https://github.com/deis/workflow-e2e/commit/382cba2c9b7409dde474535ab1f3260bd9bd757e) (workflow-e2e) - Dockerfile: update deis CLI to a17f89a
+- [`d059474`](https://github.com/deis/slugbuilder/commit/d0594746ff7f8ff7fac27386b5c5b197ff430e09) (slugbuilder) - various: remove beta status
+- [`c3afeb8`](https://github.com/deis/minio/commit/c3afeb8d507bc8cef82cac6b2816d443983465fd) (minio) - README.md: remove beta status
+- [`0112844`](https://github.com/deis/builder/commit/0112844215e61efdc5ddd249ebef01d446d447d4) (builder) - various: remove beta status
+- [`91e869b`](https://github.com/deis/dockerbuilder/commit/91e869bedcb382d0c7514f279e7c850e673c00a4) (dockerbuilder) - various: remove beta status
+- [`bf0cac4`](https://github.com/deis/dockerbuilder/commit/bf0cac43af800d8f66677084ff1a2589cf644485) (dockerbuilder) - various: remove beta status
+- [`e618f9d`](https://github.com/deis/router/commit/e618f9d292a34871cd7d614f0789b5a051605ae8) (router) - README.md: remove beta status
+- [`816a36b`](https://github.com/deis/controller/commit/816a36b00650859de24f436f4552c0868a8a2c21) (controller) - requirements: update codecov to 2.0.5
+- [`db57962`](https://github.com/deis/controller/commit/db57962df9f2cf36792a5570b368164a86d9ed6b) (controller) - README: remove references to beta in README
+- [`4bb866f`](https://github.com/deis/controller/commit/4bb866f9673c3bcdc4aa07b3bf9009bef4df4385) (controller) - version: update platform version to 2.0.0
+- [`5f2c4d9`](https://github.com/deis/workflow/commit/5f2c4d9c23aff05fa5f507404e78d467866b27e2) (workflow) - various: remove beta status
+- [`095035d`](https://github.com/deis/workflow/commit/095035daa47dcf8b2b4e0f600c27e52edc11eaef) (workflow) - docs: update version to v2.0.0
+- [`15d5ce7`](https://github.com/deis/charts/commit/15d5ce7e19597fc80ec9f315ebb87a83790ab9fe) (charts) - workflow-rc2: releasing workflow-rc2(-e2e) and router-rc2
+- [`4e06347`](https://github.com/deis/charts/commit/4e0634712ad6293c1426c74c9ddf92916cbc1498) (charts) - workflow-rc2: releasing workflow-rc2(-e2e) and router-rc2- final images
+- [`7933ec4`](https://github.com/deis/charts/commit/7933ec4e5b741077513c7d9b2813018fd155d74e) (charts) - various: remove beta status
+- [`0301216`](https://github.com/deis/charts/commit/030121653f31982b161822b2cf212c5d89026fc7) (charts) - workflow-v2.0.0: releasing workflow-v2.0.0

--- a/src/changelogs/v2.1.0.md
+++ b/src/changelogs/v2.1.0.md
@@ -4,185 +4,185 @@
 
 #### Features
 
-- [`1e6e226`](https://github.com/deisthree/router/commit/1e6e226d00c3f620517339149ea65d60d2d2f9eb) (router) - *: Update nginx to 1.10.1
-- [`6314a15`](https://github.com/deisthree/registry/commit/6314a15bc5464e4a5ce1c313ce17a69484f4cc2c) (registry) - swift: add support for swift storage
-- [`e494bd9`](https://github.com/deisthree/postgres/commit/e494bd980d43396eeed75f123af5115ae1f54721) (postgres) - wal-e: use the latest wal-e to use aws instance profiles
-- [`6980348`](https://github.com/deisthree/slugbuilder/commit/6980348828a389051b0b4ee069d0c92bc2c4331f) (slugbuilder) - swift: Add support for swift storage
-- [`9e5ce71`](https://github.com/deisthree/dockerbuilder/commit/9e5ce719f7b67a1acc73db961c57e0d9763f33bb) (dockerbuilder) - swift: Add support for swift object storage
-- [`cb4cc44`](https://github.com/deisthree/fluentd/commit/cb4cc44189f2d9a1519f2e93f8860a35c5951de7) (fluentd) - deis-output: Custom fluentd plugin for sending data to deis components
-- [`d8f48be`](https://github.com/deisthree/workflow-manager/commit/d8f48be867cd7ddac74b36a12cb09ca285f39186) (workflow-manager) - doctor: add doctor client code and doctor api call
-- [`b95c60c`](https://github.com/deisthree/workflow-manager/commit/b95c60c11bfb4ceecc07162031e1a8cf0f058598) (workflow-manager) - swagger: add doctor api get spec
-- [`4ab1dc2`](https://github.com/deisthree/workflow-manager/commit/4ab1dc21b8df862253f406a77d3d5e988bf3c334) (workflow-manager) - doctor: add curl script to access doctor endpoint
-- [`f8bfa8d`](https://github.com/deisthree/monitor/commit/f8bfa8da180c2972626301f38730928f8ecaff65) (monitor) - telegraf: enable etcd
-- [`b1aff88`](https://github.com/deisthree/monitor/commit/b1aff883e07da8a3a08f18632337117fbab76493) (monitor) - telegraf: enable prometheus flag
-- [`5e19462`](https://github.com/deisthree/monitor/commit/5e194623473330431dc38168147300c7bd3aeb65) (monitor) - grafana,telegraf: Pull metric data from nsq via telegraf
-- [`5cb3cb4`](https://github.com/deisthree/monitor/commit/5cb3cb4397ea4a66ca64c766a9b9a19c10391052) (monitor) - grafana: Add deis-health dashboard
-- [`8cca750`](https://github.com/deisthree/workflow-e2e/commit/8cca750a61f33a07ac08da1d45977bf0fc5c0e45) (workflow-e2e) - registry: PORT is required for private registry
-- [`f0f5712`](https://github.com/deisthree/workflow-e2e/commit/f0f571287247d05a94b9e654b003d605f1a6354a) (workflow-e2e) - apps: apps:run will now print on stderr if the command errors (#231)
-- [`6876296`](https://github.com/deisthree/workflow-e2e/commit/6876296253471ec6a4c1c0b30149365867ecc5f5) (workflow-e2e) - docker: install specified CLI version at runtime (#233)
-- [`c65d01b`](https://github.com/deisthree/workflow-e2e/commit/c65d01b244dfc823819ff2ee847c8b4fecb3fd60) (workflow-e2e) - *: update to use new errors from CLI (#239)
-- [`a532726`](https://github.com/deisthree/workflow-e2e/commit/a532726d43d692809291601ff1500769d29ba2a4) (workflow-e2e) - git_push_test.go: add git push interrupt test
-- [`34cbfe2`](https://github.com/deisthree/workflow-e2e/commit/34cbfe254d0d1bd378252d7c0a84e9fd833abc81) (workflow-e2e) - healthchecks: add deis healthchecks e2e tests
-- [`a369718`](https://github.com/deisthree/logger/commit/a3697183597c544fdc7a5b422645712030b8fc0d) (logger) - ringbuffer: Treat empty ringbuffer as error
-- [`8ed585f`](https://github.com/deisthree/charts/commit/8ed585fa10d24227bbc9777a2132363cdd5f4b7f) (charts) - workflow-dev: Add nsq to the workflow chart
-- [`5b29b4c`](https://github.com/deisthree/charts/commit/5b29b4cd5da48d4b9f7761d2b3239f890e8cbdf3) (charts) - database: Add easier off-cluster db config
-- [`6fdcf08`](https://github.com/deisthree/builder/commit/6fdcf08064d9ac7b15115553e76c7dc3e6c31f37) (builder) - lock: add timeout to repository lock feature
-- [`422075b`](https://github.com/deisthree/builder/commit/422075bf7962f695299fd7ed68c9a8279c14aca1) (builder) - swift: Add support for swift object storage
-- [`a1c4619`](https://github.com/deisthree/controller/commit/a1c4619c545d5baed6194a88bd40ea3d115b22c2) (controller) - config: validate PORT and HEALTHCHECK_* values for config:set operations
-- [`ccc6b1f`](https://github.com/deisthree/controller/commit/ccc6b1fc4c545b2eaba557a2ae9b4367c3675e3c) (controller) - release: require PORT to be set when private registry is set
-- [`0231c58`](https://github.com/deisthree/controller/commit/0231c58bc0f73d08a7823ecf5168f61dc7c863f7) (controller) - django: explicitically define on_delete for ForeignKey fields for 2.0 compat
-- [`6e136e2`](https://github.com/deisthree/controller/commit/6e136e2cb01a5da938496051419bd689b9a5cafa) (controller) - debug: DEIS_DEBUG now affects Django DEBUG as well
-- [`4c674d0`](https://github.com/deisthree/controller/commit/4c674d0e41303a1e0d1df9623ea90c86fd8c91fd) (controller) - release: throw 409 when identical release is done sequantially
-- [`af76733`](https://github.com/deisthree/controller/commit/af7673378061e7a57b6feca7a1fd67f728aa172f) (controller) - api: Add healthcheck field to Config
-- [`7af2197`](https://github.com/deisthree/controller/commit/7af21973dff22120ab7723d9d23ecf6cf34a39a7) (controller) - settings: log all SQL queries if DEBUG==True
-- [`2b11d1b`](https://github.com/deisthree/workflow/commit/2b11d1bf113b2fdac8ecb5fdb9ef45c7bd956550) (workflow) - Makefile/Dockerfile: add docker-test recipe
-- [`7bbb8a1`](https://github.com/deisthree/workflow/commit/7bbb8a18f8f413fe94a58940517c11ea95d64aea) (workflow) - api: add v2.1 api documentation. (#357)
+- [`1e6e226`](https://github.com/deis/router/commit/1e6e226d00c3f620517339149ea65d60d2d2f9eb) (router) - *: Update nginx to 1.10.1
+- [`6314a15`](https://github.com/deis/registry/commit/6314a15bc5464e4a5ce1c313ce17a69484f4cc2c) (registry) - swift: add support for swift storage
+- [`e494bd9`](https://github.com/deis/postgres/commit/e494bd980d43396eeed75f123af5115ae1f54721) (postgres) - wal-e: use the latest wal-e to use aws instance profiles
+- [`6980348`](https://github.com/deis/slugbuilder/commit/6980348828a389051b0b4ee069d0c92bc2c4331f) (slugbuilder) - swift: Add support for swift storage
+- [`9e5ce71`](https://github.com/deis/dockerbuilder/commit/9e5ce719f7b67a1acc73db961c57e0d9763f33bb) (dockerbuilder) - swift: Add support for swift object storage
+- [`cb4cc44`](https://github.com/deis/fluentd/commit/cb4cc44189f2d9a1519f2e93f8860a35c5951de7) (fluentd) - deis-output: Custom fluentd plugin for sending data to deis components
+- [`d8f48be`](https://github.com/deis/workflow-manager/commit/d8f48be867cd7ddac74b36a12cb09ca285f39186) (workflow-manager) - doctor: add doctor client code and doctor api call
+- [`b95c60c`](https://github.com/deis/workflow-manager/commit/b95c60c11bfb4ceecc07162031e1a8cf0f058598) (workflow-manager) - swagger: add doctor api get spec
+- [`4ab1dc2`](https://github.com/deis/workflow-manager/commit/4ab1dc21b8df862253f406a77d3d5e988bf3c334) (workflow-manager) - doctor: add curl script to access doctor endpoint
+- [`f8bfa8d`](https://github.com/deis/monitor/commit/f8bfa8da180c2972626301f38730928f8ecaff65) (monitor) - telegraf: enable etcd
+- [`b1aff88`](https://github.com/deis/monitor/commit/b1aff883e07da8a3a08f18632337117fbab76493) (monitor) - telegraf: enable prometheus flag
+- [`5e19462`](https://github.com/deis/monitor/commit/5e194623473330431dc38168147300c7bd3aeb65) (monitor) - grafana,telegraf: Pull metric data from nsq via telegraf
+- [`5cb3cb4`](https://github.com/deis/monitor/commit/5cb3cb4397ea4a66ca64c766a9b9a19c10391052) (monitor) - grafana: Add deis-health dashboard
+- [`8cca750`](https://github.com/deis/workflow-e2e/commit/8cca750a61f33a07ac08da1d45977bf0fc5c0e45) (workflow-e2e) - registry: PORT is required for private registry
+- [`f0f5712`](https://github.com/deis/workflow-e2e/commit/f0f571287247d05a94b9e654b003d605f1a6354a) (workflow-e2e) - apps: apps:run will now print on stderr if the command errors (#231)
+- [`6876296`](https://github.com/deis/workflow-e2e/commit/6876296253471ec6a4c1c0b30149365867ecc5f5) (workflow-e2e) - docker: install specified CLI version at runtime (#233)
+- [`c65d01b`](https://github.com/deis/workflow-e2e/commit/c65d01b244dfc823819ff2ee847c8b4fecb3fd60) (workflow-e2e) - *: update to use new errors from CLI (#239)
+- [`a532726`](https://github.com/deis/workflow-e2e/commit/a532726d43d692809291601ff1500769d29ba2a4) (workflow-e2e) - git_push_test.go: add git push interrupt test
+- [`34cbfe2`](https://github.com/deis/workflow-e2e/commit/34cbfe254d0d1bd378252d7c0a84e9fd833abc81) (workflow-e2e) - healthchecks: add deis healthchecks e2e tests
+- [`a369718`](https://github.com/deis/logger/commit/a3697183597c544fdc7a5b422645712030b8fc0d) (logger) - ringbuffer: Treat empty ringbuffer as error
+- [`8ed585f`](https://github.com/deis/charts/commit/8ed585fa10d24227bbc9777a2132363cdd5f4b7f) (charts) - workflow-dev: Add nsq to the workflow chart
+- [`5b29b4c`](https://github.com/deis/charts/commit/5b29b4cd5da48d4b9f7761d2b3239f890e8cbdf3) (charts) - database: Add easier off-cluster db config
+- [`6fdcf08`](https://github.com/deis/builder/commit/6fdcf08064d9ac7b15115553e76c7dc3e6c31f37) (builder) - lock: add timeout to repository lock feature
+- [`422075b`](https://github.com/deis/builder/commit/422075bf7962f695299fd7ed68c9a8279c14aca1) (builder) - swift: Add support for swift object storage
+- [`a1c4619`](https://github.com/deis/controller/commit/a1c4619c545d5baed6194a88bd40ea3d115b22c2) (controller) - config: validate PORT and HEALTHCHECK_* values for config:set operations
+- [`ccc6b1f`](https://github.com/deis/controller/commit/ccc6b1fc4c545b2eaba557a2ae9b4367c3675e3c) (controller) - release: require PORT to be set when private registry is set
+- [`0231c58`](https://github.com/deis/controller/commit/0231c58bc0f73d08a7823ecf5168f61dc7c863f7) (controller) - django: explicitically define on_delete for ForeignKey fields for 2.0 compat
+- [`6e136e2`](https://github.com/deis/controller/commit/6e136e2cb01a5da938496051419bd689b9a5cafa) (controller) - debug: DEIS_DEBUG now affects Django DEBUG as well
+- [`4c674d0`](https://github.com/deis/controller/commit/4c674d0e41303a1e0d1df9623ea90c86fd8c91fd) (controller) - release: throw 409 when identical release is done sequantially
+- [`af76733`](https://github.com/deis/controller/commit/af7673378061e7a57b6feca7a1fd67f728aa172f) (controller) - api: Add healthcheck field to Config
+- [`7af2197`](https://github.com/deis/controller/commit/7af21973dff22120ab7723d9d23ecf6cf34a39a7) (controller) - settings: log all SQL queries if DEBUG==True
+- [`2b11d1b`](https://github.com/deis/workflow/commit/2b11d1bf113b2fdac8ecb5fdb9ef45c7bd956550) (workflow) - Makefile/Dockerfile: add docker-test recipe
+- [`7bbb8a1`](https://github.com/deis/workflow/commit/7bbb8a18f8f413fe94a58940517c11ea95d64aea) (workflow) - api: add v2.1 api documentation. (#357)
 
 #### Fixes
 
-- [`4338ee1`](https://github.com/deisthree/slugrunner/commit/4338ee1ac8943febcac4c29c0a49d34d185e27c0) (slugrunner) - Dockerfile: download the object storage CLI from GCS
-- [`8bfc4ee`](https://github.com/deisthree/postgres/commit/8bfc4ee2a198eb9e8d29fd871a45e24dba9edf5d) (postgres) - contrib: allow 5 or 6 backups
-- [`419a0e3`](https://github.com/deisthree/postgres/commit/419a0e36fbc85fd6095c6e678d88a009eb3249b3) (postgres) - rootfs: enable archive_mode before initial boot
-- [`923c9f8`](https://github.com/deisthree/slugbuilder/commit/923c9f8459561f411a191cff6ba80ca4dc8e54d3) (slugbuilder) - Dockerfile: download the object storage CLI from GCS
-- [`e7a22e0`](https://github.com/deisthree/dockerbuilder/commit/e7a22e0872e948788597cd4890fc149f4b6b5426) (dockerbuilder) - objectstore: set properly builder bucket file environment variable
-- [`f724059`](https://github.com/deisthree/fluentd/commit/f7240594b40463786d9e7b0cf55185a1d881cff7) (fluentd) - boot: Move from old type declaration to @type
-- [`2890575`](https://github.com/deisthree/fluentd/commit/28905756bf0d71f6885ba19a2adcff313b1328f4) (fluentd) - boot: Create better way to generate fluentd conf
-- [`6ae5779`](https://github.com/deisthree/minio/commit/6ae577905f5f9c0ff0d27e1621357b7b1db208e5) (minio) - Dockerfile: download minio from a mirror (#110)
-- [`af9ef04`](https://github.com/deisthree/workflow-manager/commit/af9ef041b2b04cb013e7c7d659a85af478048ea2) (workflow-manager) - doctor: including API version and /doctor in url (#78)
-- [`6f71be2`](https://github.com/deisthree/workflow-e2e/commit/6f71be2c027ca44154838307ecbe79718cdff36d) (workflow-e2e) - registry: overwriting variable typo
-- [`34f16a5`](https://github.com/deisthree/workflow-e2e/commit/34f16a50ab51f1e32a53806990c8017e03c43e52) (workflow-e2e) - registry: recorganise registry tests order and fix a should(say()) call
-- [`188f6aa`](https://github.com/deisthree/workflow-e2e/commit/188f6aae25fef8fc947167ddcb7931060e48e5da) (workflow-e2e) - registry: more port setting and fix up error message detection
-- [`d56ba6d`](https://github.com/deisthree/workflow-e2e/commit/d56ba6d4be55596986e0dc9746052aabf1ed2adc) (workflow-e2e) - apps_test: escape quotes properly in deis run spec
-- [`afbe0f7`](https://github.com/deisthree/workflow-e2e/commit/afbe0f77cc426f711b568a0f1ed57421610e5058) (workflow-e2e) - README: update go report card badge url (#232)
-- [`8cf7025`](https://github.com/deisthree/workflow-e2e/commit/8cf702517c59dfdeea0149cda422a0a24b3fe0ab) (workflow-e2e) - apps/commands: match substring, not entire string
-- [`7d15489`](https://github.com/deisthree/workflow-e2e/commit/7d15489d87d9ee5f0178d904c644e22188ba6412) (workflow-e2e) - config: unsetting a key that does not exist results in exit 1
-- [`4ee56b2`](https://github.com/deisthree/workflow-e2e/commit/4ee56b2dd2dbd841e811e48793564fcaf2b51d54) (workflow-e2e) - deps: update SDK to reflect changed spelling of hyphen (#246)
-- [`64b4512`](https://github.com/deisthree/charts/commit/64b4512f8f36d025929ea6b8e0e5954328be526f) (charts) - minio: create minio when using storage type as minio via env vars
-- [`5cf4df4`](https://github.com/deisthree/builder/commit/5cf4df4171a0adeeecc49dedce45b332f3506166) (builder) - sshd: unlock the repository when gitreceive succeeds or fails
-- [`3a332a4`](https://github.com/deisthree/builder/commit/3a332a4222ba6f5c224bf2c66cdf90d4419db4ae) (builder) - flag: Use DEIS_DEBUG instead DEBUG environment variable for debug settings
-- [`43a66c9`](https://github.com/deisthree/builder/commit/43a66c9f209f52ca5c54f9ab089bce1ab8338fa4) (builder) - README: update go report card badge url (#370)
-- [`2f253dd`](https://github.com/deisthree/builder/commit/2f253ddc8fb442d81de1ae5dc89604fb7b6235b2) (builder) - server.go: don't reply false on failed lock
-- [`844b2ff`](https://github.com/deisthree/builder/commit/844b2ff1a72939880eb5dda5c756cbb9e57752fe) (builder) - pkg: set check timeouts to 10s
-- [`3e7a785`](https://github.com/deisthree/builder/commit/3e7a785db5402cbd343a5f688d6798ecfe658efc) (builder) - pkg/sshd/server.go: remove the closer channel (#359)
-- [`a230d05`](https://github.com/deisthree/builder/commit/a230d0513fe622c88aa6daf0ebe5ab695e955468) (builder) - pkg/gitreceive/config.go: require dependent image names (#377)
-- [`df30ee6`](https://github.com/deisthree/controller/commit/df30ee653402959a7bee1ee04a911eca14981576) (controller) - api: remove slug tarball info from app log
-- [`61b6858`](https://github.com/deisthree/controller/commit/61b68581f2687ec7fa061c77984775ddc8a65904) (controller) - scheduler: remove unused health check config option: HEALTCHECK_PORT
-- [`c6686e9`](https://github.com/deisthree/controller/commit/c6686e90fa39526c1051ec0035621452d7625f67) (controller) - scheduler: cast ports to int before passing them on to k8s
-- [`2f1b140`](https://github.com/deisthree/controller/commit/2f1b140011a7255e1a13398748e01a26ed3edc2f) (controller) - management: handle errors in object loading and application deployments instead of throwing exceptions
-- [`dc4769a`](https://github.com/deisthree/controller/commit/dc4769a8bbff4fa253ab5cdd52dfa93b4fa54325) (controller) - logs: retry fetching logs from the logger 3 times if the services is unavailable
-- [`c8c7d80`](https://github.com/deisthree/controller/commit/c8c7d80e7c64c5b29c504cf2169e5976bfee09f2) (controller) - scale: get the desired number of replicas from the rc
-- [`3fa6f70`](https://github.com/deisthree/controller/commit/3fa6f702bbe9e2dc4b3ec70cdad333b41f2091c2) (controller) - scheduler: make deploy have 0 replicas by default and then use scaling to go up
-- [`09b9be2`](https://github.com/deisthree/controller/commit/09b9be2c38435d91fda11d8c3bcb7df10b8acaee) (controller) - secrets: update env secrets if they already exists (overwrites existing values)
-- [`5fb1bbb`](https://github.com/deisthree/controller/commit/5fb1bbbe4d18e2e3019543804bcd040feee7b62e) (controller) - config: when rolling a new config copy from the latest release instead of latest config for the app
-- [`0d9988b`](https://github.com/deisthree/controller/commit/0d9988b23332e47310227358c8eefa25c03181a9) (controller) - serializer: skip None values in config and registry
-- [`936a40e`](https://github.com/deisthree/controller/commit/936a40ef498267a2edd0a5ac82ab5d4ab066532c) (controller) - exceptions: tests now capture critical only and uncaught exceptions have been reclassified as critical
-- [`3f980b8`](https://github.com/deisthree/controller/commit/3f980b89740f5b5f728b37c010e95f69193b9613) (controller) - exceptions: log certain APIExceptions tracebacks
-- [`9f8ac04`](https://github.com/deisthree/controller/commit/9f8ac042d37290c86b34dd1f7e0b9afb14202a7f) (controller) - config: return a 422 if unsetting a config key that does not exist
-- [`cae4bf9`](https://github.com/deisthree/controller/commit/cae4bf9ce906ec223ce6bbf760492d0eefed5c05) (controller) - models: hypens -> hyphens (#840)
-- [`e108f14`](https://github.com/deisthree/workflow/commit/e108f14c082c7333edf9fa4a1e8a2a506d6c64a9) (workflow) - registry: explain PORT is required when using private registry information
-- [`e197163`](https://github.com/deisthree/workflow/commit/e197163f2befa6e2ceb2c7947f97c1f593b3ca48) (workflow) - component-config: clarify GUNICORN_WORKERS value
-- [`dc5ee1a`](https://github.com/deisthree/workflow/commit/dc5ee1acb02d49fac96c80aa7bc5b8e321853792) (workflow) - api: update out of date cert api docs (#339)
-- [`25006d1`](https://github.com/deisthree/workflow/commit/25006d17c721eb417e591d4dbce7cbc418868dfa) (workflow) - applications: fixup exec probe output
+- [`4338ee1`](https://github.com/deis/slugrunner/commit/4338ee1ac8943febcac4c29c0a49d34d185e27c0) (slugrunner) - Dockerfile: download the object storage CLI from GCS
+- [`8bfc4ee`](https://github.com/deis/postgres/commit/8bfc4ee2a198eb9e8d29fd871a45e24dba9edf5d) (postgres) - contrib: allow 5 or 6 backups
+- [`419a0e3`](https://github.com/deis/postgres/commit/419a0e36fbc85fd6095c6e678d88a009eb3249b3) (postgres) - rootfs: enable archive_mode before initial boot
+- [`923c9f8`](https://github.com/deis/slugbuilder/commit/923c9f8459561f411a191cff6ba80ca4dc8e54d3) (slugbuilder) - Dockerfile: download the object storage CLI from GCS
+- [`e7a22e0`](https://github.com/deis/dockerbuilder/commit/e7a22e0872e948788597cd4890fc149f4b6b5426) (dockerbuilder) - objectstore: set properly builder bucket file environment variable
+- [`f724059`](https://github.com/deis/fluentd/commit/f7240594b40463786d9e7b0cf55185a1d881cff7) (fluentd) - boot: Move from old type declaration to @type
+- [`2890575`](https://github.com/deis/fluentd/commit/28905756bf0d71f6885ba19a2adcff313b1328f4) (fluentd) - boot: Create better way to generate fluentd conf
+- [`6ae5779`](https://github.com/deis/minio/commit/6ae577905f5f9c0ff0d27e1621357b7b1db208e5) (minio) - Dockerfile: download minio from a mirror (#110)
+- [`af9ef04`](https://github.com/deis/workflow-manager/commit/af9ef041b2b04cb013e7c7d659a85af478048ea2) (workflow-manager) - doctor: including API version and /doctor in url (#78)
+- [`6f71be2`](https://github.com/deis/workflow-e2e/commit/6f71be2c027ca44154838307ecbe79718cdff36d) (workflow-e2e) - registry: overwriting variable typo
+- [`34f16a5`](https://github.com/deis/workflow-e2e/commit/34f16a50ab51f1e32a53806990c8017e03c43e52) (workflow-e2e) - registry: recorganise registry tests order and fix a should(say()) call
+- [`188f6aa`](https://github.com/deis/workflow-e2e/commit/188f6aae25fef8fc947167ddcb7931060e48e5da) (workflow-e2e) - registry: more port setting and fix up error message detection
+- [`d56ba6d`](https://github.com/deis/workflow-e2e/commit/d56ba6d4be55596986e0dc9746052aabf1ed2adc) (workflow-e2e) - apps_test: escape quotes properly in deis run spec
+- [`afbe0f7`](https://github.com/deis/workflow-e2e/commit/afbe0f77cc426f711b568a0f1ed57421610e5058) (workflow-e2e) - README: update go report card badge url (#232)
+- [`8cf7025`](https://github.com/deis/workflow-e2e/commit/8cf702517c59dfdeea0149cda422a0a24b3fe0ab) (workflow-e2e) - apps/commands: match substring, not entire string
+- [`7d15489`](https://github.com/deis/workflow-e2e/commit/7d15489d87d9ee5f0178d904c644e22188ba6412) (workflow-e2e) - config: unsetting a key that does not exist results in exit 1
+- [`4ee56b2`](https://github.com/deis/workflow-e2e/commit/4ee56b2dd2dbd841e811e48793564fcaf2b51d54) (workflow-e2e) - deps: update SDK to reflect changed spelling of hyphen (#246)
+- [`64b4512`](https://github.com/deis/charts/commit/64b4512f8f36d025929ea6b8e0e5954328be526f) (charts) - minio: create minio when using storage type as minio via env vars
+- [`5cf4df4`](https://github.com/deis/builder/commit/5cf4df4171a0adeeecc49dedce45b332f3506166) (builder) - sshd: unlock the repository when gitreceive succeeds or fails
+- [`3a332a4`](https://github.com/deis/builder/commit/3a332a4222ba6f5c224bf2c66cdf90d4419db4ae) (builder) - flag: Use DEIS_DEBUG instead DEBUG environment variable for debug settings
+- [`43a66c9`](https://github.com/deis/builder/commit/43a66c9f209f52ca5c54f9ab089bce1ab8338fa4) (builder) - README: update go report card badge url (#370)
+- [`2f253dd`](https://github.com/deis/builder/commit/2f253ddc8fb442d81de1ae5dc89604fb7b6235b2) (builder) - server.go: don't reply false on failed lock
+- [`844b2ff`](https://github.com/deis/builder/commit/844b2ff1a72939880eb5dda5c756cbb9e57752fe) (builder) - pkg: set check timeouts to 10s
+- [`3e7a785`](https://github.com/deis/builder/commit/3e7a785db5402cbd343a5f688d6798ecfe658efc) (builder) - pkg/sshd/server.go: remove the closer channel (#359)
+- [`a230d05`](https://github.com/deis/builder/commit/a230d0513fe622c88aa6daf0ebe5ab695e955468) (builder) - pkg/gitreceive/config.go: require dependent image names (#377)
+- [`df30ee6`](https://github.com/deis/controller/commit/df30ee653402959a7bee1ee04a911eca14981576) (controller) - api: remove slug tarball info from app log
+- [`61b6858`](https://github.com/deis/controller/commit/61b68581f2687ec7fa061c77984775ddc8a65904) (controller) - scheduler: remove unused health check config option: HEALTCHECK_PORT
+- [`c6686e9`](https://github.com/deis/controller/commit/c6686e90fa39526c1051ec0035621452d7625f67) (controller) - scheduler: cast ports to int before passing them on to k8s
+- [`2f1b140`](https://github.com/deis/controller/commit/2f1b140011a7255e1a13398748e01a26ed3edc2f) (controller) - management: handle errors in object loading and application deployments instead of throwing exceptions
+- [`dc4769a`](https://github.com/deis/controller/commit/dc4769a8bbff4fa253ab5cdd52dfa93b4fa54325) (controller) - logs: retry fetching logs from the logger 3 times if the services is unavailable
+- [`c8c7d80`](https://github.com/deis/controller/commit/c8c7d80e7c64c5b29c504cf2169e5976bfee09f2) (controller) - scale: get the desired number of replicas from the rc
+- [`3fa6f70`](https://github.com/deis/controller/commit/3fa6f702bbe9e2dc4b3ec70cdad333b41f2091c2) (controller) - scheduler: make deploy have 0 replicas by default and then use scaling to go up
+- [`09b9be2`](https://github.com/deis/controller/commit/09b9be2c38435d91fda11d8c3bcb7df10b8acaee) (controller) - secrets: update env secrets if they already exists (overwrites existing values)
+- [`5fb1bbb`](https://github.com/deis/controller/commit/5fb1bbbe4d18e2e3019543804bcd040feee7b62e) (controller) - config: when rolling a new config copy from the latest release instead of latest config for the app
+- [`0d9988b`](https://github.com/deis/controller/commit/0d9988b23332e47310227358c8eefa25c03181a9) (controller) - serializer: skip None values in config and registry
+- [`936a40e`](https://github.com/deis/controller/commit/936a40ef498267a2edd0a5ac82ab5d4ab066532c) (controller) - exceptions: tests now capture critical only and uncaught exceptions have been reclassified as critical
+- [`3f980b8`](https://github.com/deis/controller/commit/3f980b89740f5b5f728b37c010e95f69193b9613) (controller) - exceptions: log certain APIExceptions tracebacks
+- [`9f8ac04`](https://github.com/deis/controller/commit/9f8ac042d37290c86b34dd1f7e0b9afb14202a7f) (controller) - config: return a 422 if unsetting a config key that does not exist
+- [`cae4bf9`](https://github.com/deis/controller/commit/cae4bf9ce906ec223ce6bbf760492d0eefed5c05) (controller) - models: hypens -> hyphens (#840)
+- [`e108f14`](https://github.com/deis/workflow/commit/e108f14c082c7333edf9fa4a1e8a2a506d6c64a9) (workflow) - registry: explain PORT is required when using private registry information
+- [`e197163`](https://github.com/deis/workflow/commit/e197163f2befa6e2ceb2c7947f97c1f593b3ca48) (workflow) - component-config: clarify GUNICORN_WORKERS value
+- [`dc5ee1a`](https://github.com/deis/workflow/commit/dc5ee1acb02d49fac96c80aa7bc5b8e321853792) (workflow) - api: update out of date cert api docs (#339)
+- [`25006d1`](https://github.com/deis/workflow/commit/25006d17c721eb417e591d4dbce7cbc418868dfa) (workflow) - applications: fixup exec probe output
 
 
 
 #### Documentation
 
-- [`044f85c`](https://github.com/deisthree/slugrunner/commit/044f85c6bd86d233a58e76143ec6283d85d954db) (slugrunner) - CHANGELOG.md: add entry for v2.0.0
-- [`bf3e1da`](https://github.com/deisthree/router/commit/bf3e1daf9b578fb8e01a077bd2ff75af6b69953b) (router) - README: add codecov.io badge
-- [`0aa8abb`](https://github.com/deisthree/router/commit/0aa8abb23da786498b6096bf43857c28b549ac81) (router) - readme: Add anchors to every row in annotations table
-- [`a80425d`](https://github.com/deisthree/router/commit/a80425d94e17b4758e42a206e552f9e9bc197ef5) (router) - CHANGELOG.md: add entry for v2.0.0
-- [`6b60912`](https://github.com/deisthree/router/commit/6b60912fc7bab68b5724d5cb8e3e7ee572cf793d) (router) - README: fix Go report card badge
-- [`4b1f311`](https://github.com/deisthree/registry/commit/4b1f31127f87447c2abe25075377a234a97a78c4) (registry) - CHANGELOG.md: add entry for v2.0.0
-- [`5fc10d5`](https://github.com/deisthree/registry/commit/5fc10d554514b908b6e8d820c6d81d8544915cbf) (registry) - README: fix Go report card badge
-- [`61a4dc9`](https://github.com/deisthree/postgres/commit/61a4dc9a9671bb436968a5f655fd87f3bb6c520e) (postgres) - CHANGELOG.md: add entry for v2.0.0
-- [`4efe5f9`](https://github.com/deisthree/postgres/commit/4efe5f9e8851b627ee156db22f32d83dac5a531b) (postgres) - README.md: Fix the default value of IMAGE_PREFIX
-- [`920dbf6`](https://github.com/deisthree/slugbuilder/commit/920dbf606bf24213b4cea02457bfd838e711e2ee) (slugbuilder) - CHANGELOG.md: add entry for v2.0.0
-- [`48d4ecb`](https://github.com/deisthree/dockerbuilder/commit/48d4ecbf94781333daa8346a966210f710110cd3) (dockerbuilder) - CHANGELOG.md: add entry for v2.0.0
-- [`7f046cc`](https://github.com/deisthree/fluentd/commit/7f046cc542cf42b5160e48cd6a7c9284b363999f) (fluentd) - CHANGELOG.md: add entry for v2.0.0
-- [`31e054d`](https://github.com/deisthree/minio/commit/31e054df00fa1ea25be8d7e5f7e47280c63da72e) (minio) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`958ccd7`](https://github.com/deisthree/minio/commit/958ccd7af60354e6263278ba6f592a5449e25ed8) (minio) - CHANGELOG.md: add entry for v2.0.0
-- [`ebbbc3a`](https://github.com/deisthree/workflow-manager/commit/ebbbc3a1364678435e11bb0518c5f388893a9d51) (workflow-manager) - CHANGELOG.md: add entry for v2.0.0
-- [`04f65c6`](https://github.com/deisthree/monitor/commit/04f65c67550c80cff40335ea13497d8603347a6b) (monitor) - CHANGELOG.md: add entry for v2.0.0
-- [`94bf4c1`](https://github.com/deisthree/workflow-e2e/commit/94bf4c15fe3c67aa9cfa5f4d57618ecf8e53bfe5) (workflow-e2e) - CHANGELOG.md: add entry for v2.0.0
-- [`778ab68`](https://github.com/deisthree/logger/commit/778ab68fd56d9308e1d4d61a024a544edef72e7b) (logger) - README: add codecov.io badge
-- [`d3fc751`](https://github.com/deisthree/logger/commit/d3fc75189fbeb8dbd728cffb5d53324c8ec25db9) (logger) - CHANGELOG.md: add entry for v2.0.0
-- [`178bc7c`](https://github.com/deisthree/logger/commit/178bc7cb110c23c03cb7ade4df851e00fbc79316) (logger) - README: fix Go report card badge
-- [`6367466`](https://github.com/deisthree/charts/commit/63674660da06c0f9deb0a89e9f9a8d8fa63812b0) (charts) - CHANGELOG.md: add entry for v2.0.0
-- [`e038851`](https://github.com/deisthree/builder/commit/e038851678da9363a99a3639d67181abb6ab68bf) (builder) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`58a8786`](https://github.com/deisthree/builder/commit/58a8786d764db22a7f01c68398ec86aff34f6541) (builder) - pkg: update help URL to https://deis.com/
-- [`0df2ba3`](https://github.com/deisthree/builder/commit/0df2ba3a70cf22c3195af25833a70cfce68fc195) (builder) - CHANGELOG.md: add entry for v2.0.0
-- [`c3945f2`](https://github.com/deisthree/builder/commit/c3945f2ef286fb103ea413647497a6e4884352d1) (builder) - README: add codecov.io badge
-- [`b001515`](https://github.com/deisthree/controller/commit/b0015157ba5288d3fdd6dde104efa879305bd4e2) (controller) - CHANGELOG.md: add entry for v2.0.0-rc2
-- [`c7fb984`](https://github.com/deisthree/controller/commit/c7fb984d077d605d0469649f826c1b38458adaf8) (controller) - CHANGELOG.md: add entry for v2.0.0
-- [`9063a96`](https://github.com/deisthree/workflow/commit/9063a96112c7d90d526df707f94bd33392804d5f) (workflow) - installing-workflow: fix missing watch flag
-- [`cf9693f`](https://github.com/deisthree/workflow/commit/cf9693f9ed5bbe2d1ea8a613bb797f556768182f) (workflow) - release-checklist.md: remove bintray references
-- [`cda073c`](https://github.com/deisthree/workflow/commit/cda073c9bfdeb02425208f7e1ff734bfda50c353) (workflow) - CHANGELOG.md: add entry for v2.0.0
-- [`5c753e5`](https://github.com/deisthree/workflow/commit/5c753e5840d94b88ecf92c0458a1d618a3e78dcf) (workflow) - styles: update the theme to match deis.com
-- [`a77d967`](https://github.com/deisthree/workflow/commit/a77d96780012c1a0dee70422d7827574f7660512) (workflow) - styles: remove sass from makefile
-- [`e37b2dc`](https://github.com/deisthree/workflow/commit/e37b2dc4eedce6ee5ff194965cf97e619c6d6d54) (workflow) - styles: tidy up JS, better affix the sidebar menu
-- [`919f22c`](https://github.com/deisthree/workflow/commit/919f22c16532f1e091ffa276a80c4190c369f28e) (workflow) - styles: fix urls, style for better mobile layout
-- [`e868009`](https://github.com/deisthree/workflow/commit/e868009bddf5f4ba3c717c63a91dd15d89feb3e5) (workflow) - styles: remove bower_components
-- [`2e1c6a9`](https://github.com/deisthree/workflow/commit/2e1c6a97fae0f9e5ca80a71b54235f52c7b07e94) (workflow) - styles: mobile off-canvas menu
-- [`908f715`](https://github.com/deisthree/workflow/commit/908f71528e207bae5d7a31ad69b582657c4777a4) (workflow) - styles: color changes to open sidebar sections
-- [`82000d1`](https://github.com/deisthree/workflow/commit/82000d17a41ae69d47553af6e5c1afb8e9945815) (workflow) - src/roadmap/release-checklist.md: update Step 2.1
-- [`7cbd1de`](https://github.com/deisthree/workflow/commit/7cbd1de5d6b28b1c73e240582a6044b9fad02b97) (workflow) - src/roadmap/release-checklist.md: update if major release
-- [`dad9598`](https://github.com/deisthree/workflow/commit/dad9598e53e0b777732b80a83fc838ee38c34744) (workflow) - submitting-a-pr: add "hotfix revert" exception to LGTM rules
-- [`a0ff462`](https://github.com/deisthree/workflow/commit/a0ff462fa89c52de4529e1035da5d4e44e8df15d) (workflow) - release-checklist: Improve instructions pertaining to previous release
-- [`cdbc575`](https://github.com/deisthree/workflow/commit/cdbc575daebfec6f1e62b0180916b4a2977aa32d) (workflow) - README.md: fix quick start guide URL
-- [`9e843cd`](https://github.com/deisthree/workflow/commit/9e843cd65933700521132439bb78fd9b32d1fcdf) (workflow) - s3: add instruction for using IAM creds
-- [`b451c66`](https://github.com/deisthree/workflow/commit/b451c66111df010c5452c2eee9292906e90af41b) (workflow) - release_checklist.md: return to using immutable tags
-- [`2286765`](https://github.com/deisthree/workflow/commit/22867651d2f6baf387dbb19ae1b2617445e4adf8) (workflow) - submitting-a-pull-request.md: add info on testing paired commits
-- [`467a21d`](https://github.com/deisthree/workflow/commit/467a21d887b8f342ce39e2cc0912e17467b61dce) (workflow) - platform-logging.md: Need "--namespace=deis" when deleting pods.
-- [`606bdd8`](https://github.com/deisthree/workflow/commit/606bdd8ced5c426769e505095d0ccc7d073b1264) (workflow) - router: Remove invalid labels from example whitelists
-- [`87e0b58`](https://github.com/deisthree/workflow/commit/87e0b5878eb147575529fa6c6e548ab50f061080) (workflow) - upgrade-workflow.md: Fix a typo.
-- [`aa7144c`](https://github.com/deisthree/workflow/commit/aa7144c41c2eee0c6fae589691f2780e995d154c) (workflow) - platform-ssl.md: correct example manifest
-- [`9d5d1d5`](https://github.com/deisthree/workflow/commit/9d5d1d5e23aaba81448b996934a843f25c667c5a) (workflow) - database: Document off-cluster db configuration
-- [`0cb76fc`](https://github.com/deisthree/workflow/commit/0cb76fc25356916d48045b4bb48c9a9eb6f9811c) (workflow) - applications: add documentation for healthchecks
-- [`7ee764f`](https://github.com/deisthree/workflow/commit/7ee764f954bf789b055ccae0a2aac696da291625) (workflow) - release-checklist.md: modify docker tag/push instructions to use new deisrel command (#355)
-- [`eda6479`](https://github.com/deisthree/workflow/commit/eda64791be6caeba2181b4cc5d47800b447012b5) (workflow) - v2.1.0: Updates docs for latest release
+- [`044f85c`](https://github.com/deis/slugrunner/commit/044f85c6bd86d233a58e76143ec6283d85d954db) (slugrunner) - CHANGELOG.md: add entry for v2.0.0
+- [`bf3e1da`](https://github.com/deis/router/commit/bf3e1daf9b578fb8e01a077bd2ff75af6b69953b) (router) - README: add codecov.io badge
+- [`0aa8abb`](https://github.com/deis/router/commit/0aa8abb23da786498b6096bf43857c28b549ac81) (router) - readme: Add anchors to every row in annotations table
+- [`a80425d`](https://github.com/deis/router/commit/a80425d94e17b4758e42a206e552f9e9bc197ef5) (router) - CHANGELOG.md: add entry for v2.0.0
+- [`6b60912`](https://github.com/deis/router/commit/6b60912fc7bab68b5724d5cb8e3e7ee572cf793d) (router) - README: fix Go report card badge
+- [`4b1f311`](https://github.com/deis/registry/commit/4b1f31127f87447c2abe25075377a234a97a78c4) (registry) - CHANGELOG.md: add entry for v2.0.0
+- [`5fc10d5`](https://github.com/deis/registry/commit/5fc10d554514b908b6e8d820c6d81d8544915cbf) (registry) - README: fix Go report card badge
+- [`61a4dc9`](https://github.com/deis/postgres/commit/61a4dc9a9671bb436968a5f655fd87f3bb6c520e) (postgres) - CHANGELOG.md: add entry for v2.0.0
+- [`4efe5f9`](https://github.com/deis/postgres/commit/4efe5f9e8851b627ee156db22f32d83dac5a531b) (postgres) - README.md: Fix the default value of IMAGE_PREFIX
+- [`920dbf6`](https://github.com/deis/slugbuilder/commit/920dbf606bf24213b4cea02457bfd838e711e2ee) (slugbuilder) - CHANGELOG.md: add entry for v2.0.0
+- [`48d4ecb`](https://github.com/deis/dockerbuilder/commit/48d4ecbf94781333daa8346a966210f710110cd3) (dockerbuilder) - CHANGELOG.md: add entry for v2.0.0
+- [`7f046cc`](https://github.com/deis/fluentd/commit/7f046cc542cf42b5160e48cd6a7c9284b363999f) (fluentd) - CHANGELOG.md: add entry for v2.0.0
+- [`31e054d`](https://github.com/deis/minio/commit/31e054df00fa1ea25be8d7e5f7e47280c63da72e) (minio) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`958ccd7`](https://github.com/deis/minio/commit/958ccd7af60354e6263278ba6f592a5449e25ed8) (minio) - CHANGELOG.md: add entry for v2.0.0
+- [`ebbbc3a`](https://github.com/deis/workflow-manager/commit/ebbbc3a1364678435e11bb0518c5f388893a9d51) (workflow-manager) - CHANGELOG.md: add entry for v2.0.0
+- [`04f65c6`](https://github.com/deis/monitor/commit/04f65c67550c80cff40335ea13497d8603347a6b) (monitor) - CHANGELOG.md: add entry for v2.0.0
+- [`94bf4c1`](https://github.com/deis/workflow-e2e/commit/94bf4c15fe3c67aa9cfa5f4d57618ecf8e53bfe5) (workflow-e2e) - CHANGELOG.md: add entry for v2.0.0
+- [`778ab68`](https://github.com/deis/logger/commit/778ab68fd56d9308e1d4d61a024a544edef72e7b) (logger) - README: add codecov.io badge
+- [`d3fc751`](https://github.com/deis/logger/commit/d3fc75189fbeb8dbd728cffb5d53324c8ec25db9) (logger) - CHANGELOG.md: add entry for v2.0.0
+- [`178bc7c`](https://github.com/deis/logger/commit/178bc7cb110c23c03cb7ade4df851e00fbc79316) (logger) - README: fix Go report card badge
+- [`6367466`](https://github.com/deis/charts/commit/63674660da06c0f9deb0a89e9f9a8d8fa63812b0) (charts) - CHANGELOG.md: add entry for v2.0.0
+- [`e038851`](https://github.com/deis/builder/commit/e038851678da9363a99a3639d67181abb6ab68bf) (builder) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`58a8786`](https://github.com/deis/builder/commit/58a8786d764db22a7f01c68398ec86aff34f6541) (builder) - pkg: update help URL to https://deis.com/
+- [`0df2ba3`](https://github.com/deis/builder/commit/0df2ba3a70cf22c3195af25833a70cfce68fc195) (builder) - CHANGELOG.md: add entry for v2.0.0
+- [`c3945f2`](https://github.com/deis/builder/commit/c3945f2ef286fb103ea413647497a6e4884352d1) (builder) - README: add codecov.io badge
+- [`b001515`](https://github.com/deis/controller/commit/b0015157ba5288d3fdd6dde104efa879305bd4e2) (controller) - CHANGELOG.md: add entry for v2.0.0-rc2
+- [`c7fb984`](https://github.com/deis/controller/commit/c7fb984d077d605d0469649f826c1b38458adaf8) (controller) - CHANGELOG.md: add entry for v2.0.0
+- [`9063a96`](https://github.com/deis/workflow/commit/9063a96112c7d90d526df707f94bd33392804d5f) (workflow) - installing-workflow: fix missing watch flag
+- [`cf9693f`](https://github.com/deis/workflow/commit/cf9693f9ed5bbe2d1ea8a613bb797f556768182f) (workflow) - release-checklist.md: remove bintray references
+- [`cda073c`](https://github.com/deis/workflow/commit/cda073c9bfdeb02425208f7e1ff734bfda50c353) (workflow) - CHANGELOG.md: add entry for v2.0.0
+- [`5c753e5`](https://github.com/deis/workflow/commit/5c753e5840d94b88ecf92c0458a1d618a3e78dcf) (workflow) - styles: update the theme to match deis.com
+- [`a77d967`](https://github.com/deis/workflow/commit/a77d96780012c1a0dee70422d7827574f7660512) (workflow) - styles: remove sass from makefile
+- [`e37b2dc`](https://github.com/deis/workflow/commit/e37b2dc4eedce6ee5ff194965cf97e619c6d6d54) (workflow) - styles: tidy up JS, better affix the sidebar menu
+- [`919f22c`](https://github.com/deis/workflow/commit/919f22c16532f1e091ffa276a80c4190c369f28e) (workflow) - styles: fix urls, style for better mobile layout
+- [`e868009`](https://github.com/deis/workflow/commit/e868009bddf5f4ba3c717c63a91dd15d89feb3e5) (workflow) - styles: remove bower_components
+- [`2e1c6a9`](https://github.com/deis/workflow/commit/2e1c6a97fae0f9e5ca80a71b54235f52c7b07e94) (workflow) - styles: mobile off-canvas menu
+- [`908f715`](https://github.com/deis/workflow/commit/908f71528e207bae5d7a31ad69b582657c4777a4) (workflow) - styles: color changes to open sidebar sections
+- [`82000d1`](https://github.com/deis/workflow/commit/82000d17a41ae69d47553af6e5c1afb8e9945815) (workflow) - src/roadmap/release-checklist.md: update Step 2.1
+- [`7cbd1de`](https://github.com/deis/workflow/commit/7cbd1de5d6b28b1c73e240582a6044b9fad02b97) (workflow) - src/roadmap/release-checklist.md: update if major release
+- [`dad9598`](https://github.com/deis/workflow/commit/dad9598e53e0b777732b80a83fc838ee38c34744) (workflow) - submitting-a-pr: add "hotfix revert" exception to LGTM rules
+- [`a0ff462`](https://github.com/deis/workflow/commit/a0ff462fa89c52de4529e1035da5d4e44e8df15d) (workflow) - release-checklist: Improve instructions pertaining to previous release
+- [`cdbc575`](https://github.com/deis/workflow/commit/cdbc575daebfec6f1e62b0180916b4a2977aa32d) (workflow) - README.md: fix quick start guide URL
+- [`9e843cd`](https://github.com/deis/workflow/commit/9e843cd65933700521132439bb78fd9b32d1fcdf) (workflow) - s3: add instruction for using IAM creds
+- [`b451c66`](https://github.com/deis/workflow/commit/b451c66111df010c5452c2eee9292906e90af41b) (workflow) - release_checklist.md: return to using immutable tags
+- [`2286765`](https://github.com/deis/workflow/commit/22867651d2f6baf387dbb19ae1b2617445e4adf8) (workflow) - submitting-a-pull-request.md: add info on testing paired commits
+- [`467a21d`](https://github.com/deis/workflow/commit/467a21d887b8f342ce39e2cc0912e17467b61dce) (workflow) - platform-logging.md: Need "--namespace=deis" when deleting pods.
+- [`606bdd8`](https://github.com/deis/workflow/commit/606bdd8ced5c426769e505095d0ccc7d073b1264) (workflow) - router: Remove invalid labels from example whitelists
+- [`87e0b58`](https://github.com/deis/workflow/commit/87e0b5878eb147575529fa6c6e548ab50f061080) (workflow) - upgrade-workflow.md: Fix a typo.
+- [`aa7144c`](https://github.com/deis/workflow/commit/aa7144c41c2eee0c6fae589691f2780e995d154c) (workflow) - platform-ssl.md: correct example manifest
+- [`9d5d1d5`](https://github.com/deis/workflow/commit/9d5d1d5e23aaba81448b996934a843f25c667c5a) (workflow) - database: Document off-cluster db configuration
+- [`0cb76fc`](https://github.com/deis/workflow/commit/0cb76fc25356916d48045b4bb48c9a9eb6f9811c) (workflow) - applications: add documentation for healthchecks
+- [`7ee764f`](https://github.com/deis/workflow/commit/7ee764f954bf789b055ccae0a2aac696da291625) (workflow) - release-checklist.md: modify docker tag/push instructions to use new deisrel command (#355)
+- [`eda6479`](https://github.com/deis/workflow/commit/eda64791be6caeba2181b4cc5d47800b447012b5) (workflow) - v2.1.0: Updates docs for latest release
 
 
 
 #### Maintenance
 
-- [`0526f01`](https://github.com/deisthree/slugrunner/commit/0526f01f5a2b8f75ff36b052e32f76f0d5f638ba) (slugrunner) - manifests: remove unused/deprecated manifests dir
-- [`3b3aaad`](https://github.com/deisthree/slugrunner/commit/3b3aaad32a39a2378adf369aac9496633fc39055) (slugrunner) - Dockerfile: Remove WORKFLOW_RELEASE env var
-- [`7c23489`](https://github.com/deisthree/router/commit/7c23489c3315d144ff42a2e1f53fe901bca086c1) (router) - Dockerfile: Remove WORKFLOW_RELEASE env var
-- [`f0bb535`](https://github.com/deisthree/slugbuilder/commit/f0bb5355a59085f55d1113fab01c00a132ab09af) (slugbuilder) - buildpacks: update heroku-buildpack-go to v41
-- [`4aeb7ff`](https://github.com/deisthree/slugbuilder/commit/4aeb7ff1d6522ca4173be8f266df375ca256aa37) (slugbuilder) - buildpacks: update heroku-buildpack-php to v105
-- [`70b88ef`](https://github.com/deisthree/slugbuilder/commit/70b88ef417423d621289c54be5373370d9e339aa) (slugbuilder) - manifests: remove unused/deprecated manifests dir
-- [`cad6225`](https://github.com/deisthree/slugbuilder/commit/cad6225b1f85126fae736be74f5243aef21c64d1) (slugbuilder) - buildpacks: update heroku-buildpack-php to v107
-- [`eb47460`](https://github.com/deisthree/dockerbuilder/commit/eb47460386c6f536b682cf7e5c51fa9bef4163fc) (dockerbuilder) - manifests: remove unused/deprecated manifests dir
-- [`905cde5`](https://github.com/deisthree/fluentd/commit/905cde5e32e88fa6823aa54a020e4e6dc6ec753b) (fluentd) - Dockerfile: Remove WORKFLOW_RELEASE env var
-- [`52c97ad`](https://github.com/deisthree/minio/commit/52c97ad1205a11de084d412e77889e9e49f5534c) (minio) - README.md: remove beta status
-- [`6aac8ba`](https://github.com/deisthree/minio/commit/6aac8ba7560834f57907ff9788cfeaff7fbe1166) (minio) - Dockerfile: Remove WORKFLOW_RELEASE env var
-- [`3cbf260`](https://github.com/deisthree/monitor/commit/3cbf2608b12fc7a5e9a7f84756bd6d9117b64a6d) (monitor) - grafana: Update nsq dashboard to add message per second graph
-- [`8f52433`](https://github.com/deisthree/monitor/commit/8f524332eefa7807707fcbbe427f3c7024ee9058) (monitor) - grafana: Remove stray alias in a kubernetes health graph
-- [`5ff77c7`](https://github.com/deisthree/monitor/commit/5ff77c76fa01e0b6fa3967f3f58a750446a8514f) (monitor) - Dockerfile: Remove WORKFLOW_RELEASE env var
-- [`7d6a033`](https://github.com/deisthree/workflow-e2e/commit/7d6a0336b641c0685586737ae2c82c243d85d286) (workflow-e2e) - Makefile: remove deprecated '-f' flag
-- [`7123b6a`](https://github.com/deisthree/logger/commit/7123b6a4df32b33d0d5a959869579b4e3a9eebbf) (logger) - transport: Refactor to use pluggable Aggregator component...
-- [`ba819b0`](https://github.com/deisthree/logger/commit/ba819b09801ec28a802d3febd9826a3ff8d9ecdc) (logger) - Dockerfile: Remove WORKFLOW_RELEASE env var
-- [`92abf85`](https://github.com/deisthree/charts/commit/92abf85d17bfb452d1e67b684768fd4e9862dd70) (charts) - router-dev/Chart.yaml: bump version to v2.0.0
-- [`46289d0`](https://github.com/deisthree/charts/commit/46289d0aeb15d01a78a85b9c02c90a6ac6020e0e) (charts) - workflow/router-dev/Chart.yaml: prepend description with chart name
-- [`64026dc`](https://github.com/deisthree/charts/commit/64026dc785a906b0662edd486ff0d2e5982a939f) (charts) - workflow-dev: Update image name in nsqd-rc to be nsq.
-- [`fcd4fce`](https://github.com/deisthree/charts/commit/fcd4fce4e2f74c10612c85bb8d1b704e13a28f16) (charts) - logger/fluentd: Update logging stack to reflect nsq usage
-- [`473ea02`](https://github.com/deisthree/charts/commit/473ea02b1124556c9b4f143effeabf020fee2eb8) (charts) - workflow-dev: Update telegraf env vars
-- [`010de23`](https://github.com/deisthree/charts/commit/010de23a61c92d104689982e4becf8d381030c4b) (charts) - workflow-dev: remove stdout metrics config from fluentd
-- [`3274b8c`](https://github.com/deisthree/charts/commit/3274b8cd44debd3843129ff23075f7e6e059ee0f) (charts) - logger: Stop logging via UDP
-- [`fc70265`](https://github.com/deisthree/charts/commit/fc702659e5693cdf0ad5cd378bc2cf4684564c49) (charts) - workflow-v2.1.0: releasing workflow-v2.1.0(-e2e) and router-v2.1.0
-- [`f6580ee`](https://github.com/deisthree/builder/commit/f6580ee558309f9d5902e660b2de69a0e07d776a) (builder) - various: remove beta status
-- [`03a8ac5`](https://github.com/deisthree/builder/commit/03a8ac598880511dd3b189d85211efad699551ed) (builder) - Dockerfile: bump git to v2.8.4
-- [`bf35966`](https://github.com/deisthree/controller/commit/bf359660be57858a6343cb4206aedf98fbc38761) (controller) - requirements: update codecov to 2.0.5
-- [`59a8d23`](https://github.com/deisthree/controller/commit/59a8d23efacc0b261a08d0d76a0d1a2c7676c3f7) (controller) - Dockerfile: update to base:0.3.0 image to get a slimmer image
-- [`3a6ee54`](https://github.com/deisthree/controller/commit/3a6ee546da5f36279fad4576c8a30eb4cea13bcc) (controller) - README: remove references to beta in README
-- [`7a88725`](https://github.com/deisthree/controller/commit/7a8872514e6af00c09e225a282c6064c8dfb4a6f) (controller) - requirements: update to Django 1.9.7
-- [`04049b4`](https://github.com/deisthree/controller/commit/04049b43cc56eecbd1d9fb76dd1c588aceffc379) (controller) - version: update platform version to 2.0.0
-- [`db2e182`](https://github.com/deisthree/controller/commit/db2e182e6dc817d17deeee282e4c73eb253ce1b9) (controller) - deis: bump version to 2.1.0-dev
-- [`13cffb6`](https://github.com/deisthree/controller/commit/13cffb67302e1cba3b0c8503236c8b5e5c662de2) (controller) - requirements: update ndg-httpsclient to 0.4.1
-- [`eda8bea`](https://github.com/deisthree/controller/commit/eda8bea6f4e21b9b1a82cd2c8c4fc9b43f9aa9f6) (controller) - rootfs: bump platform version to 2.1.0 (#841)
-- [`214b0a9`](https://github.com/deisthree/controller/commit/214b0a99c48e9f6b051de064566f6f022dcaf0de) (controller) - api: bump api version to v2.1.0
-- [`595d377`](https://github.com/deisthree/workflow/commit/595d377dcb69926041bb5d65ddf929925304d8ba) (workflow) - health: note that kubernetes does not support query params in the health check path
-- [`88e240a`](https://github.com/deisthree/workflow/commit/88e240ac89506667e350388fae3f71460b3ba36b) (workflow) - docs: update version to v2.0.0
-- [`20f2b5a`](https://github.com/deisthree/workflow/commit/20f2b5a362fcb28879710e8999035efcebc8e5be) (workflow) - ga: use deis.com GA account
-- [`10b1146`](https://github.com/deisthree/workflow/commit/10b114607243db32255cf6bee51970b3293e194c) (workflow) - docs: ignore bower_components for doc styles
+- [`0526f01`](https://github.com/deis/slugrunner/commit/0526f01f5a2b8f75ff36b052e32f76f0d5f638ba) (slugrunner) - manifests: remove unused/deprecated manifests dir
+- [`3b3aaad`](https://github.com/deis/slugrunner/commit/3b3aaad32a39a2378adf369aac9496633fc39055) (slugrunner) - Dockerfile: Remove WORKFLOW_RELEASE env var
+- [`7c23489`](https://github.com/deis/router/commit/7c23489c3315d144ff42a2e1f53fe901bca086c1) (router) - Dockerfile: Remove WORKFLOW_RELEASE env var
+- [`f0bb535`](https://github.com/deis/slugbuilder/commit/f0bb5355a59085f55d1113fab01c00a132ab09af) (slugbuilder) - buildpacks: update heroku-buildpack-go to v41
+- [`4aeb7ff`](https://github.com/deis/slugbuilder/commit/4aeb7ff1d6522ca4173be8f266df375ca256aa37) (slugbuilder) - buildpacks: update heroku-buildpack-php to v105
+- [`70b88ef`](https://github.com/deis/slugbuilder/commit/70b88ef417423d621289c54be5373370d9e339aa) (slugbuilder) - manifests: remove unused/deprecated manifests dir
+- [`cad6225`](https://github.com/deis/slugbuilder/commit/cad6225b1f85126fae736be74f5243aef21c64d1) (slugbuilder) - buildpacks: update heroku-buildpack-php to v107
+- [`eb47460`](https://github.com/deis/dockerbuilder/commit/eb47460386c6f536b682cf7e5c51fa9bef4163fc) (dockerbuilder) - manifests: remove unused/deprecated manifests dir
+- [`905cde5`](https://github.com/deis/fluentd/commit/905cde5e32e88fa6823aa54a020e4e6dc6ec753b) (fluentd) - Dockerfile: Remove WORKFLOW_RELEASE env var
+- [`52c97ad`](https://github.com/deis/minio/commit/52c97ad1205a11de084d412e77889e9e49f5534c) (minio) - README.md: remove beta status
+- [`6aac8ba`](https://github.com/deis/minio/commit/6aac8ba7560834f57907ff9788cfeaff7fbe1166) (minio) - Dockerfile: Remove WORKFLOW_RELEASE env var
+- [`3cbf260`](https://github.com/deis/monitor/commit/3cbf2608b12fc7a5e9a7f84756bd6d9117b64a6d) (monitor) - grafana: Update nsq dashboard to add message per second graph
+- [`8f52433`](https://github.com/deis/monitor/commit/8f524332eefa7807707fcbbe427f3c7024ee9058) (monitor) - grafana: Remove stray alias in a kubernetes health graph
+- [`5ff77c7`](https://github.com/deis/monitor/commit/5ff77c76fa01e0b6fa3967f3f58a750446a8514f) (monitor) - Dockerfile: Remove WORKFLOW_RELEASE env var
+- [`7d6a033`](https://github.com/deis/workflow-e2e/commit/7d6a0336b641c0685586737ae2c82c243d85d286) (workflow-e2e) - Makefile: remove deprecated '-f' flag
+- [`7123b6a`](https://github.com/deis/logger/commit/7123b6a4df32b33d0d5a959869579b4e3a9eebbf) (logger) - transport: Refactor to use pluggable Aggregator component...
+- [`ba819b0`](https://github.com/deis/logger/commit/ba819b09801ec28a802d3febd9826a3ff8d9ecdc) (logger) - Dockerfile: Remove WORKFLOW_RELEASE env var
+- [`92abf85`](https://github.com/deis/charts/commit/92abf85d17bfb452d1e67b684768fd4e9862dd70) (charts) - router-dev/Chart.yaml: bump version to v2.0.0
+- [`46289d0`](https://github.com/deis/charts/commit/46289d0aeb15d01a78a85b9c02c90a6ac6020e0e) (charts) - workflow/router-dev/Chart.yaml: prepend description with chart name
+- [`64026dc`](https://github.com/deis/charts/commit/64026dc785a906b0662edd486ff0d2e5982a939f) (charts) - workflow-dev: Update image name in nsqd-rc to be nsq.
+- [`fcd4fce`](https://github.com/deis/charts/commit/fcd4fce4e2f74c10612c85bb8d1b704e13a28f16) (charts) - logger/fluentd: Update logging stack to reflect nsq usage
+- [`473ea02`](https://github.com/deis/charts/commit/473ea02b1124556c9b4f143effeabf020fee2eb8) (charts) - workflow-dev: Update telegraf env vars
+- [`010de23`](https://github.com/deis/charts/commit/010de23a61c92d104689982e4becf8d381030c4b) (charts) - workflow-dev: remove stdout metrics config from fluentd
+- [`3274b8c`](https://github.com/deis/charts/commit/3274b8cd44debd3843129ff23075f7e6e059ee0f) (charts) - logger: Stop logging via UDP
+- [`fc70265`](https://github.com/deis/charts/commit/fc702659e5693cdf0ad5cd378bc2cf4684564c49) (charts) - workflow-v2.1.0: releasing workflow-v2.1.0(-e2e) and router-v2.1.0
+- [`f6580ee`](https://github.com/deis/builder/commit/f6580ee558309f9d5902e660b2de69a0e07d776a) (builder) - various: remove beta status
+- [`03a8ac5`](https://github.com/deis/builder/commit/03a8ac598880511dd3b189d85211efad699551ed) (builder) - Dockerfile: bump git to v2.8.4
+- [`bf35966`](https://github.com/deis/controller/commit/bf359660be57858a6343cb4206aedf98fbc38761) (controller) - requirements: update codecov to 2.0.5
+- [`59a8d23`](https://github.com/deis/controller/commit/59a8d23efacc0b261a08d0d76a0d1a2c7676c3f7) (controller) - Dockerfile: update to base:0.3.0 image to get a slimmer image
+- [`3a6ee54`](https://github.com/deis/controller/commit/3a6ee546da5f36279fad4576c8a30eb4cea13bcc) (controller) - README: remove references to beta in README
+- [`7a88725`](https://github.com/deis/controller/commit/7a8872514e6af00c09e225a282c6064c8dfb4a6f) (controller) - requirements: update to Django 1.9.7
+- [`04049b4`](https://github.com/deis/controller/commit/04049b43cc56eecbd1d9fb76dd1c588aceffc379) (controller) - version: update platform version to 2.0.0
+- [`db2e182`](https://github.com/deis/controller/commit/db2e182e6dc817d17deeee282e4c73eb253ce1b9) (controller) - deis: bump version to 2.1.0-dev
+- [`13cffb6`](https://github.com/deis/controller/commit/13cffb67302e1cba3b0c8503236c8b5e5c662de2) (controller) - requirements: update ndg-httpsclient to 0.4.1
+- [`eda8bea`](https://github.com/deis/controller/commit/eda8bea6f4e21b9b1a82cd2c8c4fc9b43f9aa9f6) (controller) - rootfs: bump platform version to 2.1.0 (#841)
+- [`214b0a9`](https://github.com/deis/controller/commit/214b0a99c48e9f6b051de064566f6f022dcaf0de) (controller) - api: bump api version to v2.1.0
+- [`595d377`](https://github.com/deis/workflow/commit/595d377dcb69926041bb5d65ddf929925304d8ba) (workflow) - health: note that kubernetes does not support query params in the health check path
+- [`88e240a`](https://github.com/deis/workflow/commit/88e240ac89506667e350388fae3f71460b3ba36b) (workflow) - docs: update version to v2.0.0
+- [`20f2b5a`](https://github.com/deis/workflow/commit/20f2b5a362fcb28879710e8999035efcebc8e5be) (workflow) - ga: use deis.com GA account
+- [`10b1146`](https://github.com/deis/workflow/commit/10b114607243db32255cf6bee51970b3293e194c) (workflow) - docs: ignore bower_components for doc styles

--- a/src/changelogs/v2.10.0.md
+++ b/src/changelogs/v2.10.0.md
@@ -15,96 +15,96 @@
 
 #### Features
 
-- [`38275ea`](https://github.com/deisthree/controller/commit/38275ea3d20a5e40413d8e0fbfbb09d8fb0184a2) (controller) - controller: add LDAP authentication
-- [`51cab9d`](https://github.com/deisthree/controller/commit/51cab9dacab73054247f37830ca6ea06608ac02d) (controller) - api: add deploy hooks (#1168)
-- [`805a455`](https://github.com/deisthree/controller/commit/805a455520c034c829b144d9dd0b793730443183) (controller) - api: validate a certificate's private key (#1157)
-- [`5bed284`](https://github.com/deisthree/fluentd/commit/5bed284d6835376675f79d15279a6b2100766cc7) (fluentd) - charts: add optional syslog endpoint setting
-- [`830cee8`](https://github.com/deisthree/postgres/commit/830cee802e45542f1ccb1ed0f5f50d49bc3e5410) (postgres) - charts: Add support to specify creds for in cluster db through values file
-- [`f7df62a`](https://github.com/deisthree/workflow-e2e/commit/f7df62a34e90cef38cabee02f78162f591a3fd5b) (workflow-e2e) - auth_test.go: add interactive register spec
-- [`67b658f`](https://github.com/deisthree/workflow/commit/67b658f692c65e274b486e7f3e91705bd1204921) (workflow) - charts: Add optional syslog endpoint setting to fluentd
-- [`4a5b895`](https://github.com/deisthree/workflow/commit/4a5b8951aff85cbf1cbb923360a4fcb96fdab826) (workflow) - azure: Add docs to specify support for the azure container registry
-- [`19b9ec1`](https://github.com/deisthree/workflow/commit/19b9ec1d96287e3c8d341dcc1a79a6850b6dc973) (workflow) - azure: skeleton for Azure Container Service quickstart
-- [`f344230`](https://github.com/deisthree/workflow/commit/f344230b2490d50fa3fd07028a5bc7c8011d1359) (workflow) - Dockerfile: make the Dockerfile more functional
-- [`de4564f`](https://github.com/deisthree/workflow/commit/de4564fd7417112fcd7e3bed29043cd45fcd7bc4) (workflow) - managing-deis: add docs for deploy hooks
-- [`e255775`](https://github.com/deisthree/workflow/commit/e2557755b4badd0e6b1a36c7a6c450987540d376) (workflow) - charts: Add support to specify creds for in cluster db through values file
+- [`38275ea`](https://github.com/deis/controller/commit/38275ea3d20a5e40413d8e0fbfbb09d8fb0184a2) (controller) - controller: add LDAP authentication
+- [`51cab9d`](https://github.com/deis/controller/commit/51cab9dacab73054247f37830ca6ea06608ac02d) (controller) - api: add deploy hooks (#1168)
+- [`805a455`](https://github.com/deis/controller/commit/805a455520c034c829b144d9dd0b793730443183) (controller) - api: validate a certificate's private key (#1157)
+- [`5bed284`](https://github.com/deis/fluentd/commit/5bed284d6835376675f79d15279a6b2100766cc7) (fluentd) - charts: add optional syslog endpoint setting
+- [`830cee8`](https://github.com/deis/postgres/commit/830cee802e45542f1ccb1ed0f5f50d49bc3e5410) (postgres) - charts: Add support to specify creds for in cluster db through values file
+- [`f7df62a`](https://github.com/deis/workflow-e2e/commit/f7df62a34e90cef38cabee02f78162f591a3fd5b) (workflow-e2e) - auth_test.go: add interactive register spec
+- [`67b658f`](https://github.com/deis/workflow/commit/67b658f692c65e274b486e7f3e91705bd1204921) (workflow) - charts: Add optional syslog endpoint setting to fluentd
+- [`4a5b895`](https://github.com/deis/workflow/commit/4a5b8951aff85cbf1cbb923360a4fcb96fdab826) (workflow) - azure: Add docs to specify support for the azure container registry
+- [`19b9ec1`](https://github.com/deis/workflow/commit/19b9ec1d96287e3c8d341dcc1a79a6850b6dc973) (workflow) - azure: skeleton for Azure Container Service quickstart
+- [`f344230`](https://github.com/deis/workflow/commit/f344230b2490d50fa3fd07028a5bc7c8011d1359) (workflow) - Dockerfile: make the Dockerfile more functional
+- [`de4564f`](https://github.com/deis/workflow/commit/de4564fd7417112fcd7e3bed29043cd45fcd7bc4) (workflow) - managing-deis: add docs for deploy hooks
+- [`e255775`](https://github.com/deis/workflow/commit/e2557755b4badd0e6b1a36c7a6c450987540d376) (workflow) - charts: Add support to specify creds for in cluster db through values file
 
 #### Refactors
 
-- [`ffa66e7`](https://github.com/deisthree/controller/commit/ffa66e7c62a58c5edf804b232e92c0748c30404f) (controller) - api: placate new flake8 linter checks
-- [`e470052`](https://github.com/deisthree/controller/commit/e470052be7d9ee61628ce1e79d77ddb30f3a7257) (controller) - codecov: add 0.2% failure threshold to codecov (#1192)
-- [`f2bc3ae`](https://github.com/deisthree/registry/commit/f2bc3aefc6a3b43f414bbd131956abf171ffd9bd) (registry) - update docs and Makefile
-- [`ba06288`](https://github.com/deisthree/workflow-cli/commit/ba06288d035df826c988a40db96ef036e173d41d) (workflow-cli) - placate gometalinter checks
-- [`91dda51`](https://github.com/deisthree/workflow-e2e/commit/91dda5188daacb22bcb54fb54db3935bf737f1fd) (workflow-e2e) - adjust error message expectations
-- [`1c05adb`](https://github.com/deisthree/workflow/commit/1c05adb0118f3db4e2548f2d250c5cb29bd22848) (workflow) - require key_json chart value to be base64-encoded
+- [`ffa66e7`](https://github.com/deis/controller/commit/ffa66e7c62a58c5edf804b232e92c0748c30404f) (controller) - api: placate new flake8 linter checks
+- [`e470052`](https://github.com/deis/controller/commit/e470052be7d9ee61628ce1e79d77ddb30f3a7257) (controller) - codecov: add 0.2% failure threshold to codecov (#1192)
+- [`f2bc3ae`](https://github.com/deis/registry/commit/f2bc3aefc6a3b43f414bbd131956abf171ffd9bd) (registry) - update docs and Makefile
+- [`ba06288`](https://github.com/deis/workflow-cli/commit/ba06288d035df826c988a40db96ef036e173d41d) (workflow-cli) - placate gometalinter checks
+- [`91dda51`](https://github.com/deis/workflow-e2e/commit/91dda5188daacb22bcb54fb54db3935bf737f1fd) (workflow-e2e) - adjust error message expectations
+- [`1c05adb`](https://github.com/deis/workflow/commit/1c05adb0118f3db4e2548f2d250c5cb29bd22848) (workflow) - require key_json chart value to be base64-encoded
 
 #### Fixes
 
-- [`1609d89`](https://github.com/deisthree/controller/commit/1609d897fb16dc3e376905fd7f49638d3db575c9) (controller) - apiserver: Add an option to skip ssl verification when interacting with the k8s api
-- [`d2ee40f`](https://github.com/deisthree/controller/commit/d2ee40f40d3c663af5956228f6d26f8966cd4466) (controller) - boot: Don't change group ownership of docker socket
-- [`62f081a`](https://github.com/deisthree/controller/commit/62f081a7e56eb6f06230d6612b5203d183016b1e) (controller) - scheduler: use pypa packaging to compare server version (#1167)
-- [`9f4543b`](https://github.com/deisthree/controller/commit/9f4543b6ca79475156a51f8c6dd14006dc71db59) (controller) - domain: remove the annotation when domain is deleted
-- [`27a59d1`](https://github.com/deisthree/controller/commit/27a59d11446d182e7749647e70b1baaa7103bb8a) (controller) - service-config: Don't add annotations if the value is empty
-- [`890a263`](https://github.com/deisthree/controller/commit/890a26318802fedf1ce82c42ad2401af57671af4) (controller) - api: account for NoneType when resource is gone (#1178)
-- [`f132b25`](https://github.com/deisthree/controller/commit/f132b2524028ed324cc38cdd45920b76883135e4) (controller) - api: validate app name against k8s service regex (#1163)
-- [`9098331`](https://github.com/deisthree/controller/commit/9098331900f1dda36ba4f858b4bbbc1719933979) (controller) - perms: Use the same regex for perms as auth endpoint (#1181)
-- [`30ab1d3`](https://github.com/deisthree/controller/commit/30ab1d3b338374277d1ccc6324ceb4738e9af6c6) (controller) - settings: disable LDAP by default (#1191)
-- [`4c36791`](https://github.com/deisthree/controller/commit/4c36791fe0829b48b7aeebe422f05e46d4e06df3) (controller) - management: display error when connecting to the database (#1190)
-- [`78ad61f`](https://github.com/deisthree/fluentd/commit/78ad61f7bd22450e820d6c34b56c31cd07d76c31) (fluentd) - logger: show error message and backtrace
-- [`107b2e1`](https://github.com/deisthree/fluentd/commit/107b2e14558be4c64e75f4debd153b921cff709f) (fluentd) - logger: utf-8 encoding
-- [`34da2e2`](https://github.com/deisthree/router/commit/34da2e281dcead217b11adfc56904c1fe3efac85) (router) - charts: enable hostports by default
-- [`4284483`](https://github.com/deisthree/workflow-cli/commit/4284483d69056333bff010d74093e259ff0442ac) (workflow-cli) - healthcheck: Parse arguments properly for httpheaders
-- [`958a3ab`](https://github.com/deisthree/workflow-cli/commit/958a3ab6bdfaf191f173d35ead96b08d698b4cf8) (workflow-cli) - Jenkinsfile: update downstream test job
-- [`2b7700d`](https://github.com/deisthree/workflow-cli/commit/2b7700dbe93aac847d827c2c19f4b8cdfc49ddff) (workflow-cli) - glide: update the controller sdk go version in the glide
-- [`388fd97`](https://github.com/deisthree/workflow-cli/commit/388fd9772ba9aa7fc7b7fe83f56fabb6e8ed1843) (workflow-cli) - Jenkinsfile: set git_branch to env.BRANCH_NAME
-- [`6d644a1`](https://github.com/deisthree/workflow-e2e/commit/6d644a120fa819c746c6bd832039a04c8ed3badd) (workflow-e2e) - docker-test-integration.sh: explicit DEBUG_MODE check
-- [`f81df33`](https://github.com/deisthree/workflow-e2e/commit/f81df33de3570907a90bc3538235fb8f6faf9f38) (workflow-e2e) - chart: s/ginko/ginkgo
-- [`a686dfd`](https://github.com/deisthree/workflow/commit/a686dfd32141edb90dcd32ca07536c55b21bc6ba) (workflow) - values: redis params are in the redis chart
-- [`b3a9db1`](https://github.com/deisthree/workflow/commit/b3a9db14c41caae331d53ef5dd553d856ccbb271) (workflow) - upgrade: Use a random generated name for upgrade job so it be upgraded multiple times using helm
-- [`5b7b98d`](https://github.com/deisthree/workflow/commit/5b7b98ddb85fa621fd7ab1c852907991a2f3faa5) (workflow) - releases: remove reference to deis/charts in release notes
-- [`233b630`](https://github.com/deisthree/workflow/commit/233b630cb4b3e6f658c3d7b530ca67434e6baaed) (workflow) - managing-workflow: update logging and monitoring docs to reflect helm v2
-- [`6989718`](https://github.com/deisthree/workflow/commit/698971858c98ea25b3bf17ee8e932f1df47004dc) (workflow) - charts: enable hostports by default
-- [`2a96baf`](https://github.com/deisthree/workflow/commit/2a96bafeaf2507d368c3785fea5ce5054a6af840) (workflow) - upgrading-workflow: fix helm upgrade usage
+- [`1609d89`](https://github.com/deis/controller/commit/1609d897fb16dc3e376905fd7f49638d3db575c9) (controller) - apiserver: Add an option to skip ssl verification when interacting with the k8s api
+- [`d2ee40f`](https://github.com/deis/controller/commit/d2ee40f40d3c663af5956228f6d26f8966cd4466) (controller) - boot: Don't change group ownership of docker socket
+- [`62f081a`](https://github.com/deis/controller/commit/62f081a7e56eb6f06230d6612b5203d183016b1e) (controller) - scheduler: use pypa packaging to compare server version (#1167)
+- [`9f4543b`](https://github.com/deis/controller/commit/9f4543b6ca79475156a51f8c6dd14006dc71db59) (controller) - domain: remove the annotation when domain is deleted
+- [`27a59d1`](https://github.com/deis/controller/commit/27a59d11446d182e7749647e70b1baaa7103bb8a) (controller) - service-config: Don't add annotations if the value is empty
+- [`890a263`](https://github.com/deis/controller/commit/890a26318802fedf1ce82c42ad2401af57671af4) (controller) - api: account for NoneType when resource is gone (#1178)
+- [`f132b25`](https://github.com/deis/controller/commit/f132b2524028ed324cc38cdd45920b76883135e4) (controller) - api: validate app name against k8s service regex (#1163)
+- [`9098331`](https://github.com/deis/controller/commit/9098331900f1dda36ba4f858b4bbbc1719933979) (controller) - perms: Use the same regex for perms as auth endpoint (#1181)
+- [`30ab1d3`](https://github.com/deis/controller/commit/30ab1d3b338374277d1ccc6324ceb4738e9af6c6) (controller) - settings: disable LDAP by default (#1191)
+- [`4c36791`](https://github.com/deis/controller/commit/4c36791fe0829b48b7aeebe422f05e46d4e06df3) (controller) - management: display error when connecting to the database (#1190)
+- [`78ad61f`](https://github.com/deis/fluentd/commit/78ad61f7bd22450e820d6c34b56c31cd07d76c31) (fluentd) - logger: show error message and backtrace
+- [`107b2e1`](https://github.com/deis/fluentd/commit/107b2e14558be4c64e75f4debd153b921cff709f) (fluentd) - logger: utf-8 encoding
+- [`34da2e2`](https://github.com/deis/router/commit/34da2e281dcead217b11adfc56904c1fe3efac85) (router) - charts: enable hostports by default
+- [`4284483`](https://github.com/deis/workflow-cli/commit/4284483d69056333bff010d74093e259ff0442ac) (workflow-cli) - healthcheck: Parse arguments properly for httpheaders
+- [`958a3ab`](https://github.com/deis/workflow-cli/commit/958a3ab6bdfaf191f173d35ead96b08d698b4cf8) (workflow-cli) - Jenkinsfile: update downstream test job
+- [`2b7700d`](https://github.com/deis/workflow-cli/commit/2b7700dbe93aac847d827c2c19f4b8cdfc49ddff) (workflow-cli) - glide: update the controller sdk go version in the glide
+- [`388fd97`](https://github.com/deis/workflow-cli/commit/388fd9772ba9aa7fc7b7fe83f56fabb6e8ed1843) (workflow-cli) - Jenkinsfile: set git_branch to env.BRANCH_NAME
+- [`6d644a1`](https://github.com/deis/workflow-e2e/commit/6d644a120fa819c746c6bd832039a04c8ed3badd) (workflow-e2e) - docker-test-integration.sh: explicit DEBUG_MODE check
+- [`f81df33`](https://github.com/deis/workflow-e2e/commit/f81df33de3570907a90bc3538235fb8f6faf9f38) (workflow-e2e) - chart: s/ginko/ginkgo
+- [`a686dfd`](https://github.com/deis/workflow/commit/a686dfd32141edb90dcd32ca07536c55b21bc6ba) (workflow) - values: redis params are in the redis chart
+- [`b3a9db1`](https://github.com/deis/workflow/commit/b3a9db14c41caae331d53ef5dd553d856ccbb271) (workflow) - upgrade: Use a random generated name for upgrade job so it be upgraded multiple times using helm
+- [`5b7b98d`](https://github.com/deis/workflow/commit/5b7b98ddb85fa621fd7ab1c852907991a2f3faa5) (workflow) - releases: remove reference to deis/charts in release notes
+- [`233b630`](https://github.com/deis/workflow/commit/233b630cb4b3e6f658c3d7b530ca67434e6baaed) (workflow) - managing-workflow: update logging and monitoring docs to reflect helm v2
+- [`6989718`](https://github.com/deis/workflow/commit/698971858c98ea25b3bf17ee8e932f1df47004dc) (workflow) - charts: enable hostports by default
+- [`2a96baf`](https://github.com/deis/workflow/commit/2a96bafeaf2507d368c3785fea5ce5054a6af840) (workflow) - upgrading-workflow: fix helm upgrade usage
 
 #### Documentation
 
-- [`ee93ec4`](https://github.com/deisthree/controller/commit/ee93ec49c5e93f0a7237b0ffa717ffc2aca8487d) (controller) - README.md: update badge to use deis-bot's account
-- [`b4a86c8`](https://github.com/deisthree/controller/commit/b4a86c84d3a0ef8e5008758bd2552e46d75b18e8) (controller) - README: remove helmc mention
-- [`1e90453`](https://github.com/deisthree/registry-token-refresher/commit/1e904537f96b01ae2f9adfa37909478e1138abcf) (registry-token-refresher) - update key_json value
-- [`29492e5`](https://github.com/deisthree/workflow/commit/29492e5336ea956175e225051ea604bcffaaaffa) (workflow) - managing-workflow: Add docs about resource quota for application namespace
-- [`c9539d0`](https://github.com/deisthree/workflow/commit/c9539d0a23c80ee76150bdb14384b32652dd6bb2) (workflow) - src/roadmap/releases.md: update to use k/helm
-- [`48b875e`](https://github.com/deisthree/workflow/commit/48b875e0bdef8f008e4dd09f18e58a43bce4be19) (workflow) - gke/boot: Update command to auth to kubernetes host
-- [`3c6cb1c`](https://github.com/deisthree/workflow/commit/3c6cb1c3fe44a950d64204e2c3604f546d15f230) (workflow) - azure-acs: style and typo fixes
-- [`42f99cf`](https://github.com/deisthree/workflow/commit/42f99cf1c8b54fa49ed52eee69ab9d9fc976b718) (workflow) - managing-workflow: Add LDAP configuration
-- [`3773830`](https://github.com/deisthree/workflow/commit/377383088735dda38d48bc959a6e3b2edaed7760) (workflow) - releases.md: update to reference workflow-chart-stage job
-- [`6fa3f37`](https://github.com/deisthree/workflow/commit/6fa3f375d289ec120d3fe4601e73316777aeae85) (workflow) - system-requirements: add warning for k8s 1.5
-- [`057cbe6`](https://github.com/deisthree/workflow/commit/057cbe60924f0a3407ab174082be538d7cc9aecb) (workflow) - azure-acs: more info and spell fixes
-- [`5bbc137`](https://github.com/deisthree/workflow/commit/5bbc1372c950a98ce0b7709e85e620f5f78453ed) (workflow) - installing-workflow: deprecate support for v1.2 clusters
-- [`c5d4d46`](https://github.com/deisthree/workflow/commit/c5d4d46d909fddffa921b4a0bd4bab03f48d44fe) (workflow) - update versions to v2.9.1 and add changelog
-- [`0a8e44e`](https://github.com/deisthree/workflow/commit/0a8e44e46245acd08513e768593075c144cd0007) (workflow) - remove need for echo after helm fetch verify; update sha256
-- [`0cc5dfb`](https://github.com/deisthree/workflow/commit/0cc5dfb584d43bba9691939abfd9b5e4608a32eb) (workflow) - releases.md: add patch release notes
-- [`f16816e`](https://github.com/deisthree/workflow/commit/f16816ec9e4d55b9a0307ef549bc1ff596063b6c) (workflow) - README.md: add temporary holiday notice
-- [`3406eac`](https://github.com/deisthree/workflow/commit/3406eaccbd1b1164405a37fd0913577734842ee5) (workflow) - applications: fix broken links for SSH keys
-- [`70f50a5`](https://github.com/deisthree/workflow/commit/70f50a58de214285e01288244de2109d00d41079) (workflow) - add upgrade note for gcs/gcr
-- [`5f6dd73`](https://github.com/deisthree/workflow/commit/5f6dd73770b11deee5c1a2cf15fcb9573bcc2ff1) (workflow) - upgrading-workflow: add note about using single quotes around base64 encoded string
+- [`ee93ec4`](https://github.com/deis/controller/commit/ee93ec49c5e93f0a7237b0ffa717ffc2aca8487d) (controller) - README.md: update badge to use deis-bot's account
+- [`b4a86c8`](https://github.com/deis/controller/commit/b4a86c84d3a0ef8e5008758bd2552e46d75b18e8) (controller) - README: remove helmc mention
+- [`1e90453`](https://github.com/deis/registry-token-refresher/commit/1e904537f96b01ae2f9adfa37909478e1138abcf) (registry-token-refresher) - update key_json value
+- [`29492e5`](https://github.com/deis/workflow/commit/29492e5336ea956175e225051ea604bcffaaaffa) (workflow) - managing-workflow: Add docs about resource quota for application namespace
+- [`c9539d0`](https://github.com/deis/workflow/commit/c9539d0a23c80ee76150bdb14384b32652dd6bb2) (workflow) - src/roadmap/releases.md: update to use k/helm
+- [`48b875e`](https://github.com/deis/workflow/commit/48b875e0bdef8f008e4dd09f18e58a43bce4be19) (workflow) - gke/boot: Update command to auth to kubernetes host
+- [`3c6cb1c`](https://github.com/deis/workflow/commit/3c6cb1c3fe44a950d64204e2c3604f546d15f230) (workflow) - azure-acs: style and typo fixes
+- [`42f99cf`](https://github.com/deis/workflow/commit/42f99cf1c8b54fa49ed52eee69ab9d9fc976b718) (workflow) - managing-workflow: Add LDAP configuration
+- [`3773830`](https://github.com/deis/workflow/commit/377383088735dda38d48bc959a6e3b2edaed7760) (workflow) - releases.md: update to reference workflow-chart-stage job
+- [`6fa3f37`](https://github.com/deis/workflow/commit/6fa3f375d289ec120d3fe4601e73316777aeae85) (workflow) - system-requirements: add warning for k8s 1.5
+- [`057cbe6`](https://github.com/deis/workflow/commit/057cbe60924f0a3407ab174082be538d7cc9aecb) (workflow) - azure-acs: more info and spell fixes
+- [`5bbc137`](https://github.com/deis/workflow/commit/5bbc1372c950a98ce0b7709e85e620f5f78453ed) (workflow) - installing-workflow: deprecate support for v1.2 clusters
+- [`c5d4d46`](https://github.com/deis/workflow/commit/c5d4d46d909fddffa921b4a0bd4bab03f48d44fe) (workflow) - update versions to v2.9.1 and add changelog
+- [`0a8e44e`](https://github.com/deis/workflow/commit/0a8e44e46245acd08513e768593075c144cd0007) (workflow) - remove need for echo after helm fetch verify; update sha256
+- [`0cc5dfb`](https://github.com/deis/workflow/commit/0cc5dfb584d43bba9691939abfd9b5e4608a32eb) (workflow) - releases.md: add patch release notes
+- [`f16816e`](https://github.com/deis/workflow/commit/f16816ec9e4d55b9a0307ef549bc1ff596063b6c) (workflow) - README.md: add temporary holiday notice
+- [`3406eac`](https://github.com/deis/workflow/commit/3406eaccbd1b1164405a37fd0913577734842ee5) (workflow) - applications: fix broken links for SSH keys
+- [`70f50a5`](https://github.com/deis/workflow/commit/70f50a58de214285e01288244de2109d00d41079) (workflow) - add upgrade note for gcs/gcr
+- [`5f6dd73`](https://github.com/deis/workflow/commit/5f6dd73770b11deee5c1a2cf15fcb9573bcc2ff1) (workflow) - upgrading-workflow: add note about using single quotes around base64 encoded string
 
 #### Maintenance
 
-- [`22288eb`](https://github.com/deisthree/controller/commit/22288eb1f861975beb319fbf2365c765569705fa) (controller) - requirements: update requests lib to 2.12.3
-- [`f3d71c0`](https://github.com/deisthree/controller/commit/f3d71c0bc9bbadbf86585d3218053758f9fbf313) (controller) - requirements: update Django to 1.10.4
-- [`cfc08d6`](https://github.com/deisthree/controller/commit/cfc08d6b1d25b2bfbd78bb040ccd169d97161aae) (controller) - dev_requirements: upgrade flake8 to 3.2.1
-- [`f3d9c1b`](https://github.com/deisthree/controller/commit/f3d9c1b05cc0b6ff22f726fb17795b2f728b4431) (controller) - requirements: update pytz to 2016.10
-- [`6d13723`](https://github.com/deisthree/controller/commit/6d1372394bb3cf648444c0e0173e0e63e5e25984) (controller) - Makefile: remove pyvenv script (#1161)
-- [`0566131`](https://github.com/deisthree/controller/commit/05661317fc185b0a6c647a6766588ab7ee959470) (controller) - dev_requirements: update coverage to 4.3.1
-- [`b3056f0`](https://github.com/deisthree/controller/commit/b3056f0478f8a76c17e85472aa0a3e9fd45d93bb) (controller) - requirements: update requests to 2.12.4
-- [`f478ee9`](https://github.com/deisthree/controller/commit/f478ee981d8136c607b71e6ed318c0d3c1d97530) (controller) - requirements: update idna to 2.2
-- [`b6d19d5`](https://github.com/deisthree/logger/commit/b6d19d5a0f64297691a6c054c3fafb84c9455fec) (logger) - manifests: remove manifests
-- [`50307cc`](https://github.com/deisthree/logger/commit/50307cc40d644f8d7566b6cd0b80d440873774b7) (logger) - glide: update envconfig
-- [`a0e22a7`](https://github.com/deisthree/router/commit/a0e22a7a25af62fa8b757147d0b798802390342c) (router) - nginx: update nginx to 1.11.7
-- [`8622f48`](https://github.com/deisthree/router/commit/8622f486b2bf396513962e2a9fe20147db3ea71c) (router) - nginx: update nginx to 1.11.8
-- [`0fd3251`](https://github.com/deisthree/workflow-cli/commit/0fd325103d1c797ca623523fd2149fb3a8fc7d3d) (workflow-cli) Dockerfile: update go-dev to v0.21.0
-- [`62c2e65`](https://github.com/deisthree/workflow-cli/commit/62c2e657581adf4be0ced87afa9c74184362f3fd) (workflow-cli) glide: bump controller-sdk-go to 50747d7
-- [`bf269d2`](https://github.com/deisthree/workflow/commit/bf269d2abc65b2d537f792029f490deedc8e3077) (workflow) azure: add Azure section to sidebar
-- [`a4a589e`](https://github.com/deisthree/workflow/commit/a4a589e64cbff86e8c8d446edca82c92b3cb27c2) (workflow) docs: add images for ui steps
-- [`bf61fd6`](https://github.com/deisthree/workflow/commit/bf61fd662604c47b6ed1c9f308976dec6b78a429) (workflow) docs: flesh out steps for azure acs through UI
-- [`ddfe3a0`](https://github.com/deisthree/workflow/commit/ddfe3a0de06b0976f74353e65bf861237d4d0145) (workflow) chart: update values file description
-- [`1fb84dc`](https://github.com/deisthree/workflow/commit/1fb84dc4a95737ceb9e7f4f1ced22aaac84fc298) (workflow) controller: disable tls verification on acs
+- [`22288eb`](https://github.com/deis/controller/commit/22288eb1f861975beb319fbf2365c765569705fa) (controller) - requirements: update requests lib to 2.12.3
+- [`f3d71c0`](https://github.com/deis/controller/commit/f3d71c0bc9bbadbf86585d3218053758f9fbf313) (controller) - requirements: update Django to 1.10.4
+- [`cfc08d6`](https://github.com/deis/controller/commit/cfc08d6b1d25b2bfbd78bb040ccd169d97161aae) (controller) - dev_requirements: upgrade flake8 to 3.2.1
+- [`f3d9c1b`](https://github.com/deis/controller/commit/f3d9c1b05cc0b6ff22f726fb17795b2f728b4431) (controller) - requirements: update pytz to 2016.10
+- [`6d13723`](https://github.com/deis/controller/commit/6d1372394bb3cf648444c0e0173e0e63e5e25984) (controller) - Makefile: remove pyvenv script (#1161)
+- [`0566131`](https://github.com/deis/controller/commit/05661317fc185b0a6c647a6766588ab7ee959470) (controller) - dev_requirements: update coverage to 4.3.1
+- [`b3056f0`](https://github.com/deis/controller/commit/b3056f0478f8a76c17e85472aa0a3e9fd45d93bb) (controller) - requirements: update requests to 2.12.4
+- [`f478ee9`](https://github.com/deis/controller/commit/f478ee981d8136c607b71e6ed318c0d3c1d97530) (controller) - requirements: update idna to 2.2
+- [`b6d19d5`](https://github.com/deis/logger/commit/b6d19d5a0f64297691a6c054c3fafb84c9455fec) (logger) - manifests: remove manifests
+- [`50307cc`](https://github.com/deis/logger/commit/50307cc40d644f8d7566b6cd0b80d440873774b7) (logger) - glide: update envconfig
+- [`a0e22a7`](https://github.com/deis/router/commit/a0e22a7a25af62fa8b757147d0b798802390342c) (router) - nginx: update nginx to 1.11.7
+- [`8622f48`](https://github.com/deis/router/commit/8622f486b2bf396513962e2a9fe20147db3ea71c) (router) - nginx: update nginx to 1.11.8
+- [`0fd3251`](https://github.com/deis/workflow-cli/commit/0fd325103d1c797ca623523fd2149fb3a8fc7d3d) (workflow-cli) Dockerfile: update go-dev to v0.21.0
+- [`62c2e65`](https://github.com/deis/workflow-cli/commit/62c2e657581adf4be0ced87afa9c74184362f3fd) (workflow-cli) glide: bump controller-sdk-go to 50747d7
+- [`bf269d2`](https://github.com/deis/workflow/commit/bf269d2abc65b2d537f792029f490deedc8e3077) (workflow) azure: add Azure section to sidebar
+- [`a4a589e`](https://github.com/deis/workflow/commit/a4a589e64cbff86e8c8d446edca82c92b3cb27c2) (workflow) docs: add images for ui steps
+- [`bf61fd6`](https://github.com/deis/workflow/commit/bf61fd662604c47b6ed1c9f308976dec6b78a429) (workflow) docs: flesh out steps for azure acs through UI
+- [`ddfe3a0`](https://github.com/deis/workflow/commit/ddfe3a0de06b0976f74353e65bf861237d4d0145) (workflow) chart: update values file description
+- [`1fb84dc`](https://github.com/deis/workflow/commit/1fb84dc4a95737ceb9e7f4f1ced22aaac84fc298) (workflow) controller: disable tls verification on acs

--- a/src/changelogs/v2.11.0.md
+++ b/src/changelogs/v2.11.0.md
@@ -23,110 +23,110 @@
 
 #### Features
 
-- [`bd97e3e`](https://github.com/deisthree/builder/commit/bd97e3e15ff406989d6c97d1d572b1206787b9a2) (builder) - cleaner: delete from object store
-- [`fcc5bb0`](https://github.com/deisthree/builder/commit/fcc5bb0666adf892c12f17d2ae4a66f5abe45869) (builder) - Makefile: set docker build flags via environment variable
-- [`ae03152`](https://github.com/deisthree/controller/commit/ae03152028aee5bb181c20a2ed58dff215ba2812) (controller) - settings: Get timezone from environment variable (#1196)
-- [`48cd872`](https://github.com/deisthree/controller/commit/48cd87272e85a4e5d7fb75b30636ce38d67183a8) (controller) - Makefile: set docker build flags via environment variable
-- [`003e8dd`](https://github.com/deisthree/dockerbuilder/commit/003e8dd9c1f71c8cbe5a30c70955c356c80b4c3b) (dockerbuilder) - Makefile: set docker build flags via environment variable
-- [`a1e28c8`](https://github.com/deisthree/fluentd/commit/a1e28c86e1719f2112f9157574bf021c31218535) (fluentd) - Makefile: set docker build flags via environment variable
-- [`8ce9845`](https://github.com/deisthree/logger/commit/8ce9845701e62d000a95174417f325df3e7107d9) (logger) - Makefile: set docker build flags via environment variable
-- [`b2fc347`](https://github.com/deisthree/minio/commit/b2fc347315860b2da8d13f6e405c8b65bdb252ea) (minio) - Makefile: set docker build flags via environment variable
-- [`bfdf091`](https://github.com/deisthree/monitor/commit/bfdf091c3768ab4dfd2bdae2360c81280d7b466e) (monitor) - charts: add optional persistence storage to influxdb and grafana
-- [`138fb11`](https://github.com/deisthree/monitor/commit/138fb11af703f410c9861c0f048ee5fec803a12f) (monitor) - charts: add optional persistence storage to influxdb and grafana
-- [`c58fde6`](https://github.com/deisthree/monitor/commit/c58fde69e32fcd118862e927527c565b2c8e8a9c) (monitor) - Makefile: set docker build flags via environment variable
-- [`b32fe54`](https://github.com/deisthree/nsq/commit/b32fe54dcbc19a5ecfe38616f58494facbea67e0) (nsq) - Makefile: set docker build flags via environment variable
-- [`524fdf5`](https://github.com/deisthree/postgres/commit/524fdf51282ca688201db61e01e818cfcb9d89eb) (postgres) - Makefile: set docker build flags via environment variable
-- [`0cf0deb`](https://github.com/deisthree/redis/commit/0cf0debb6f891a2d8f5ca4197106b235a7c6712b) (redis) - Makefile: set docker build flags via environment variable
-- [`4f46069`](https://github.com/deisthree/registry/commit/4f46069113c8093b03c56bfbe1fd6dae701fe726) (registry) - Makefile: set docker build flags via environment variable
-- [`faf2eb2`](https://github.com/deisthree/registry-token-refresher/commit/faf2eb211b42f98fd1a5936af573b7870ab65fcc) (registry-token-refresher) - Makefile: set docker build flags via environment variable
-- [`4ca3a74`](https://github.com/deisthree/router/commit/4ca3a7411e4ddcacde3759c3be7a543e2f269818) (router) - router: make default app configurable
-- [`5dba76c`](https://github.com/deisthree/router/commit/5dba76ca8c8d8201291dd3a5231fcd08875561b8) (router) - router: make server_token flag configurable
-- [`cf87e27`](https://github.com/deisthree/router/commit/cf87e2700ebfc1cacc8b332026e6b5a5bc572bdb) (router) - Makefile: set docker build flags via environment variable
-- [`30d2caa`](https://github.com/deisthree/slugbuilder/commit/30d2caa540ae9658e6ca0bb97ffd66abe509afcd) (slugbuilder) - Makefile: set docker build flags via environment variable
-- [`3ef0a86`](https://github.com/deisthree/workflow/commit/3ef0a8615ad77f407f7b275644e42e07c597a38d) (workflow) Makefile: set docker build flags via environment variable
-- [`6307677`](https://github.com/deisthree/workflow/commit/630767794f1b4254e7f3c46b103ab3bb77420133) (workflow) charts: add optional persistence storage to influxdb and grafana (#699)
-- [`9b09080`](https://github.com/deisthree/workflow-manager/commit/9b09080ce7ba6991362c33bf55d58a6753131706) (workflow-manager) - Makefile: set docker build flags via environment variable
-- [`cc60fa0`](https://github.com/deisthree/workflow-cli/commit/cc60fa059aa3e7a61bc3d68a0aea5e2bd01c531f) (workflow-cli) Makefile: set docker build flags via environment variable
-- [`70797cb`](https://github.com/deisthree/workflow-e2e/commit/70797cbdb76251ccbefc052820f81e52eaa7765f) (workflow-e2e) limits-cmd: accept new limits:set value type
+- [`bd97e3e`](https://github.com/deis/builder/commit/bd97e3e15ff406989d6c97d1d572b1206787b9a2) (builder) - cleaner: delete from object store
+- [`fcc5bb0`](https://github.com/deis/builder/commit/fcc5bb0666adf892c12f17d2ae4a66f5abe45869) (builder) - Makefile: set docker build flags via environment variable
+- [`ae03152`](https://github.com/deis/controller/commit/ae03152028aee5bb181c20a2ed58dff215ba2812) (controller) - settings: Get timezone from environment variable (#1196)
+- [`48cd872`](https://github.com/deis/controller/commit/48cd87272e85a4e5d7fb75b30636ce38d67183a8) (controller) - Makefile: set docker build flags via environment variable
+- [`003e8dd`](https://github.com/deis/dockerbuilder/commit/003e8dd9c1f71c8cbe5a30c70955c356c80b4c3b) (dockerbuilder) - Makefile: set docker build flags via environment variable
+- [`a1e28c8`](https://github.com/deis/fluentd/commit/a1e28c86e1719f2112f9157574bf021c31218535) (fluentd) - Makefile: set docker build flags via environment variable
+- [`8ce9845`](https://github.com/deis/logger/commit/8ce9845701e62d000a95174417f325df3e7107d9) (logger) - Makefile: set docker build flags via environment variable
+- [`b2fc347`](https://github.com/deis/minio/commit/b2fc347315860b2da8d13f6e405c8b65bdb252ea) (minio) - Makefile: set docker build flags via environment variable
+- [`bfdf091`](https://github.com/deis/monitor/commit/bfdf091c3768ab4dfd2bdae2360c81280d7b466e) (monitor) - charts: add optional persistence storage to influxdb and grafana
+- [`138fb11`](https://github.com/deis/monitor/commit/138fb11af703f410c9861c0f048ee5fec803a12f) (monitor) - charts: add optional persistence storage to influxdb and grafana
+- [`c58fde6`](https://github.com/deis/monitor/commit/c58fde69e32fcd118862e927527c565b2c8e8a9c) (monitor) - Makefile: set docker build flags via environment variable
+- [`b32fe54`](https://github.com/deis/nsq/commit/b32fe54dcbc19a5ecfe38616f58494facbea67e0) (nsq) - Makefile: set docker build flags via environment variable
+- [`524fdf5`](https://github.com/deis/postgres/commit/524fdf51282ca688201db61e01e818cfcb9d89eb) (postgres) - Makefile: set docker build flags via environment variable
+- [`0cf0deb`](https://github.com/deis/redis/commit/0cf0debb6f891a2d8f5ca4197106b235a7c6712b) (redis) - Makefile: set docker build flags via environment variable
+- [`4f46069`](https://github.com/deis/registry/commit/4f46069113c8093b03c56bfbe1fd6dae701fe726) (registry) - Makefile: set docker build flags via environment variable
+- [`faf2eb2`](https://github.com/deis/registry-token-refresher/commit/faf2eb211b42f98fd1a5936af573b7870ab65fcc) (registry-token-refresher) - Makefile: set docker build flags via environment variable
+- [`4ca3a74`](https://github.com/deis/router/commit/4ca3a7411e4ddcacde3759c3be7a543e2f269818) (router) - router: make default app configurable
+- [`5dba76c`](https://github.com/deis/router/commit/5dba76ca8c8d8201291dd3a5231fcd08875561b8) (router) - router: make server_token flag configurable
+- [`cf87e27`](https://github.com/deis/router/commit/cf87e2700ebfc1cacc8b332026e6b5a5bc572bdb) (router) - Makefile: set docker build flags via environment variable
+- [`30d2caa`](https://github.com/deis/slugbuilder/commit/30d2caa540ae9658e6ca0bb97ffd66abe509afcd) (slugbuilder) - Makefile: set docker build flags via environment variable
+- [`3ef0a86`](https://github.com/deis/workflow/commit/3ef0a8615ad77f407f7b275644e42e07c597a38d) (workflow) Makefile: set docker build flags via environment variable
+- [`6307677`](https://github.com/deis/workflow/commit/630767794f1b4254e7f3c46b103ab3bb77420133) (workflow) charts: add optional persistence storage to influxdb and grafana (#699)
+- [`9b09080`](https://github.com/deis/workflow-manager/commit/9b09080ce7ba6991362c33bf55d58a6753131706) (workflow-manager) - Makefile: set docker build flags via environment variable
+- [`cc60fa0`](https://github.com/deis/workflow-cli/commit/cc60fa059aa3e7a61bc3d68a0aea5e2bd01c531f) (workflow-cli) Makefile: set docker build flags via environment variable
+- [`70797cb`](https://github.com/deis/workflow-e2e/commit/70797cbdb76251ccbefc052820f81e52eaa7765f) (workflow-e2e) limits-cmd: accept new limits:set value type
 
 #### Refactors
 
-- [`7bb769f`](https://github.com/deisthree/dockerbuilder/commit/7bb769f48a09c01f081ca79123be0526ecde7de3) (dockerbuilder) - deploy.py: placate new flake8 linter checks
-- [`88f7007`](https://github.com/deisthree/workflow/commit/88f7007c8f547946dfe6e5bc64ad93bab3a226a3) (workflow) upgrading-workflow: use -w 0 flag when base64 encoding
-- [`3e65eba`](https://github.com/deisthree/workflow/commit/3e65ebadbbbaf64eeed35c9e4c68bf145a555382) (workflow) quickstart: use markdown-include to de-duplicate quickstart info
+- [`7bb769f`](https://github.com/deis/dockerbuilder/commit/7bb769f48a09c01f081ca79123be0526ecde7de3) (dockerbuilder) - deploy.py: placate new flake8 linter checks
+- [`88f7007`](https://github.com/deis/workflow/commit/88f7007c8f547946dfe6e5bc64ad93bab3a226a3) (workflow) upgrading-workflow: use -w 0 flag when base64 encoding
+- [`3e65eba`](https://github.com/deis/workflow/commit/3e65ebadbbbaf64eeed35c9e4c68bf145a555382) (workflow) quickstart: use markdown-include to de-duplicate quickstart info
 
 #### Fixes
 
-- [`634bfe9`](https://github.com/deisthree/builder/commit/634bfe9409c8a8ac4060e25ce16cc4a1e374509d) (builder) - charts: reference registry-proxy on 127.0.0.1
-- [`84b6342`](https://github.com/deisthree/controller/commit/84b63426e4331ffba39cf16f75b135b43393cde4) (controller) - charts: pipeline time_zone value to quote func
-- [`3f860bf`](https://github.com/deisthree/controller/commit/3f860bfca316ecfa0de0b5318114c883bdceaf16) (controller) - Dockerfile: force gunzip of copyright archive
-- [`e8f0284`](https://github.com/deisthree/controller/commit/e8f0284da2c190d9b75d6d5ffbca0ae669f7e008) (controller) - Makefile: build docker image with --no-cache by default
-- [`bdb5acd`](https://github.com/deisthree/controller/commit/bdb5acdfb9dde926ca57b2c8c3be9df742b2e038) (controller) - api: add certificate private key validator migration (#1199)
-- [`da408b3`](https://github.com/deisthree/controller/commit/da408b3fb94c5af5f559a18746208d411d1a6aa1) (controller) - charts: reference registry-proxy on 127.0.0.1 (#1239)
-- [`f14a6db`](https://github.com/deisthree/dockerbuilder/commit/f14a6db42b436aee01abf328fac65472476b9dd1) (dockerbuilder) - Dockerfile: fix gunzip -f
-- [`c9f6e01`](https://github.com/deisthree/postgres/commit/c9f6e01574dfca47f9827ada5972739a4dc6487c) (postgres) - 001_setup_envdir.sh: inspect actual var instead of literal string
-- [`5aafbac`](https://github.com/deisthree/registry/commit/5aafbac11dd1e345dca8836df802b33f6518a3c3) (registry) - create-bucket: set BUCKET_NAME for swift
-- [`96f0c61`](https://github.com/deisthree/router/commit/96f0c6172ff9570fd2dc5259ad23a2201a7e457a) (router) - charts: remove deployment and service annotations
-- [`6d0d344`](https://github.com/deisthree/slugbuilder/commit/6d0d3448b6b02612e64f680cff83233ed7cbf940) (slugbuilder) - download_buildpack: define name of buildpack
-- [`2817dbc`](https://github.com/deisthree/workflow/commit/2817dbc8f5d98efb97ea7a54b51314c8fc8e923c) (workflow) azure: use regular storage instead of premium
-- [`8691955`](https://github.com/deisthree/workflow/commit/8691955c044f3ad2fab3a5db907b2ebd5146f16c) (workflow) azure/quickstart: fix Azure link in the menu
-- [`0d647e5`](https://github.com/deisthree/workflow/commit/0d647e516764ef9dae4f61897f24dbcc58b50d25) (workflow) applications: fixup --headers usage
-- [`e6c9e23`](https://github.com/deisthree/workflow/commit/e6c9e23923b3594819cea370c97b10ef187620a6) (workflow) tuning-component-settings: move LDAP settings under Controller
+- [`634bfe9`](https://github.com/deis/builder/commit/634bfe9409c8a8ac4060e25ce16cc4a1e374509d) (builder) - charts: reference registry-proxy on 127.0.0.1
+- [`84b6342`](https://github.com/deis/controller/commit/84b63426e4331ffba39cf16f75b135b43393cde4) (controller) - charts: pipeline time_zone value to quote func
+- [`3f860bf`](https://github.com/deis/controller/commit/3f860bfca316ecfa0de0b5318114c883bdceaf16) (controller) - Dockerfile: force gunzip of copyright archive
+- [`e8f0284`](https://github.com/deis/controller/commit/e8f0284da2c190d9b75d6d5ffbca0ae669f7e008) (controller) - Makefile: build docker image with --no-cache by default
+- [`bdb5acd`](https://github.com/deis/controller/commit/bdb5acdfb9dde926ca57b2c8c3be9df742b2e038) (controller) - api: add certificate private key validator migration (#1199)
+- [`da408b3`](https://github.com/deis/controller/commit/da408b3fb94c5af5f559a18746208d411d1a6aa1) (controller) - charts: reference registry-proxy on 127.0.0.1 (#1239)
+- [`f14a6db`](https://github.com/deis/dockerbuilder/commit/f14a6db42b436aee01abf328fac65472476b9dd1) (dockerbuilder) - Dockerfile: fix gunzip -f
+- [`c9f6e01`](https://github.com/deis/postgres/commit/c9f6e01574dfca47f9827ada5972739a4dc6487c) (postgres) - 001_setup_envdir.sh: inspect actual var instead of literal string
+- [`5aafbac`](https://github.com/deis/registry/commit/5aafbac11dd1e345dca8836df802b33f6518a3c3) (registry) - create-bucket: set BUCKET_NAME for swift
+- [`96f0c61`](https://github.com/deis/router/commit/96f0c6172ff9570fd2dc5259ad23a2201a7e457a) (router) - charts: remove deployment and service annotations
+- [`6d0d344`](https://github.com/deis/slugbuilder/commit/6d0d3448b6b02612e64f680cff83233ed7cbf940) (slugbuilder) - download_buildpack: define name of buildpack
+- [`2817dbc`](https://github.com/deis/workflow/commit/2817dbc8f5d98efb97ea7a54b51314c8fc8e923c) (workflow) azure: use regular storage instead of premium
+- [`8691955`](https://github.com/deis/workflow/commit/8691955c044f3ad2fab3a5db907b2ebd5146f16c) (workflow) azure/quickstart: fix Azure link in the menu
+- [`0d647e5`](https://github.com/deis/workflow/commit/0d647e516764ef9dae4f61897f24dbcc58b50d25) (workflow) applications: fixup --headers usage
+- [`e6c9e23`](https://github.com/deis/workflow/commit/e6c9e23923b3594819cea370c97b10ef187620a6) (workflow) tuning-component-settings: move LDAP settings under Controller
 
 #### Documentation
 
-- [`6cbd175`](https://github.com/deisthree/builder/commit/6cbd175b4052a419577fc23a81d157b3560a96d9) (builder) - *: Fix typo in README.md
-- [`7911fac`](https://github.com/deisthree/builder/commit/7911face08f89032a664246f914bdd3a8570e9ec) (builder) - *: update main README.md
-- [`51879b2`](https://github.com/deisthree/controller/commit/51879b2913151cf3d11fb90bdd42da9702bd30cc) (controller) - README: specify correct python version
-- [`1345f2c`](https://github.com/deisthree/controller/commit/1345f2cafa69886cd2bfcc463d29cec3aac025a7) (controller) - README: update database usage in tests (#1233)
-- [`64eeff1`](https://github.com/deisthree/logger/commit/64eeff17a8684d4caf10f528a89a5f7dae9d87a7) (logger) - README.md: update Deis Workflow reference
-- [`9bcbcfd`](https://github.com/deisthree/monitor/commit/9bcbcfd780a506dc655b370e6953c3c8212cef5f) (monitor) - README.md: update Deis Workflow reference
-- [`963c100`](https://github.com/deisthree/nsq/commit/963c1003910f659b49675ce1bb26948c269019cf) (nsq) - README.md: update Deis Workflow reference
-- [`d9882fa`](https://github.com/deisthree/redis/commit/d9882fac0b33c95987ca78727aa71beadde2e3a9) (redis) - README.md: update Deis Workflow reference
-- [`9293f37`](https://github.com/deisthree/workflow-cli/commit/9293f37a5551defb9f2775b47fdb6eae1bda1c24) (workflow-cli) README: add latest stable release URL
-- [`16034cc`](https://github.com/deisthree/workflow/commit/16034cc94930b98be97ef1eb3456ee7681574608) (workflow) releases: omit obsolete requirement for a charts PR
-- [`c61eedb`](https://github.com/deisthree/workflow/commit/c61eedb184fab6b4f071fc27c307670675430db5) (workflow) releases: move workflow docs release after changelog PR
-- [`d430e42`](https://github.com/deisthree/workflow/commit/d430e42a089e923dc9afa6f39050d37e81330fe3) (workflow) azure: streamline azure boot process
-- [`a71c0da`](https://github.com/deisthree/workflow/commit/a71c0da9befc24a1dd267350c974d32317ec5c78) (workflow) installing-workflow: no periods in S3 bucket names
-- [`7cc8b2f`](https://github.com/deisthree/workflow/commit/7cc8b2f4c93469d8dbda7739196950360460dfd5) (workflow) production-deployments: recommend disabling grafana signups
-- [`a5f92eb`](https://github.com/deisthree/workflow/commit/a5f92ebbbe04761520659b36d572187ead5bbd97) (workflow) monitoring: document grafana and influxdb persistence (#713)
-- [`c0410c6`](https://github.com/deisthree/workflow/commit/c0410c66c93ff78d3e36a35025b362d5e6261b70) (workflow) components: document the monitoring stack
-- [`4eea426`](https://github.com/deisthree/workflow/commit/4eea4265c4345aaf0594193dfd0c243b947356bf) (workflow) Azure: remove service principal steps
-- [`c65fae6`](https://github.com/deisthree/workflow/commit/c65fae60895f7d286a3a8a4ff73fc81aa716a677) (workflow) Azure: note for kubernetes get-credentials
-- [`a5d71e2`](https://github.com/deisthree/workflow/commit/a5d71e2ddfd377c71e18e9fe5e4e198a3c398366) (workflow) Azure: Fix storage key and add note
-- [`cccde15`](https://github.com/deisthree/workflow/commit/cccde1538f37dd96b2166f456a64f01c51785e7f) (workflow) api/v2.3: add TLS API examples and index v2.3 API
-- [`5a37885`](https://github.com/deisthree/workflow/commit/5a3788539d3ee5dc32d7fb7189b28b5a19b82417) (workflow) managing-workflow: Add scaling the routers to the production deployment notes.
-- [`c0285ed`](https://github.com/deisthree/workflow/commit/c0285ed9edf6990161a9321159252a5d2318da22) (workflow) aws: update for latest k8s version available
+- [`6cbd175`](https://github.com/deis/builder/commit/6cbd175b4052a419577fc23a81d157b3560a96d9) (builder) - *: Fix typo in README.md
+- [`7911fac`](https://github.com/deis/builder/commit/7911face08f89032a664246f914bdd3a8570e9ec) (builder) - *: update main README.md
+- [`51879b2`](https://github.com/deis/controller/commit/51879b2913151cf3d11fb90bdd42da9702bd30cc) (controller) - README: specify correct python version
+- [`1345f2c`](https://github.com/deis/controller/commit/1345f2cafa69886cd2bfcc463d29cec3aac025a7) (controller) - README: update database usage in tests (#1233)
+- [`64eeff1`](https://github.com/deis/logger/commit/64eeff17a8684d4caf10f528a89a5f7dae9d87a7) (logger) - README.md: update Deis Workflow reference
+- [`9bcbcfd`](https://github.com/deis/monitor/commit/9bcbcfd780a506dc655b370e6953c3c8212cef5f) (monitor) - README.md: update Deis Workflow reference
+- [`963c100`](https://github.com/deis/nsq/commit/963c1003910f659b49675ce1bb26948c269019cf) (nsq) - README.md: update Deis Workflow reference
+- [`d9882fa`](https://github.com/deis/redis/commit/d9882fac0b33c95987ca78727aa71beadde2e3a9) (redis) - README.md: update Deis Workflow reference
+- [`9293f37`](https://github.com/deis/workflow-cli/commit/9293f37a5551defb9f2775b47fdb6eae1bda1c24) (workflow-cli) README: add latest stable release URL
+- [`16034cc`](https://github.com/deis/workflow/commit/16034cc94930b98be97ef1eb3456ee7681574608) (workflow) releases: omit obsolete requirement for a charts PR
+- [`c61eedb`](https://github.com/deis/workflow/commit/c61eedb184fab6b4f071fc27c307670675430db5) (workflow) releases: move workflow docs release after changelog PR
+- [`d430e42`](https://github.com/deis/workflow/commit/d430e42a089e923dc9afa6f39050d37e81330fe3) (workflow) azure: streamline azure boot process
+- [`a71c0da`](https://github.com/deis/workflow/commit/a71c0da9befc24a1dd267350c974d32317ec5c78) (workflow) installing-workflow: no periods in S3 bucket names
+- [`7cc8b2f`](https://github.com/deis/workflow/commit/7cc8b2f4c93469d8dbda7739196950360460dfd5) (workflow) production-deployments: recommend disabling grafana signups
+- [`a5f92eb`](https://github.com/deis/workflow/commit/a5f92ebbbe04761520659b36d572187ead5bbd97) (workflow) monitoring: document grafana and influxdb persistence (#713)
+- [`c0410c6`](https://github.com/deis/workflow/commit/c0410c66c93ff78d3e36a35025b362d5e6261b70) (workflow) components: document the monitoring stack
+- [`4eea426`](https://github.com/deis/workflow/commit/4eea4265c4345aaf0594193dfd0c243b947356bf) (workflow) Azure: remove service principal steps
+- [`c65fae6`](https://github.com/deis/workflow/commit/c65fae60895f7d286a3a8a4ff73fc81aa716a677) (workflow) Azure: note for kubernetes get-credentials
+- [`a5d71e2`](https://github.com/deis/workflow/commit/a5d71e2ddfd377c71e18e9fe5e4e198a3c398366) (workflow) Azure: Fix storage key and add note
+- [`cccde15`](https://github.com/deis/workflow/commit/cccde1538f37dd96b2166f456a64f01c51785e7f) (workflow) api/v2.3: add TLS API examples and index v2.3 API
+- [`5a37885`](https://github.com/deis/workflow/commit/5a3788539d3ee5dc32d7fb7189b28b5a19b82417) (workflow) managing-workflow: Add scaling the routers to the production deployment notes.
+- [`c0285ed`](https://github.com/deis/workflow/commit/c0285ed9edf6990161a9321159252a5d2318da22) (workflow) aws: update for latest k8s version available
 
 #### Maintenance
 
-- [`0ed0404`](https://github.com/deisthree/builder/commit/0ed0404b928789d9bbf0278f9f13d688e7f3e11f) (builder) - Dockerfile: update deis/base to v0.3.6
-- [`d7f5ff0`](https://github.com/deisthree/builder/commit/d7f5ff03d6801826c2137ed7ad046b2a0ce016c6) (builder) - glide: bump golang.org/x/crypto to b822463
-- [`22106d2`](https://github.com/deisthree/controller/commit/22106d22694d8108125af6a63d70d9d84608303b) (controller) - requirements: update Django to 1.10.5
-- [`1c12587`](https://github.com/deisthree/controller/commit/1c125875280a80ed4faf052732b1f6ffb7da544e) (controller) - Dockerfile: update deis/base to v0.3.6 (#1197)
-- [`4e45ef5`](https://github.com/deisthree/controller/commit/4e45ef5866ff368de3ae7fb018ccf36de79dc376) (controller) - requirements: update requests to 2.12.5
-- [`9faa4b2`](https://github.com/deisthree/controller/commit/9faa4b22a34565b17db2c98e13823f15049b69c2) (controller) - dev_requirements: update coverage to 4.3.4
-- [`4b7db76`](https://github.com/deisthree/controller/commit/4b7db7670ea134b5716226a1a355d24751c46108) (controller) - requirements: update pyldap to 2.4.28
-- [`d6b188d`](https://github.com/deisthree/dockerbuilder/commit/d6b188d954bbef0ae6a296886596d533b006adf5) (dockerbuilder) - dev_requirements: upgrade flake8 to 3.2.1
-- [`82f77c3`](https://github.com/deisthree/dockerbuilder/commit/82f77c31963833f8d5624d4a69b0edef548fa4d1) (dockerbuilder) - Dockerfile: update deis/base to v0.3.6
-- [`40f647e`](https://github.com/deisthree/fluentd/commit/40f647e00b0437c276386f4dcfa11bb761b2686c) (fluentd) - Dockerfile: update deis/base to v0.3.6
-- [`f7afeb7`](https://github.com/deisthree/logger/commit/f7afeb7d15b2d7b2c1ab4331b1d2aa91d28e2d8e) (logger) - Dockerfile: update deis/base to v0.3.6
-- [`14342eb`](https://github.com/deisthree/minio/commit/14342eb74e910a67ec060998ad21ea1f0aa61e8e) (minio) - Dockerfile: update deis/base to v0.3.6
-- [`8969f32`](https://github.com/deisthree/monitor/commit/8969f3205d909dd06e171fec5f07a9b0e57ec357) (monitor) - Dockerfile: update Grafana to 4.0.2
-- [`acb12e7`](https://github.com/deisthree/monitor/commit/acb12e7490c52368978401a15030a8c8badb640f) (monitor) - Dockerfile: update deis/base to v0.3.6
-- [`ca8a140`](https://github.com/deisthree/monitor/commit/ca8a14030e93ae332f90b15a19244f3803f976b7) (monitor) - Dockerfile: update Influxdb to 1.1.1
-- [`287dd60`](https://github.com/deisthree/monitor/commit/287dd60d606b0f2ea5e93638f12d20a6a31e09ea) (monitor) - Dockerfile: update Influxdb to 1.1.1
-- [`7c3ca4b`](https://github.com/deisthree/nsq/commit/7c3ca4b4a67a308f27852f07747b9914322556c4) (nsq) - Dockerfile: update deis/base to v0.3.6
-- [`d04a77b`](https://github.com/deisthree/postgres/commit/d04a77b0addff9dfb48696b60ea969097be9974a) (postgres) - Dockerfile: update deis/base to v0.3.6
-- [`9f2e1b1`](https://github.com/deisthree/redis/commit/9f2e1b13f95726dc5b82c668ded32ee44af0c063) (redis) - Dockerfile: update deis/base to v0.3.6
-- [`bb6bba4`](https://github.com/deisthree/registry-token-refresher/commit/bb6bba4258a9dba4b8de2bcc1aebda4330061401) (registry-token-refresher) - Dockerfile: update deis/base to v0.3.6
-- [`dfb2cae`](https://github.com/deisthree/router/commit/dfb2caef93642e87b737dad0b27ddd71526104a3) (router) - Dockerfile: update deis/base to v0.3.6
-- [`7638ca7`](https://github.com/deisthree/slugbuilder/commit/7638ca7744b18fd9a83eccfb28e30595257d2495) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v93
-- [`ac0192f`](https://github.com/deisthree/slugbuilder/commit/ac0192fbbd7ecf6bf217239fa65a352648daf498) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v150
-- [`3f4ccc4`](https://github.com/deisthree/slugbuilder/commit/3f4ccc4128114a3984203c8773090046f3393375) (slugbuilder) - buildpacks: update heroku-buildpack-python to v97
-- [`c40c6a0`](https://github.com/deisthree/slugbuilder/commit/c40c6a04b3c6a62b27ad739b9e7f25c23aa2380a) (slugbuilder) - buildpacks: update heroku-buildpack-php to v117
-- [`2df92c0`](https://github.com/deisthree/workflow/commit/2df92c0875ff2b12212f0320e29f724e53beae14) (workflow) roadmap: update product roadmap
-- [`1d12348`](https://github.com/deisthree/workflow/commit/1d12348ed0d96a1e090d5a8d15b07921665e2021) (workflow) vagrant: update kubernetes release tarball to v1.5.1(workflow)
-- [`f50916b`](https://github.com/deisthree/workflow-manager/commit/f50916b2f0d0a7a07854a15b6a8550b5672126a6) (workflow-manager) - Dockerfile: update deis/base to v0.3.6
-- [`7960130`](https://github.com/deisthree/workflow-cli/commit/7960130d68000a1a77929c452645cdc1aeaf5e7b) (workflow-cli) glide: update controller sdk to 9520b6c
-- [`ba0d452`](https://github.com/deisthree/workflow-e2e/commit/ba0d452c455fb1622ef602e672fea8bfb8da8a25) (workflow-e2e) glide: run glide up to get latest packages (#347)
+- [`0ed0404`](https://github.com/deis/builder/commit/0ed0404b928789d9bbf0278f9f13d688e7f3e11f) (builder) - Dockerfile: update deis/base to v0.3.6
+- [`d7f5ff0`](https://github.com/deis/builder/commit/d7f5ff03d6801826c2137ed7ad046b2a0ce016c6) (builder) - glide: bump golang.org/x/crypto to b822463
+- [`22106d2`](https://github.com/deis/controller/commit/22106d22694d8108125af6a63d70d9d84608303b) (controller) - requirements: update Django to 1.10.5
+- [`1c12587`](https://github.com/deis/controller/commit/1c125875280a80ed4faf052732b1f6ffb7da544e) (controller) - Dockerfile: update deis/base to v0.3.6 (#1197)
+- [`4e45ef5`](https://github.com/deis/controller/commit/4e45ef5866ff368de3ae7fb018ccf36de79dc376) (controller) - requirements: update requests to 2.12.5
+- [`9faa4b2`](https://github.com/deis/controller/commit/9faa4b22a34565b17db2c98e13823f15049b69c2) (controller) - dev_requirements: update coverage to 4.3.4
+- [`4b7db76`](https://github.com/deis/controller/commit/4b7db7670ea134b5716226a1a355d24751c46108) (controller) - requirements: update pyldap to 2.4.28
+- [`d6b188d`](https://github.com/deis/dockerbuilder/commit/d6b188d954bbef0ae6a296886596d533b006adf5) (dockerbuilder) - dev_requirements: upgrade flake8 to 3.2.1
+- [`82f77c3`](https://github.com/deis/dockerbuilder/commit/82f77c31963833f8d5624d4a69b0edef548fa4d1) (dockerbuilder) - Dockerfile: update deis/base to v0.3.6
+- [`40f647e`](https://github.com/deis/fluentd/commit/40f647e00b0437c276386f4dcfa11bb761b2686c) (fluentd) - Dockerfile: update deis/base to v0.3.6
+- [`f7afeb7`](https://github.com/deis/logger/commit/f7afeb7d15b2d7b2c1ab4331b1d2aa91d28e2d8e) (logger) - Dockerfile: update deis/base to v0.3.6
+- [`14342eb`](https://github.com/deis/minio/commit/14342eb74e910a67ec060998ad21ea1f0aa61e8e) (minio) - Dockerfile: update deis/base to v0.3.6
+- [`8969f32`](https://github.com/deis/monitor/commit/8969f3205d909dd06e171fec5f07a9b0e57ec357) (monitor) - Dockerfile: update Grafana to 4.0.2
+- [`acb12e7`](https://github.com/deis/monitor/commit/acb12e7490c52368978401a15030a8c8badb640f) (monitor) - Dockerfile: update deis/base to v0.3.6
+- [`ca8a140`](https://github.com/deis/monitor/commit/ca8a14030e93ae332f90b15a19244f3803f976b7) (monitor) - Dockerfile: update Influxdb to 1.1.1
+- [`287dd60`](https://github.com/deis/monitor/commit/287dd60d606b0f2ea5e93638f12d20a6a31e09ea) (monitor) - Dockerfile: update Influxdb to 1.1.1
+- [`7c3ca4b`](https://github.com/deis/nsq/commit/7c3ca4b4a67a308f27852f07747b9914322556c4) (nsq) - Dockerfile: update deis/base to v0.3.6
+- [`d04a77b`](https://github.com/deis/postgres/commit/d04a77b0addff9dfb48696b60ea969097be9974a) (postgres) - Dockerfile: update deis/base to v0.3.6
+- [`9f2e1b1`](https://github.com/deis/redis/commit/9f2e1b13f95726dc5b82c668ded32ee44af0c063) (redis) - Dockerfile: update deis/base to v0.3.6
+- [`bb6bba4`](https://github.com/deis/registry-token-refresher/commit/bb6bba4258a9dba4b8de2bcc1aebda4330061401) (registry-token-refresher) - Dockerfile: update deis/base to v0.3.6
+- [`dfb2cae`](https://github.com/deis/router/commit/dfb2caef93642e87b737dad0b27ddd71526104a3) (router) - Dockerfile: update deis/base to v0.3.6
+- [`7638ca7`](https://github.com/deis/slugbuilder/commit/7638ca7744b18fd9a83eccfb28e30595257d2495) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v93
+- [`ac0192f`](https://github.com/deis/slugbuilder/commit/ac0192fbbd7ecf6bf217239fa65a352648daf498) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v150
+- [`3f4ccc4`](https://github.com/deis/slugbuilder/commit/3f4ccc4128114a3984203c8773090046f3393375) (slugbuilder) - buildpacks: update heroku-buildpack-python to v97
+- [`c40c6a0`](https://github.com/deis/slugbuilder/commit/c40c6a04b3c6a62b27ad739b9e7f25c23aa2380a) (slugbuilder) - buildpacks: update heroku-buildpack-php to v117
+- [`2df92c0`](https://github.com/deis/workflow/commit/2df92c0875ff2b12212f0320e29f724e53beae14) (workflow) roadmap: update product roadmap
+- [`1d12348`](https://github.com/deis/workflow/commit/1d12348ed0d96a1e090d5a8d15b07921665e2021) (workflow) vagrant: update kubernetes release tarball to v1.5.1(workflow)
+- [`f50916b`](https://github.com/deis/workflow-manager/commit/f50916b2f0d0a7a07854a15b6a8550b5672126a6) (workflow-manager) - Dockerfile: update deis/base to v0.3.6
+- [`7960130`](https://github.com/deis/workflow-cli/commit/7960130d68000a1a77929c452645cdc1aeaf5e7b) (workflow-cli) glide: update controller sdk to 9520b6c
+- [`ba0d452`](https://github.com/deis/workflow-e2e/commit/ba0d452c455fb1622ef602e672fea8bfb8da8a25) (workflow-e2e) glide: run glide up to get latest packages (#347)

--- a/src/changelogs/v2.12.0.md
+++ b/src/changelogs/v2.12.0.md
@@ -18,93 +18,93 @@
 
 #### Features
 
-- [`b91c8a0`](https://github.com/deisthree/builder/commit/b91c8a0bb831cbfa312d6cfcddffe280a6469824) (builder) - gitreceive: add app envvars to DOCKER_BUILD_ARGS
-- [`357f9a1`](https://github.com/deisthree/builder/commit/357f9a1e984fbaf89691370aac58849e7115ddc7) (builder) - gitreceive: fix type of dockerBuildArgs
-- [`2c1316a`](https://github.com/deisthree/dockerbuilder/commit/2c1316a27fae9629eaa40ccbd916c03a1b38a582) (dockerbuilder) - deploy: support DOCKER_BUILD_ARGS envvar
-- [`0681d7e`](https://github.com/deisthree/dockerbuilder/commit/0681d7e24557a0688ca4e35741c42af116766968) (dockerbuilder) - deploy: Use empty default if DOCKER_BUILD_ARGS env var is not set
-- [`a3ed520`](https://github.com/deisthree/fluentd/commit/a3ed5205e44bb6f93cfc964e2d58d6893563a803) (fluentd) - elasticsearch: add support for "reload_connections" option
-- [`503ca0e`](https://github.com/deisthree/monitor/commit/503ca0ea937c2487bbf6bffd8c7ec8075f0f805b) (monitor) - grafana: allow user to install plugins
-- [`74449a6`](https://github.com/deisthree/router/commit/74449a607426aa05b51c890972f30e7140c57348) (router) - charts: add resource requests to chart
-- [`d241b74`](https://github.com/deisthree/router/commit/d241b74f4125a5b7a15e49cb754798822a76f585) (router) - proxyBuffers: Add app-level proxy buffer config options
-- [`2b9074f`](https://github.com/deisthree/router/commit/2b9074f8964ace98d277c883542529f4abf6019d) (router) - proxyBuffers: Set at global level; override at app level
-- [`98796f8`](https://github.com/deisthree/slugrunner/commit/98796f84bd7837cada8c406091ececa359760bc7) (slugrunner) - Makefile: set docker build flags via environment variable
-- [`d3e0d74`](https://github.com/deisthree/workflow-e2e/commit/d3e0d74355f42fcc8cbbd67845f18479ad03fac4) (workflow-e2e) - tests: add config:set spec with dockerfile app
+- [`b91c8a0`](https://github.com/deis/builder/commit/b91c8a0bb831cbfa312d6cfcddffe280a6469824) (builder) - gitreceive: add app envvars to DOCKER_BUILD_ARGS
+- [`357f9a1`](https://github.com/deis/builder/commit/357f9a1e984fbaf89691370aac58849e7115ddc7) (builder) - gitreceive: fix type of dockerBuildArgs
+- [`2c1316a`](https://github.com/deis/dockerbuilder/commit/2c1316a27fae9629eaa40ccbd916c03a1b38a582) (dockerbuilder) - deploy: support DOCKER_BUILD_ARGS envvar
+- [`0681d7e`](https://github.com/deis/dockerbuilder/commit/0681d7e24557a0688ca4e35741c42af116766968) (dockerbuilder) - deploy: Use empty default if DOCKER_BUILD_ARGS env var is not set
+- [`a3ed520`](https://github.com/deis/fluentd/commit/a3ed5205e44bb6f93cfc964e2d58d6893563a803) (fluentd) - elasticsearch: add support for "reload_connections" option
+- [`503ca0e`](https://github.com/deis/monitor/commit/503ca0ea937c2487bbf6bffd8c7ec8075f0f805b) (monitor) - grafana: allow user to install plugins
+- [`74449a6`](https://github.com/deis/router/commit/74449a607426aa05b51c890972f30e7140c57348) (router) - charts: add resource requests to chart
+- [`d241b74`](https://github.com/deis/router/commit/d241b74f4125a5b7a15e49cb754798822a76f585) (router) - proxyBuffers: Add app-level proxy buffer config options
+- [`2b9074f`](https://github.com/deis/router/commit/2b9074f8964ace98d277c883542529f4abf6019d) (router) - proxyBuffers: Set at global level; override at app level
+- [`98796f8`](https://github.com/deis/slugrunner/commit/98796f84bd7837cada8c406091ececa359760bc7) (slugrunner) - Makefile: set docker build flags via environment variable
+- [`d3e0d74`](https://github.com/deis/workflow-e2e/commit/d3e0d74355f42fcc8cbbd67845f18479ad03fac4) (workflow-e2e) - tests: add config:set spec with dockerfile app
 
 #### Refactors
 
-- [`3b7fcef`](https://github.com/deisthree/builder/commit/3b7fcef896d74b239ab22ac240d8cf9b181357c3) (builder) - pkg: placate new go metalinter warnings
-- [`84753d2`](https://github.com/deisthree/router/commit/84753d243b7fc3602e23dca18cb021cef2933061) (router) - charts: disable host_port/enabled by default
-- [`9ecea1f`](https://github.com/deisthree/workflow/commit/9ecea1f26978120ef8936b4b7ebd6a18afb04e60) (workflow) - chart: remove upgrade-job.yaml (#748)
-- [`f5e7199`](https://github.com/deisthree/workflow/commit/f5e7199219bddc70e3c325df7d971927aa1c243b) (workflow) - router: disable router hostPort usage by default
+- [`3b7fcef`](https://github.com/deis/builder/commit/3b7fcef896d74b239ab22ac240d8cf9b181357c3) (builder) - pkg: placate new go metalinter warnings
+- [`84753d2`](https://github.com/deis/router/commit/84753d243b7fc3602e23dca18cb021cef2933061) (router) - charts: disable host_port/enabled by default
+- [`9ecea1f`](https://github.com/deis/workflow/commit/9ecea1f26978120ef8936b4b7ebd6a18afb04e60) (workflow) - chart: remove upgrade-job.yaml (#748)
+- [`f5e7199`](https://github.com/deis/workflow/commit/f5e7199219bddc70e3c325df7d971927aa1c243b) (workflow) - router: disable router hostPort usage by default
 
 #### Fixes
 
-- [`b3b1d20`](https://github.com/deisthree/builder/commit/b3b1d203d36b1ee2066b9d5ebe96be5362b3b8f4) (builder) - Dockerfile: force gunzip of license files
-- [`e1e3452`](https://github.com/deisthree/builder/commit/e1e345286fada7638b7a408a8c4235dfffbe3293) (builder) - gitreceive/build.go: watch pods in the appropriate namespace
-- [`7f121a4`](https://github.com/deisthree/builder/commit/7f121a45ef08c1022e415f377889f258176c0329) (builder) - .travis.yml: declare env vars on one line
-- [`98f50c5`](https://github.com/deisthree/controller/commit/98f50c55391a0dcd41c8bc9c7c6d504f9b7b68dc) (controller) - models/app: recreate proc types on switch from Dockerfile to buildpack
-- [`8480f69`](https://github.com/deisthree/controller/commit/8480f69fbcdb1ec8a9bad6fcdf179d55e38f8edd) (controller) - app.py: use current namespace instead of "deis"
-- [`bfadce8`](https://github.com/deisthree/controller/commit/bfadce8814f550bcbc433b20cf31917aba06f494) (controller) - charts: default registration mode to "admin_only"
-- [`13b2463`](https://github.com/deisthree/dockerbuilder/commit/13b2463d5311da00ac5125534ee7add19a89fa3a) (dockerbuilder) - deploy: inject DOCKER_BUILD_ARGS into the Dockerfile
-- [`861100b`](https://github.com/deisthree/fluentd/commit/861100bbf4aa0dc281585128ad42f575b06c07cc) (fluentd) - Dockerfile: force gunzip of license files
-- [`5188f77`](https://github.com/deisthree/postgres/commit/5188f77e368c173fdf721d088c72157a52c047e7) (postgres) - create_bucket: avoid S3 InvalidLocationConstraint error
-- [`2ada84f`](https://github.com/deisthree/postgres/commit/2ada84f3ef6b22980a25c01e0a2d279fa46d3434) (postgres) - .travis.yml: declare env vars on one line
-- [`86a30d7`](https://github.com/deisthree/registry/commit/86a30d779f24049b528668287278bd0946795a06) (registry) - .travis.yml: declare env vars on one line
-- [`a885078`](https://github.com/deisthree/registry/commit/a885078faf719d5dbd68981ed8f0420de36484ca) (registry) - create-bucket: avoid S3 InvalidLocationConstraint error
-- [`5df84f1`](https://github.com/deisthree/router/commit/5df84f138e7bedce2c7173add23a53817732c8a5) (router) - Dockerfile: force gunzip of license files
-- [`fa9c217`](https://github.com/deisthree/router/commit/fa9c2173df8695c6d1ef7222187d1d88ac2ac806) (router) - style: Apply mandatory formatting fixes
-- [`f2d7ee5`](https://github.com/deisthree/router/commit/f2d7ee5a03a7102125981c1c8393a214de698d08) (router) - .travis.yml: Make travis apply style checks
-- [`65b7487`](https://github.com/deisthree/router/commit/65b7487066028fd54c75179d22158df71e272da3) (router) - charts: quote annotation values
-- [`e7bb879`](https://github.com/deisthree/workflow/commit/e7bb879ca01ccaaffb05ee74eb6deeb99aab66ae) (workflow) - quickstart: fix kops typo
-- [`1c506d7`](https://github.com/deisthree/workflow/commit/1c506d7ccad56edf4c5370552f20483d439d7a64) (workflow) - quickstart: update azure quickstart docs
-- [`7d63d07`](https://github.com/deisthree/workflow/commit/7d63d0718123a24fedde5540247505598f46b671) (workflow) - charts: default registration mode to "admin_only" (#758)
-- [`02e9437`](https://github.com/deisthree/workflow/commit/02e9437d800dd0a71bc9390ad58b50c8bf263497) (workflow) - quickstart: prepend Azure envvars with AZURE_
-- [`6f5d0ca`](https://github.com/deisthree/workflow/commit/6f5d0caccb4aec8b2cad74abaae99a6552a6b74b) (workflow) - aws/boot: don't overwrite kops with kubectl
+- [`b3b1d20`](https://github.com/deis/builder/commit/b3b1d203d36b1ee2066b9d5ebe96be5362b3b8f4) (builder) - Dockerfile: force gunzip of license files
+- [`e1e3452`](https://github.com/deis/builder/commit/e1e345286fada7638b7a408a8c4235dfffbe3293) (builder) - gitreceive/build.go: watch pods in the appropriate namespace
+- [`7f121a4`](https://github.com/deis/builder/commit/7f121a45ef08c1022e415f377889f258176c0329) (builder) - .travis.yml: declare env vars on one line
+- [`98f50c5`](https://github.com/deis/controller/commit/98f50c55391a0dcd41c8bc9c7c6d504f9b7b68dc) (controller) - models/app: recreate proc types on switch from Dockerfile to buildpack
+- [`8480f69`](https://github.com/deis/controller/commit/8480f69fbcdb1ec8a9bad6fcdf179d55e38f8edd) (controller) - app.py: use current namespace instead of "deis"
+- [`bfadce8`](https://github.com/deis/controller/commit/bfadce8814f550bcbc433b20cf31917aba06f494) (controller) - charts: default registration mode to "admin_only"
+- [`13b2463`](https://github.com/deis/dockerbuilder/commit/13b2463d5311da00ac5125534ee7add19a89fa3a) (dockerbuilder) - deploy: inject DOCKER_BUILD_ARGS into the Dockerfile
+- [`861100b`](https://github.com/deis/fluentd/commit/861100bbf4aa0dc281585128ad42f575b06c07cc) (fluentd) - Dockerfile: force gunzip of license files
+- [`5188f77`](https://github.com/deis/postgres/commit/5188f77e368c173fdf721d088c72157a52c047e7) (postgres) - create_bucket: avoid S3 InvalidLocationConstraint error
+- [`2ada84f`](https://github.com/deis/postgres/commit/2ada84f3ef6b22980a25c01e0a2d279fa46d3434) (postgres) - .travis.yml: declare env vars on one line
+- [`86a30d7`](https://github.com/deis/registry/commit/86a30d779f24049b528668287278bd0946795a06) (registry) - .travis.yml: declare env vars on one line
+- [`a885078`](https://github.com/deis/registry/commit/a885078faf719d5dbd68981ed8f0420de36484ca) (registry) - create-bucket: avoid S3 InvalidLocationConstraint error
+- [`5df84f1`](https://github.com/deis/router/commit/5df84f138e7bedce2c7173add23a53817732c8a5) (router) - Dockerfile: force gunzip of license files
+- [`fa9c217`](https://github.com/deis/router/commit/fa9c2173df8695c6d1ef7222187d1d88ac2ac806) (router) - style: Apply mandatory formatting fixes
+- [`f2d7ee5`](https://github.com/deis/router/commit/f2d7ee5a03a7102125981c1c8393a214de698d08) (router) - .travis.yml: Make travis apply style checks
+- [`65b7487`](https://github.com/deis/router/commit/65b7487066028fd54c75179d22158df71e272da3) (router) - charts: quote annotation values
+- [`e7bb879`](https://github.com/deis/workflow/commit/e7bb879ca01ccaaffb05ee74eb6deeb99aab66ae) (workflow) - quickstart: fix kops typo
+- [`1c506d7`](https://github.com/deis/workflow/commit/1c506d7ccad56edf4c5370552f20483d439d7a64) (workflow) - quickstart: update azure quickstart docs
+- [`7d63d07`](https://github.com/deis/workflow/commit/7d63d0718123a24fedde5540247505598f46b671) (workflow) - charts: default registration mode to "admin_only" (#758)
+- [`02e9437`](https://github.com/deis/workflow/commit/02e9437d800dd0a71bc9390ad58b50c8bf263497) (workflow) - quickstart: prepend Azure envvars with AZURE_
+- [`6f5d0ca`](https://github.com/deis/workflow/commit/6f5d0caccb4aec8b2cad74abaae99a6552a6b74b) (workflow) - aws/boot: don't overwrite kops with kubectl
 
 #### Documentation
 
-- [`3e8ff74`](https://github.com/deisthree/router/commit/3e8ff74dc69f1e4cc5c3af38341abbe8726eca20) (router) - README: Reflect newer install/hack/deploy processes
-- [`67d5d8b`](https://github.com/deisthree/workflow/commit/67d5d8b906386948531bb810fbb506101528d48b) (workflow) - src/quickstart/provider/aws: Use kops instead of kube-up.sh for workflow clusters on AWs
-- [`2217993`](https://github.com/deisthree/workflow/commit/2217993919e8bec42c443ee6a6114e01bb149993) (workflow) - src/quickstart/provider/aws: docs(src/quickstart/provider/aws) Changes from code review.
-- [`18d24d9`](https://github.com/deisthree/workflow/commit/18d24d9d819ae33994ebb4526424dc398bbc72f1) (workflow) - platform-monitoring.md: update grafana un/pw set instructions
-- [`5c16b82`](https://github.com/deisthree/workflow/commit/5c16b828636f9b2208b9f77d8bbc9341a3eec298) (workflow) - src/quickstart/provider/aws: docs(src/quickstart/provider/aws) Changes from code review.
-- [`ea8c7a6`](https://github.com/deisthree/workflow/commit/ea8c7a6226d64a66da4561959b68ad74f8e08b83) (workflow) - src/quickstart/provider/aws: Changes from code review.
-- [`e6d36a6`](https://github.com/deisthree/workflow/commit/e6d36a65f9e1abfeb305c2631316405b075a61a8) (workflow) - src/roadmap/releases.md: simplify docs in global changelog step (#722)
-- [`2511d0a`](https://github.com/deisthree/workflow/commit/2511d0adeefd6a37992688d197eeb2627e205c44) (workflow) - managing-workflow: docs(managing-workflow) Document k8s annotation for AWS ELB idle timeout
-- [`427e49a`](https://github.com/deisthree/workflow/commit/427e49a4f40542c2a124cd6c9795eae1db5d6ef8) (workflow) - tuning-component-settings: elaborate with practical examples (#749)
-- [`df70aa5`](https://github.com/deisthree/workflow/commit/df70aa5f04c2a73e22509823859a1c7d2af423a6) (workflow) - installing: specify helm v2.1.3 as minimum everywhere
+- [`3e8ff74`](https://github.com/deis/router/commit/3e8ff74dc69f1e4cc5c3af38341abbe8726eca20) (router) - README: Reflect newer install/hack/deploy processes
+- [`67d5d8b`](https://github.com/deis/workflow/commit/67d5d8b906386948531bb810fbb506101528d48b) (workflow) - src/quickstart/provider/aws: Use kops instead of kube-up.sh for workflow clusters on AWs
+- [`2217993`](https://github.com/deis/workflow/commit/2217993919e8bec42c443ee6a6114e01bb149993) (workflow) - src/quickstart/provider/aws: docs(src/quickstart/provider/aws) Changes from code review.
+- [`18d24d9`](https://github.com/deis/workflow/commit/18d24d9d819ae33994ebb4526424dc398bbc72f1) (workflow) - platform-monitoring.md: update grafana un/pw set instructions
+- [`5c16b82`](https://github.com/deis/workflow/commit/5c16b828636f9b2208b9f77d8bbc9341a3eec298) (workflow) - src/quickstart/provider/aws: docs(src/quickstart/provider/aws) Changes from code review.
+- [`ea8c7a6`](https://github.com/deis/workflow/commit/ea8c7a6226d64a66da4561959b68ad74f8e08b83) (workflow) - src/quickstart/provider/aws: Changes from code review.
+- [`e6d36a6`](https://github.com/deis/workflow/commit/e6d36a65f9e1abfeb305c2631316405b075a61a8) (workflow) - src/roadmap/releases.md: simplify docs in global changelog step (#722)
+- [`2511d0a`](https://github.com/deis/workflow/commit/2511d0adeefd6a37992688d197eeb2627e205c44) (workflow) - managing-workflow: docs(managing-workflow) Document k8s annotation for AWS ELB idle timeout
+- [`427e49a`](https://github.com/deis/workflow/commit/427e49a4f40542c2a124cd6c9795eae1db5d6ef8) (workflow) - tuning-component-settings: elaborate with practical examples (#749)
+- [`df70aa5`](https://github.com/deis/workflow/commit/df70aa5f04c2a73e22509823859a1c7d2af423a6) (workflow) - installing: specify helm v2.1.3 as minimum everywhere
 
 #### Maintenance
 
-- [`e7eafb9`](https://github.com/deisthree/builder/commit/e7eafb90bf03ad450c7c36a5fb91843a6aac3fa6) (builder) - Makefile: update docker-go-dev to v0.22.0
-- [`f3e13b3`](https://github.com/deisthree/builder/commit/f3e13b3cde15769966ca48327f10cc5b4fe280d8) (builder) - glide: bump golang.org/x/crypto to 453249f
-- [`e69a9a4`](https://github.com/deisthree/controller/commit/e69a9a4d1ba8e62fcf40028655ad72d3ccdaec1e) (controller) - requirements: update jmespath to 0.9.1
-- [`99c11d9`](https://github.com/deisthree/controller/commit/99c11d9cfcd0acb75094be16f4acea03fefd3cd6) (controller) - requirements: update requests to 2.13.0
-- [`74d16af`](https://github.com/deisthree/controller/commit/74d16af9ad4df50c81158bb57db664a43e1de669) (controller) - requirements: update backoff library
-- [`afbca0d`](https://github.com/deisthree/controller/commit/afbca0d3026ca1f9547e5de94d0a73ee5710fd2f) (controller) - requirements: update jsonschema library
-- [`5174fea`](https://github.com/deisthree/controller/commit/5174fea369e992c6689b11cc84e21a680f4a3873) (controller) - dev_requirements: update flake8 linter library
-- [`96576dd`](https://github.com/deisthree/controller/commit/96576dd73ebc5d6479323065b05f303c561b8bfc) (controller) - requirements: update django-auth-ldap to 1.2.9
-- [`8c8261d`](https://github.com/deisthree/controller/commit/8c8261de11b9332a2449997a82cdca07bdf5b9a5) (controller) - requirements: update djangorestframework to 3.5.4
-- [`894a324`](https://github.com/deisthree/controller/commit/894a3245dbfe7c366c26171d90c35bf99eedd20d) (controller) - requirements: update requests-toolbelt to 0.7.1
-- [`52a7650`](https://github.com/deisthree/dockerbuilder/commit/52a7650c8016a64f65fd5492a1463398338b5625) (dockerbuilder) - dev_requirements: update flake8 linter library
-- [`6997f06`](https://github.com/deisthree/dockerbuilder/commit/6997f06cc553cdf67590869c1ea6cdac85dbbb76) (dockerbuilder) - .travis.yml: update python to 3.5.x
-- [`23d2da2`](https://github.com/deisthree/fluentd/commit/23d2da2f5aed484401e9ba316e8f48dc3ec32742) (fluentd) - Dockerfile: update fluentd to 0.14.13
-- [`614fd40`](https://github.com/deisthree/postgres/commit/614fd4040a331375a3be466e47daf32d7fbd83a4) (postgres) - Dockerfile: bump PG_VERSION to 9.4.11-1.pgdg16.04+1
-- [`46f6e1d`](https://github.com/deisthree/router/commit/46f6e1d615949ae9294104d1f5de2617b2095b1b) (router) - Makefile: update docker-go-dev to v0.22.0
-- [`8de0045`](https://github.com/deisthree/router/commit/8de0045c3a11e851eb9cb29e9fa38371e6a19fb8) (router) - nginx: update nginx to 1.11.9
-- [`1cde072`](https://github.com/deisthree/router/commit/1cde0727bfc8f0425faef1414820cba36a668770) (router) - Makefile: Modernize dev/hack deployment
-- [`f7a202e`](https://github.com/deisthree/router/commit/f7a202e486686212a2d50df6411bf2eb52cf07b9) (router) - Makefile: Remove minimally useful clean targets
-- [`abb7a8e`](https://github.com/deisthree/slugbuilder/commit/abb7a8ec1ea82ea411c75f97e7915bd44599bf8f) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v98
-- [`d255d7b`](https://github.com/deisthree/slugbuilder/commit/d255d7b011dcdfb98e318f327461354ac5e12dba) (slugbuilder) - buildpacks: update heroku-buildpack-clojure to v76
-- [`97218ad`](https://github.com/deisthree/slugbuilder/commit/97218adb81383ecdf8e61de5e904d9622dce4ae3) (slugbuilder) - buildpacks: update heroku-buildpack-go to v60
-- [`1f35b41`](https://github.com/deisthree/slugbuilder/commit/1f35b416d3d9ff3c813c6465ec2161dbc8cb0e01) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v21
-- [`327d2bb`](https://github.com/deisthree/slugbuilder/commit/327d2bbec6157ce16a0c0e9851831c89106b40a5) (slugbuilder) - buildpacks: update heroku-buildpack-java to v50
-- [`b3844cb`](https://github.com/deisthree/slugbuilder/commit/b3844cb7ba5c2a0402a0a89b62d9d83973461a59) (slugbuilder) - buildpacks: update heroku-buildpack-php to v119
-- [`e392787`](https://github.com/deisthree/slugbuilder/commit/e3927876c0df00ec691e62c87fbf59d7d5b70870) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v153
-- [`0798cd6`](https://github.com/deisthree/slugbuilder/commit/0798cd62b5d6ec3deacacc4eff25a965796a691f) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v75
-- [`6abe59d`](https://github.com/deisthree/slugbuilder/commit/6abe59deb46662c831fbdb92cc678a9e06764893) (slugbuilder) - buildpacks: update heroku-buildpack-go to v62
-- [`d453264`](https://github.com/deisthree/slugbuilder/commit/d45326480b228ce5b171bb00d7189a070afd967d) (slugbuilder) - buildpacks: update heroku-buildpack-java to v51
-- [`4d92580`](https://github.com/deisthree/slugbuilder/commit/4d9258041107b709b46221115c08af3dc928e013) (slugbuilder) - buildpacks: update heroku-buildpack-python to v99
-- [`ead5bbb`](https://github.com/deisthree/slugbuilder/commit/ead5bbb40f8c6d8998ddcc4ec14a3679abdb50f9) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v76
-- [`a8b2844`](https://github.com/deisthree/slugbuilder/commit/a8b284472bbde03741f94febd8c7db9286298b31) (slugbuilder) - buildpacks: update heroku-buildpack-php to v120
-- [`8aff8c6`](https://github.com/deisthree/workflow-cli/commit/8aff8c698e912fe1b7a6a77c5e051f1560f4e59f) (workflow-cli) - Dockerfile: update go-dev to v0.22.0
+- [`e7eafb9`](https://github.com/deis/builder/commit/e7eafb90bf03ad450c7c36a5fb91843a6aac3fa6) (builder) - Makefile: update docker-go-dev to v0.22.0
+- [`f3e13b3`](https://github.com/deis/builder/commit/f3e13b3cde15769966ca48327f10cc5b4fe280d8) (builder) - glide: bump golang.org/x/crypto to 453249f
+- [`e69a9a4`](https://github.com/deis/controller/commit/e69a9a4d1ba8e62fcf40028655ad72d3ccdaec1e) (controller) - requirements: update jmespath to 0.9.1
+- [`99c11d9`](https://github.com/deis/controller/commit/99c11d9cfcd0acb75094be16f4acea03fefd3cd6) (controller) - requirements: update requests to 2.13.0
+- [`74d16af`](https://github.com/deis/controller/commit/74d16af9ad4df50c81158bb57db664a43e1de669) (controller) - requirements: update backoff library
+- [`afbca0d`](https://github.com/deis/controller/commit/afbca0d3026ca1f9547e5de94d0a73ee5710fd2f) (controller) - requirements: update jsonschema library
+- [`5174fea`](https://github.com/deis/controller/commit/5174fea369e992c6689b11cc84e21a680f4a3873) (controller) - dev_requirements: update flake8 linter library
+- [`96576dd`](https://github.com/deis/controller/commit/96576dd73ebc5d6479323065b05f303c561b8bfc) (controller) - requirements: update django-auth-ldap to 1.2.9
+- [`8c8261d`](https://github.com/deis/controller/commit/8c8261de11b9332a2449997a82cdca07bdf5b9a5) (controller) - requirements: update djangorestframework to 3.5.4
+- [`894a324`](https://github.com/deis/controller/commit/894a3245dbfe7c366c26171d90c35bf99eedd20d) (controller) - requirements: update requests-toolbelt to 0.7.1
+- [`52a7650`](https://github.com/deis/dockerbuilder/commit/52a7650c8016a64f65fd5492a1463398338b5625) (dockerbuilder) - dev_requirements: update flake8 linter library
+- [`6997f06`](https://github.com/deis/dockerbuilder/commit/6997f06cc553cdf67590869c1ea6cdac85dbbb76) (dockerbuilder) - .travis.yml: update python to 3.5.x
+- [`23d2da2`](https://github.com/deis/fluentd/commit/23d2da2f5aed484401e9ba316e8f48dc3ec32742) (fluentd) - Dockerfile: update fluentd to 0.14.13
+- [`614fd40`](https://github.com/deis/postgres/commit/614fd4040a331375a3be466e47daf32d7fbd83a4) (postgres) - Dockerfile: bump PG_VERSION to 9.4.11-1.pgdg16.04+1
+- [`46f6e1d`](https://github.com/deis/router/commit/46f6e1d615949ae9294104d1f5de2617b2095b1b) (router) - Makefile: update docker-go-dev to v0.22.0
+- [`8de0045`](https://github.com/deis/router/commit/8de0045c3a11e851eb9cb29e9fa38371e6a19fb8) (router) - nginx: update nginx to 1.11.9
+- [`1cde072`](https://github.com/deis/router/commit/1cde0727bfc8f0425faef1414820cba36a668770) (router) - Makefile: Modernize dev/hack deployment
+- [`f7a202e`](https://github.com/deis/router/commit/f7a202e486686212a2d50df6411bf2eb52cf07b9) (router) - Makefile: Remove minimally useful clean targets
+- [`abb7a8e`](https://github.com/deis/slugbuilder/commit/abb7a8ec1ea82ea411c75f97e7915bd44599bf8f) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v98
+- [`d255d7b`](https://github.com/deis/slugbuilder/commit/d255d7b011dcdfb98e318f327461354ac5e12dba) (slugbuilder) - buildpacks: update heroku-buildpack-clojure to v76
+- [`97218ad`](https://github.com/deis/slugbuilder/commit/97218adb81383ecdf8e61de5e904d9622dce4ae3) (slugbuilder) - buildpacks: update heroku-buildpack-go to v60
+- [`1f35b41`](https://github.com/deis/slugbuilder/commit/1f35b416d3d9ff3c813c6465ec2161dbc8cb0e01) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v21
+- [`327d2bb`](https://github.com/deis/slugbuilder/commit/327d2bbec6157ce16a0c0e9851831c89106b40a5) (slugbuilder) - buildpacks: update heroku-buildpack-java to v50
+- [`b3844cb`](https://github.com/deis/slugbuilder/commit/b3844cb7ba5c2a0402a0a89b62d9d83973461a59) (slugbuilder) - buildpacks: update heroku-buildpack-php to v119
+- [`e392787`](https://github.com/deis/slugbuilder/commit/e3927876c0df00ec691e62c87fbf59d7d5b70870) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v153
+- [`0798cd6`](https://github.com/deis/slugbuilder/commit/0798cd62b5d6ec3deacacc4eff25a965796a691f) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v75
+- [`6abe59d`](https://github.com/deis/slugbuilder/commit/6abe59deb46662c831fbdb92cc678a9e06764893) (slugbuilder) - buildpacks: update heroku-buildpack-go to v62
+- [`d453264`](https://github.com/deis/slugbuilder/commit/d45326480b228ce5b171bb00d7189a070afd967d) (slugbuilder) - buildpacks: update heroku-buildpack-java to v51
+- [`4d92580`](https://github.com/deis/slugbuilder/commit/4d9258041107b709b46221115c08af3dc928e013) (slugbuilder) - buildpacks: update heroku-buildpack-python to v99
+- [`ead5bbb`](https://github.com/deis/slugbuilder/commit/ead5bbb40f8c6d8998ddcc4ec14a3679abdb50f9) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v76
+- [`a8b2844`](https://github.com/deis/slugbuilder/commit/a8b284472bbde03741f94febd8c7db9286298b31) (slugbuilder) - buildpacks: update heroku-buildpack-php to v120
+- [`8aff8c6`](https://github.com/deis/workflow-cli/commit/8aff8c698e912fe1b7a6a77c5e051f1560f4e59f) (workflow-cli) - Dockerfile: update go-dev to v0.22.0

--- a/src/changelogs/v2.13.0.md
+++ b/src/changelogs/v2.13.0.md
@@ -21,106 +21,106 @@
 
 #### Features
 
-- [`7d928d8`](https://github.com/deisthree/builder/commit/7d928d82cdaa7eda0a2a9a6ebf957d01aa2146b6) (builder) - podselector: add pod selector for builder job
-- [`67cfd5d`](https://github.com/deisthree/builder/commit/67cfd5d844761dd887f537ef1fc64cd1860f067a) (builder) - podselector: update charts
-- [`bf9747d`](https://github.com/deisthree/builder/commit/bf9747d14220d3366fe0c5a8748bbbae2e9e4c96) (builder) - podselector: update parameter format to match other annotation
-- [`01db893`](https://github.com/deisthree/builder/commit/01db893cb5ff5ebf67999ebb179e3e6487641f56) (builder) - ingress: Experimental Native Ingress
-- [`50a1592`](https://github.com/deisthree/controller/commit/50a1592706922e6bd88dce12709aa94bc66ae761) (controller) - config.py: Add ability to setup default tags
-- [`726a587`](https://github.com/deisthree/controller/commit/726a5875eb0486a50f98971fa62789cff7b217b0) (controller) - ingress: Feature work for experimental native ingress
-- [`0e117b1`](https://github.com/deisthree/controller/commit/0e117b1bd04dfd84a94d5e295c4d16328db7e66e) (controller) - api: allow app names up to 63 characters in length (#1198)
-- [`2e8ec75`](https://github.com/deisthree/controller/commit/2e8ec75d16ef6d5a1c07d16726f09419a17208e6) (controller) - Makefile,rootfs: run unit and style tests in container
-- [`a2bbd90`](https://github.com/deisthree/dockerbuilder/commit/a2bbd90dd17a23310c1f380a3f43e53c0eaa256f) (dockerbuilder) - Makefile: run style tests in container
-- [`0325f2d`](https://github.com/deisthree/fluentd/commit/0325f2dec80322b0a390d5b71b3c23063eaa5a58) (fluentd) - out_deis.rb: allow disabling deis logs and metrics to nsq
-- [`451c846`](https://github.com/deisthree/nsq/commit/451c846997dd010709be8c0e19e2ae334764fd6a) (nsq) - Makefile: add test target
-- [`d39ea43`](https://github.com/deisthree/registry/commit/d39ea430d51635b2a3de5acc80b8fda7707cbe50) (registry) - Makefile: add test-style target
-- [`a8c0fa7`](https://github.com/deisthree/registry-proxy/commit/a8c0fa7f5db60dffa4b2fb8aa826466d6d8a2ce5) (registry-proxy) - Makefile: set docker build flags via environment variable
-- [`badc232`](https://github.com/deisthree/router/commit/badc23276a596c251e6e3164e3de26cad705757b) (router) - ingress: Experimental Native Ingress
-- [`bbf8dee`](https://github.com/deisthree/router/commit/bbf8dee9a49ecb868d0d8d2b6a75b89d28685feb) (router) - chart: add aws-specific idle timeout annotation to router service
-- [`9136b81`](https://github.com/deisthree/router/commit/9136b81bf4761718e9bf6b15c408e25d8b458111) (router) - ingress: Experimental Native Ingress
-- [`23db7df`](https://github.com/deisthree/workflow/commit/23db7dfadacd1d7543258e20e3d7f7ef11c32015) (workflow) - controller: feat(controller) default tags
-- [`259a3f8`](https://github.com/deisthree/workflow/commit/259a3f8192892dc6da5afaeaa1baa66492822c2c) (workflow) - using_dockerfiles: document build args feature flag
-- [`2692d66`](https://github.com/deisthree/workflow/commit/2692d6691dade8d510b032dd68f093449d8d8efb) (workflow) - ingress: Experimental Native Ingress
-- [`eb1c025`](https://github.com/deisthree/workflow/commit/eb1c025d78a3299a892f0b33d94118ace1fb1786) (workflow) - ingress: Support enable/disable conditions in Workflow chart
-- [`89982ee`](https://github.com/deisthree/workflow-cli/commit/89982eef4cfbd41f3000303f6dfe5fe6064d98e3) (workflow-cli) - cmd: add config:list --diff
-- [`3750f53`](https://github.com/deisthree/workflow-e2e/commit/3750f53aebc4a3eb6001dc967ece26cc7aa747ec) (workflow-e2e) - Makefile: add test target
-- [`eaa74c7`](https://github.com/deisthree/workflow-manager/commit/eaa74c7ec6345302760b5aae8d7d55167ba9153b) (workflow-manager) - clusters: added versions API route endpoints (#107)
+- [`7d928d8`](https://github.com/deis/builder/commit/7d928d82cdaa7eda0a2a9a6ebf957d01aa2146b6) (builder) - podselector: add pod selector for builder job
+- [`67cfd5d`](https://github.com/deis/builder/commit/67cfd5d844761dd887f537ef1fc64cd1860f067a) (builder) - podselector: update charts
+- [`bf9747d`](https://github.com/deis/builder/commit/bf9747d14220d3366fe0c5a8748bbbae2e9e4c96) (builder) - podselector: update parameter format to match other annotation
+- [`01db893`](https://github.com/deis/builder/commit/01db893cb5ff5ebf67999ebb179e3e6487641f56) (builder) - ingress: Experimental Native Ingress
+- [`50a1592`](https://github.com/deis/controller/commit/50a1592706922e6bd88dce12709aa94bc66ae761) (controller) - config.py: Add ability to setup default tags
+- [`726a587`](https://github.com/deis/controller/commit/726a5875eb0486a50f98971fa62789cff7b217b0) (controller) - ingress: Feature work for experimental native ingress
+- [`0e117b1`](https://github.com/deis/controller/commit/0e117b1bd04dfd84a94d5e295c4d16328db7e66e) (controller) - api: allow app names up to 63 characters in length (#1198)
+- [`2e8ec75`](https://github.com/deis/controller/commit/2e8ec75d16ef6d5a1c07d16726f09419a17208e6) (controller) - Makefile,rootfs: run unit and style tests in container
+- [`a2bbd90`](https://github.com/deis/dockerbuilder/commit/a2bbd90dd17a23310c1f380a3f43e53c0eaa256f) (dockerbuilder) - Makefile: run style tests in container
+- [`0325f2d`](https://github.com/deis/fluentd/commit/0325f2dec80322b0a390d5b71b3c23063eaa5a58) (fluentd) - out_deis.rb: allow disabling deis logs and metrics to nsq
+- [`451c846`](https://github.com/deis/nsq/commit/451c846997dd010709be8c0e19e2ae334764fd6a) (nsq) - Makefile: add test target
+- [`d39ea43`](https://github.com/deis/registry/commit/d39ea430d51635b2a3de5acc80b8fda7707cbe50) (registry) - Makefile: add test-style target
+- [`a8c0fa7`](https://github.com/deis/registry-proxy/commit/a8c0fa7f5db60dffa4b2fb8aa826466d6d8a2ce5) (registry-proxy) - Makefile: set docker build flags via environment variable
+- [`badc232`](https://github.com/deis/router/commit/badc23276a596c251e6e3164e3de26cad705757b) (router) - ingress: Experimental Native Ingress
+- [`bbf8dee`](https://github.com/deis/router/commit/bbf8dee9a49ecb868d0d8d2b6a75b89d28685feb) (router) - chart: add aws-specific idle timeout annotation to router service
+- [`9136b81`](https://github.com/deis/router/commit/9136b81bf4761718e9bf6b15c408e25d8b458111) (router) - ingress: Experimental Native Ingress
+- [`23db7df`](https://github.com/deis/workflow/commit/23db7dfadacd1d7543258e20e3d7f7ef11c32015) (workflow) - controller: feat(controller) default tags
+- [`259a3f8`](https://github.com/deis/workflow/commit/259a3f8192892dc6da5afaeaa1baa66492822c2c) (workflow) - using_dockerfiles: document build args feature flag
+- [`2692d66`](https://github.com/deis/workflow/commit/2692d6691dade8d510b032dd68f093449d8d8efb) (workflow) - ingress: Experimental Native Ingress
+- [`eb1c025`](https://github.com/deis/workflow/commit/eb1c025d78a3299a892f0b33d94118ace1fb1786) (workflow) - ingress: Support enable/disable conditions in Workflow chart
+- [`89982ee`](https://github.com/deis/workflow-cli/commit/89982eef4cfbd41f3000303f6dfe5fe6064d98e3) (workflow-cli) - cmd: add config:list --diff
+- [`3750f53`](https://github.com/deis/workflow-e2e/commit/3750f53aebc4a3eb6001dc967ece26cc7aa747ec) (workflow-e2e) - Makefile: add test target
+- [`eaa74c7`](https://github.com/deis/workflow-manager/commit/eaa74c7ec6345302760b5aae8d7d55167ba9153b) (workflow-manager) - clusters: added versions API route endpoints (#107)
 
 #### Refactors
 
-- [`e0765bf`](https://github.com/deisthree/builder/commit/e0765bff10d5526ad13b6242ced11bc5f774bd0c) (builder) - ssh keys: remove support for DSA
-- [`641f70d`](https://github.com/deisthree/builder/commit/641f70d16fc5b43f46791860cf61d68fb1d8d15e) (builder) - k8s_util: make users opt into DOCKER_BUILD_ARGS
-- [`807fe82`](https://github.com/deisthree/controller/commit/807fe82df65004996b23bae1299811efc5ef3f96) (controller) - utils: use python 3.5 asyncio keywords
-- [`3027766`](https://github.com/deisthree/monitor/commit/302776634c0b9fae3fe2b8852753e46f9cc80dfc) (monitor) - ci: refactor monitor ci
-- [`dc7c247`](https://github.com/deisthree/nsq/commit/dc7c247f7d9c22b51a1b3368dc7ea973b3b2c33a) (nsq) - ci: remove manifests dir
-- [`d5dd212`](https://github.com/deisthree/workflow/commit/d5dd212936b13720a3714373c616853710c933c2) (workflow) - quickstart: swap out Vagrant with Minikube
-- [`50ec2a2`](https://github.com/deisthree/workflow-e2e/commit/50ec2a2e60ea457740b3aa9ce4b762b02a005ae8) (workflow-e2e) - tests: update tests for new registration mode default
+- [`e0765bf`](https://github.com/deis/builder/commit/e0765bff10d5526ad13b6242ced11bc5f774bd0c) (builder) - ssh keys: remove support for DSA
+- [`641f70d`](https://github.com/deis/builder/commit/641f70d16fc5b43f46791860cf61d68fb1d8d15e) (builder) - k8s_util: make users opt into DOCKER_BUILD_ARGS
+- [`807fe82`](https://github.com/deis/controller/commit/807fe82df65004996b23bae1299811efc5ef3f96) (controller) - utils: use python 3.5 asyncio keywords
+- [`3027766`](https://github.com/deis/monitor/commit/302776634c0b9fae3fe2b8852753e46f9cc80dfc) (monitor) - ci: refactor monitor ci
+- [`dc7c247`](https://github.com/deis/nsq/commit/dc7c247f7d9c22b51a1b3368dc7ea973b3b2c33a) (nsq) - ci: remove manifests dir
+- [`d5dd212`](https://github.com/deis/workflow/commit/d5dd212936b13720a3714373c616853710c933c2) (workflow) - quickstart: swap out Vagrant with Minikube
+- [`50ec2a2`](https://github.com/deis/workflow-e2e/commit/50ec2a2e60ea457740b3aa9ce4b762b02a005ae8) (workflow-e2e) - tests: update tests for new registration mode default
 
 #### Fixes
 
-- [`9a2a1b4`](https://github.com/deisthree/builder/commit/9a2a1b4ae6cb0d64b7d2af5b27d430a388a17098) (builder) - ingress: Adding newline to builder-service.yaml
-- [`56abf92`](https://github.com/deisthree/builder/commit/56abf9296d68615bb326b309b3c2de74a9b4b91d) (builder) - gitreceive: fix checkForEnv logic
-- [`598f1a1`](https://github.com/deisthree/builder/commit/598f1a1421a56b47a58f30eaaa423d6859b30c00) (builder) - gitreceive/config.go: correct envconfig typo
-- [`1ff9245`](https://github.com/deisthree/builder/commit/1ff92459a2ff325c412f2b92290781b1a4a8b74b) (builder) - builder: truncate slugbuilder and dockerbuilder pod name length
-- [`1156475`](https://github.com/deisthree/controller/commit/115647522fbfbea709f3e3e260719818a4a2d0c1) (controller) - serializers.py: update PROCTYPE_MATCH to disallow uppercase characters (#1261)
-- [`a8002a2`](https://github.com/deisthree/controller/commit/a8002a2172bc37801fc062f9a8a9fb65e50f4be3) (controller) - api: split command arguments by space if entrypoint is not /bin/bash -c (#1264)
-- [`2dce7cd`](https://github.com/deisthree/controller/commit/2dce7cd60dc81938e14fe15560c0aa580b9cc286) (controller) - settings/production: convert "false" to boolean correctly
-- [`2569391`](https://github.com/deisthree/logger/commit/25693914362643340ef35a6eb5eae57b50b6fb75) (logger) - log: fix panic error when building app log message
-- [`a1e3fef`](https://github.com/deisthree/monitor/commit/a1e3fefd39721407d649eb3950bb888e20a10cdd) (monitor) - telegraf: fix(telegraf) ensure off-cluster influxdb url is quoted
-- [`4ac5d56`](https://github.com/deisthree/monitor/commit/4ac5d5669ff120b6db1e7a43551dc50e33cce7cc) (monitor) - influx, grafana: Add logic around pvc storage class
-- [`49a81f2`](https://github.com/deisthree/monitor/commit/49a81f2d7bb08a624501e4e769eb1290a41a3258) (monitor) - charts/monitor/values.yaml: add logger_redis_location key/value
-- [`f36f1e9`](https://github.com/deisthree/postgres/commit/f36f1e9a4b59883a1ff074918dc2ceb02617753c) (postgres) - contrib/ci/*: fix scripts
-- [`0d5ad68`](https://github.com/deisthree/registry/commit/0d5ad68581bdf0eea4600991ac19883b35a8a583) (registry) - charts: Set sessionAffinity in registry service
-- [`6771695`](https://github.com/deisthree/registry-token-refresher/commit/6771695b3b1d6e201b9d40914f6c644e4809d457) (registry-token-refresher) - travis.yml: declare env vars on one line
-- [`5f33f36`](https://github.com/deisthree/workflow/commit/5f33f3663f26ef60d609368036c7ed637d5c5d59) (workflow) - managing-app-lifecycle: fix missing hyperlink
-- [`91e7f76`](https://github.com/deisthree/workflow/commit/91e7f761f8577c32cfbd237afff19d70f1268dcc) (workflow) - tuning-component-settings: convert toml to yaml
-- [`e20215b`](https://github.com/deisthree/workflow/commit/e20215b67a4a009c06a1fb65d7fd720a3ca564ee) (workflow) - ingress: Documentation touch ups
-- [`dfdf7af`](https://github.com/deisthree/workflow-cli/commit/dfdf7afd64faf5432307be22897265914548effb) (workflow-cli) - cmd: check for invalid probe types
-- [`140ded9`](https://github.com/deisthree/workflow-e2e/commit/140ded9b62d926890892cac91c3518f790966f55) (workflow-e2e) - tests/auth: no interactive register for admin
+- [`9a2a1b4`](https://github.com/deis/builder/commit/9a2a1b4ae6cb0d64b7d2af5b27d430a388a17098) (builder) - ingress: Adding newline to builder-service.yaml
+- [`56abf92`](https://github.com/deis/builder/commit/56abf9296d68615bb326b309b3c2de74a9b4b91d) (builder) - gitreceive: fix checkForEnv logic
+- [`598f1a1`](https://github.com/deis/builder/commit/598f1a1421a56b47a58f30eaaa423d6859b30c00) (builder) - gitreceive/config.go: correct envconfig typo
+- [`1ff9245`](https://github.com/deis/builder/commit/1ff92459a2ff325c412f2b92290781b1a4a8b74b) (builder) - builder: truncate slugbuilder and dockerbuilder pod name length
+- [`1156475`](https://github.com/deis/controller/commit/115647522fbfbea709f3e3e260719818a4a2d0c1) (controller) - serializers.py: update PROCTYPE_MATCH to disallow uppercase characters (#1261)
+- [`a8002a2`](https://github.com/deis/controller/commit/a8002a2172bc37801fc062f9a8a9fb65e50f4be3) (controller) - api: split command arguments by space if entrypoint is not /bin/bash -c (#1264)
+- [`2dce7cd`](https://github.com/deis/controller/commit/2dce7cd60dc81938e14fe15560c0aa580b9cc286) (controller) - settings/production: convert "false" to boolean correctly
+- [`2569391`](https://github.com/deis/logger/commit/25693914362643340ef35a6eb5eae57b50b6fb75) (logger) - log: fix panic error when building app log message
+- [`a1e3fef`](https://github.com/deis/monitor/commit/a1e3fefd39721407d649eb3950bb888e20a10cdd) (monitor) - telegraf: fix(telegraf) ensure off-cluster influxdb url is quoted
+- [`4ac5d56`](https://github.com/deis/monitor/commit/4ac5d5669ff120b6db1e7a43551dc50e33cce7cc) (monitor) - influx, grafana: Add logic around pvc storage class
+- [`49a81f2`](https://github.com/deis/monitor/commit/49a81f2d7bb08a624501e4e769eb1290a41a3258) (monitor) - charts/monitor/values.yaml: add logger_redis_location key/value
+- [`f36f1e9`](https://github.com/deis/postgres/commit/f36f1e9a4b59883a1ff074918dc2ceb02617753c) (postgres) - contrib/ci/*: fix scripts
+- [`0d5ad68`](https://github.com/deis/registry/commit/0d5ad68581bdf0eea4600991ac19883b35a8a583) (registry) - charts: Set sessionAffinity in registry service
+- [`6771695`](https://github.com/deis/registry-token-refresher/commit/6771695b3b1d6e201b9d40914f6c644e4809d457) (registry-token-refresher) - travis.yml: declare env vars on one line
+- [`5f33f36`](https://github.com/deis/workflow/commit/5f33f3663f26ef60d609368036c7ed637d5c5d59) (workflow) - managing-app-lifecycle: fix missing hyperlink
+- [`91e7f76`](https://github.com/deis/workflow/commit/91e7f761f8577c32cfbd237afff19d70f1268dcc) (workflow) - tuning-component-settings: convert toml to yaml
+- [`e20215b`](https://github.com/deis/workflow/commit/e20215b67a4a009c06a1fb65d7fd720a3ca564ee) (workflow) - ingress: Documentation touch ups
+- [`dfdf7af`](https://github.com/deis/workflow-cli/commit/dfdf7afd64faf5432307be22897265914548effb) (workflow-cli) - cmd: check for invalid probe types
+- [`140ded9`](https://github.com/deis/workflow-e2e/commit/140ded9b62d926890892cac91c3518f790966f55) (workflow-e2e) - tests/auth: no interactive register for admin
 
 #### Documentation
 
-- [`cd016e9`](https://github.com/deisthree/controller/commit/cd016e99fed5d932995077f22dbd263088e98b64) (controller) - api,scheduler: fix "timeout" typos
-- [`03a3e4c`](https://github.com/deisthree/monitor/commit/03a3e4c47d1a5f24c92b34dc77729cbb9edbb826) (monitor) - README.md: add build badge
-- [`f0e1016`](https://github.com/deisthree/nsq/commit/f0e10166cd7d2862f44a528959189dd8b6c4a55f) (nsq) - README.md: add build badge
-- [`3a99656`](https://github.com/deisthree/workflow/commit/3a99656b5adce13d7e88c56f37b947780d0f7bc2) (workflow) - upgrading-workflow: mention helm repo update
-- [`916f200`](https://github.com/deisthree/workflow/commit/916f200b2390fdf9ee3809829253a84a2f1497ba) (workflow) - builder-nodeselector: add BUILDER_POD_NODE_SELECTOR document
-- [`32a1493`](https://github.com/deisthree/workflow/commit/32a1493b31dc4ff516f47f9910e1a2c35f7ad3cd) (workflow) - builder-nodeselector: correct grammar
-- [`fdf76e4`](https://github.com/deisthree/workflow/commit/fdf76e4f3c3d12a04f8be42f5031f0e624c77a60) (workflow) - managing-app-processes.md: update proc type naming guidelines (#769)
-- [`3df978c`](https://github.com/deisthree/workflow/commit/3df978cb879dfd7ec3151a6809a091f6c6fb002f) (workflow) - managing-app-configuration: update "kubernetes-probes" link
-- [`722795b`](https://github.com/deisthree/workflow/commit/722795b86cfceafc796a0fb2b9c6d3b6267f018c) (workflow) - configuring-load-balancers.md: mention forthcoming default (#768)
-- [`8980c62`](https://github.com/deisthree/workflow/commit/8980c62ebb459d50cbab25879829049c2a8f7605) (workflow) - src/applications/inter-app-communication.md: docs(src/applications/inter-app-communication.md) Add first draft
-- [`cc02dcd`](https://github.com/deisthree/workflow/commit/cc02dcd2e7c2be3791729dc13b9a11df0f2fd98a) (workflow) - configuring-registry.md: add examples (#779)
-- [`dc43777`](https://github.com/deisthree/workflow/commit/dc43777d42c23837b88db83b16a01b79bf7f9661) (workflow) - installing-workflow/index.md: update get pods output (#777)
+- [`cd016e9`](https://github.com/deis/controller/commit/cd016e99fed5d932995077f22dbd263088e98b64) (controller) - api,scheduler: fix "timeout" typos
+- [`03a3e4c`](https://github.com/deis/monitor/commit/03a3e4c47d1a5f24c92b34dc77729cbb9edbb826) (monitor) - README.md: add build badge
+- [`f0e1016`](https://github.com/deis/nsq/commit/f0e10166cd7d2862f44a528959189dd8b6c4a55f) (nsq) - README.md: add build badge
+- [`3a99656`](https://github.com/deis/workflow/commit/3a99656b5adce13d7e88c56f37b947780d0f7bc2) (workflow) - upgrading-workflow: mention helm repo update
+- [`916f200`](https://github.com/deis/workflow/commit/916f200b2390fdf9ee3809829253a84a2f1497ba) (workflow) - builder-nodeselector: add BUILDER_POD_NODE_SELECTOR document
+- [`32a1493`](https://github.com/deis/workflow/commit/32a1493b31dc4ff516f47f9910e1a2c35f7ad3cd) (workflow) - builder-nodeselector: correct grammar
+- [`fdf76e4`](https://github.com/deis/workflow/commit/fdf76e4f3c3d12a04f8be42f5031f0e624c77a60) (workflow) - managing-app-processes.md: update proc type naming guidelines (#769)
+- [`3df978c`](https://github.com/deis/workflow/commit/3df978cb879dfd7ec3151a6809a091f6c6fb002f) (workflow) - managing-app-configuration: update "kubernetes-probes" link
+- [`722795b`](https://github.com/deis/workflow/commit/722795b86cfceafc796a0fb2b9c6d3b6267f018c) (workflow) - configuring-load-balancers.md: mention forthcoming default (#768)
+- [`8980c62`](https://github.com/deis/workflow/commit/8980c62ebb459d50cbab25879829049c2a8f7605) (workflow) - src/applications/inter-app-communication.md: docs(src/applications/inter-app-communication.md) Add first draft
+- [`cc02dcd`](https://github.com/deis/workflow/commit/cc02dcd2e7c2be3791729dc13b9a11df0f2fd98a) (workflow) - configuring-registry.md: add examples (#779)
+- [`dc43777`](https://github.com/deis/workflow/commit/dc43777d42c23837b88db83b16a01b79bf7f9661) (workflow) - installing-workflow/index.md: update get pods output (#777)
 
 #### Maintenance
 
-- [`703c249`](https://github.com/deisthree/controller/commit/703c249880d020ae85ace976cd7626bfa41e963c) (controller) - requirements: update idna to 2.4
-- [`2224594`](https://github.com/deisthree/controller/commit/22245942633e23cd28157a71cf8f3ae6fff4eefe) (controller) - requirements: update psycopg2 to 2.7
-- [`1aed9e2`](https://github.com/deisthree/controller/commit/1aed9e2c5be9495a88376cea12bed6c632e8dbf7) (controller) - requirements: update jsonfield to 2.0.0
-- [`49ec35d`](https://github.com/deisthree/controller/commit/49ec35dce691e35bece374a5e26a8c5337f3c4c6) (controller) - requirements: update Django to 1.10.6
-- [`8d6126a`](https://github.com/deisthree/controller/commit/8d6126a4677744d37a4d77554297590fb16db95a) (controller) - requirements: update gunicorn to 19.7.0
-- [`2d071f4`](https://github.com/deisthree/controller/commit/2d071f4a8851c11b6bbbf81e80d4560a501056a9) (controller) - requirements: update idna to 2.5
-- [`53d34de`](https://github.com/deisthree/controller/commit/53d34deff101212eba98f7ed16ba9a1695eea61e) (controller) - requirements: update jsonfield to 2.0.1
-- [`0274973`](https://github.com/deisthree/controller/commit/027497363aea6e9114a237ca914054abb4a6368d) (controller) - rootfs/requirements.txt: add pyasn1
-- [`fcae228`](https://github.com/deisthree/controller/commit/fcae2286c7a344c1d0391801bc9c5029d58b9004) (controller) - requirements: update django-auth-ldap to 1.2.10
-- [`74372a5`](https://github.com/deisthree/controller/commit/74372a5dcdb53cedf111c483f6d3fc3b26c3c466) (controller) - requirements: update jmespath to 0.9.2
-- [`530256c`](https://github.com/deisthree/controller/commit/530256cc1e7788599a989011dce319bc7a0302dc) (controller) - requirements: update djangorestframework to 3.6.2
-- [`f01b846`](https://github.com/deisthree/controller/commit/f01b84665b39c9b32c5180f2fe884b8652eab3e6) (controller) - requirements: update psycopg2 to 2.7.1
-- [`429a645`](https://github.com/deisthree/controller/commit/429a645073baa9c5ecea029c5479d8741655d918) (controller) - requirements: update gunicorn to 19.7.1
-- [`0caeb81`](https://github.com/deisthree/controller/commit/0caeb817be2920770793c0ff011ceb33ea0c6999) (controller) - Makefile: remove broken "test-unit-quick" target
-- [`e8e6f58`](https://github.com/deisthree/controller/commit/e8e6f5848008068325df2d80cf190f23a73a05d6) (controller) - dev_requirements: use deis/requests-mock fork
-- [`7713ff3`](https://github.com/deisthree/postgres/commit/7713ff32d63c877f7fd166d44e6e986a079f2faf) (postgres) - Makefile: remove test-unit target
-- [`66b9f1c`](https://github.com/deisthree/registry/commit/66b9f1cef0b3650c9c5ba38904a6e183098d9b8c) (registry) - Dockerfile: bump registry to v2.6.0
-- [`a795d72`](https://github.com/deisthree/router/commit/a795d722362fc5b280942ca620d9695604488f09) (router) - ingress: Experimental Native Ingress
-- [`bece9d5`](https://github.com/deisthree/router/commit/bece9d53ff91d844b8123b3b22e62c12d5137a05) (router) - ingress: Experimental Native Ingress
-- [`ea4a68c`](https://github.com/deisthree/router/commit/ea4a68c0bf1b13a3618eeab7bcee4d7c75cb9687) (router) - nginx: update nginx to 1.11.10
-- [`be3029c`](https://github.com/deisthree/slugbuilder/commit/be3029cfe36c944273685ac415479cb200a72f74) (slugbuilder) - buildpacks: update heroku-buildpack-python to v102
-- [`d802b84`](https://github.com/deisthree/slugbuilder/commit/d802b84b32f57e933a6cf230ddf8b87a06418672) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v155
-- [`17cddde`](https://github.com/deisthree/workflow/commit/17cddde9c0214d769daac300bd49d13023f5b95d) (workflow) - ingress: Remove extra spaces
-- [`21fe9f9`](https://github.com/deisthree/workflow/commit/21fe9f9882758699368329d0c759d6d9566d47c6) (workflow) - ingress: Fix example usage in docs to match new YAML
-- [`33a6251`](https://github.com/deisthree/workflow/commit/33a625157c3e4291673a3f1f4fa57845541f1baa) (workflow) - ingress: Fix typo
-- [`9f5bcea`](https://github.com/deisthree/workflow/commit/9f5bcea949c5c3633463bd07c8a50276592530b8) (workflow) - ingress: Revert to using if statements in router
-- [`b8e404c`](https://github.com/deisthree/workflow/commit/b8e404cdc4e67f59fe1b4aa9fe1fa67a78e169b8) (workflow) - ingress: Documentation updates from code review
-- [`dcac309`](https://github.com/deisthree/workflow/commit/dcac30904d95f0e75d7d25e30b6c41f15da3b324) (workflow) - ingress: Typo in `experimental`
-- [`5d4866d`](https://github.com/deisthree/workflow/commit/5d4866df7737366d80b1a0b994f71cfc5b451c5c) (workflow) - upgrade: Upgrade kops to 1.5.3
-- [`3e09799`](https://github.com/deisthree/workflow-e2e/commit/3e097995a7b97e45d1d10e39926c01ce3cc43d69) (workflow-e2e) - README.md: update build status badge
+- [`703c249`](https://github.com/deis/controller/commit/703c249880d020ae85ace976cd7626bfa41e963c) (controller) - requirements: update idna to 2.4
+- [`2224594`](https://github.com/deis/controller/commit/22245942633e23cd28157a71cf8f3ae6fff4eefe) (controller) - requirements: update psycopg2 to 2.7
+- [`1aed9e2`](https://github.com/deis/controller/commit/1aed9e2c5be9495a88376cea12bed6c632e8dbf7) (controller) - requirements: update jsonfield to 2.0.0
+- [`49ec35d`](https://github.com/deis/controller/commit/49ec35dce691e35bece374a5e26a8c5337f3c4c6) (controller) - requirements: update Django to 1.10.6
+- [`8d6126a`](https://github.com/deis/controller/commit/8d6126a4677744d37a4d77554297590fb16db95a) (controller) - requirements: update gunicorn to 19.7.0
+- [`2d071f4`](https://github.com/deis/controller/commit/2d071f4a8851c11b6bbbf81e80d4560a501056a9) (controller) - requirements: update idna to 2.5
+- [`53d34de`](https://github.com/deis/controller/commit/53d34deff101212eba98f7ed16ba9a1695eea61e) (controller) - requirements: update jsonfield to 2.0.1
+- [`0274973`](https://github.com/deis/controller/commit/027497363aea6e9114a237ca914054abb4a6368d) (controller) - rootfs/requirements.txt: add pyasn1
+- [`fcae228`](https://github.com/deis/controller/commit/fcae2286c7a344c1d0391801bc9c5029d58b9004) (controller) - requirements: update django-auth-ldap to 1.2.10
+- [`74372a5`](https://github.com/deis/controller/commit/74372a5dcdb53cedf111c483f6d3fc3b26c3c466) (controller) - requirements: update jmespath to 0.9.2
+- [`530256c`](https://github.com/deis/controller/commit/530256cc1e7788599a989011dce319bc7a0302dc) (controller) - requirements: update djangorestframework to 3.6.2
+- [`f01b846`](https://github.com/deis/controller/commit/f01b84665b39c9b32c5180f2fe884b8652eab3e6) (controller) - requirements: update psycopg2 to 2.7.1
+- [`429a645`](https://github.com/deis/controller/commit/429a645073baa9c5ecea029c5479d8741655d918) (controller) - requirements: update gunicorn to 19.7.1
+- [`0caeb81`](https://github.com/deis/controller/commit/0caeb817be2920770793c0ff011ceb33ea0c6999) (controller) - Makefile: remove broken "test-unit-quick" target
+- [`e8e6f58`](https://github.com/deis/controller/commit/e8e6f5848008068325df2d80cf190f23a73a05d6) (controller) - dev_requirements: use deis/requests-mock fork
+- [`7713ff3`](https://github.com/deis/postgres/commit/7713ff32d63c877f7fd166d44e6e986a079f2faf) (postgres) - Makefile: remove test-unit target
+- [`66b9f1c`](https://github.com/deis/registry/commit/66b9f1cef0b3650c9c5ba38904a6e183098d9b8c) (registry) - Dockerfile: bump registry to v2.6.0
+- [`a795d72`](https://github.com/deis/router/commit/a795d722362fc5b280942ca620d9695604488f09) (router) - ingress: Experimental Native Ingress
+- [`bece9d5`](https://github.com/deis/router/commit/bece9d53ff91d844b8123b3b22e62c12d5137a05) (router) - ingress: Experimental Native Ingress
+- [`ea4a68c`](https://github.com/deis/router/commit/ea4a68c0bf1b13a3618eeab7bcee4d7c75cb9687) (router) - nginx: update nginx to 1.11.10
+- [`be3029c`](https://github.com/deis/slugbuilder/commit/be3029cfe36c944273685ac415479cb200a72f74) (slugbuilder) - buildpacks: update heroku-buildpack-python to v102
+- [`d802b84`](https://github.com/deis/slugbuilder/commit/d802b84b32f57e933a6cf230ddf8b87a06418672) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v155
+- [`17cddde`](https://github.com/deis/workflow/commit/17cddde9c0214d769daac300bd49d13023f5b95d) (workflow) - ingress: Remove extra spaces
+- [`21fe9f9`](https://github.com/deis/workflow/commit/21fe9f9882758699368329d0c759d6d9566d47c6) (workflow) - ingress: Fix example usage in docs to match new YAML
+- [`33a6251`](https://github.com/deis/workflow/commit/33a625157c3e4291673a3f1f4fa57845541f1baa) (workflow) - ingress: Fix typo
+- [`9f5bcea`](https://github.com/deis/workflow/commit/9f5bcea949c5c3633463bd07c8a50276592530b8) (workflow) - ingress: Revert to using if statements in router
+- [`b8e404c`](https://github.com/deis/workflow/commit/b8e404cdc4e67f59fe1b4aa9fe1fa67a78e169b8) (workflow) - ingress: Documentation updates from code review
+- [`dcac309`](https://github.com/deis/workflow/commit/dcac30904d95f0e75d7d25e30b6c41f15da3b324) (workflow) - ingress: Typo in `experimental`
+- [`5d4866d`](https://github.com/deis/workflow/commit/5d4866df7737366d80b1a0b994f71cfc5b451c5c) (workflow) - upgrade: Upgrade kops to 1.5.3
+- [`3e09799`](https://github.com/deis/workflow-e2e/commit/3e097995a7b97e45d1d10e39926c01ce3cc43d69) (workflow-e2e) - README.md: update build status badge

--- a/src/changelogs/v2.14.0.md
+++ b/src/changelogs/v2.14.0.md
@@ -15,62 +15,62 @@
 
 #### Features
 
-- [`c515df3`](https://github.com/deisthree/fluentd/commit/c515df308bc929e0366b6a2bd05813a506c1cdad) (fluentd) - chart: Extend values.yaml file
-- [`af04466`](https://github.com/deisthree/monitor/commit/af0446621a890bf279f0f96b8709a8b70ebd12eb) (monitor) - grafana: Allow users to set signup flag in chart
-- [`a8c0fa7`](https://github.com/deisthree/registry-proxy/commit/a8c0fa7f5db60dffa4b2fb8aa826466d6d8a2ce5) (registry-proxy) - Makefile: set docker build flags via environment variable
-- [`292a3d4`](https://github.com/deisthree/workflow/commit/292a3d4864c797812a24160c1d089c6fa40be060) (workflow) - ingress: document deis-builder DNS records
-- [`3750f53`](https://github.com/deisthree/workflow-e2e/commit/3750f53aebc4a3eb6001dc967ece26cc7aa747ec) (workflow-e2e) - Makefile: add test target
+- [`c515df3`](https://github.com/deis/fluentd/commit/c515df308bc929e0366b6a2bd05813a506c1cdad) (fluentd) - chart: Extend values.yaml file
+- [`af04466`](https://github.com/deis/monitor/commit/af0446621a890bf279f0f96b8709a8b70ebd12eb) (monitor) - grafana: Allow users to set signup flag in chart
+- [`a8c0fa7`](https://github.com/deis/registry-proxy/commit/a8c0fa7f5db60dffa4b2fb8aa826466d6d8a2ce5) (registry-proxy) - Makefile: set docker build flags via environment variable
+- [`292a3d4`](https://github.com/deis/workflow/commit/292a3d4864c797812a24160c1d089c6fa40be060) (workflow) - ingress: document deis-builder DNS records
+- [`3750f53`](https://github.com/deis/workflow-e2e/commit/3750f53aebc4a3eb6001dc967ece26cc7aa747ec) (workflow-e2e) - Makefile: add test target
 
 #### Refactors
 
-- [`08f4c69`](https://github.com/deisthree/controller/commit/08f4c690d951f720b4152d8be1941296f430d3c1) (controller) - ci: remove travis, update build status (#1287)
-- [`59cce25`](https://github.com/deisthree/fluentd/commit/59cce25ada66ca7d549bdd8e5de9f7cd7952bbeb) (fluentd) - README: update link to deis graphic
-- [`6b7d85a`](https://github.com/deisthree/fluentd/commit/6b7d85a42369cc23b21eb6422cad794c15627911) (fluentd) - makefile: Update makefile to work with new chart structure
-- [`d59bedc`](https://github.com/deisthree/fluentd/commit/d59bedc58884eb77070b848b32b43d01270e8092) (fluentd) - ci: remove _scripts; add badge
-- [`0fcea4f`](https://github.com/deisthree/monitor/commit/0fcea4f07aef369b1fdb88b5586ac8ec17f13066) (monitor) - _scripts: remove unused scripts
-- [`511fa8c`](https://github.com/deisthree/redis/commit/511fa8c6111096e406a4eb64ed20e943c5866084) (redis) - README: switch to wabs container
-- [`5c7624c`](https://github.com/deisthree/redis/commit/5c7624ceb4c02a841de6bf89e0e43d5b0c6c7480) (redis) - ci: remove travis; add badge
-- [`cea7734`](https://github.com/deisthree/router/commit/cea7734ebe2c7c7d6570497d9d2be5a453fc787c) (router) - ci: remove travis; add badge
-- [`e8de27c`](https://github.com/deisthree/slugbuilder/commit/e8de27cae818c9a45cc322a34f24ea74bee44a1d) (slugbuilder) - ci: remove travis; update badge
-- [`bd0b1d9`](https://github.com/deisthree/workflow/commit/bd0b1d955ae5c102ade03a141dab1351b7d79ed0) (workflow) - azure/boot: export AZURE_DNS_PREFIX and use $HOME
-- [`8526e49`](https://github.com/deisthree/workflow/commit/8526e49c903112c971636d7c88174f09aeea49ac) (workflow) - ci: rm travis and unused scripts (#803)
-- [`008615a`](https://github.com/deisthree/workflow-cli/commit/008615abe0a336be0d74f0185f0771938ee401fd) (workflow-cli) - Jenkinsfile: disable win agent
-- [`50ec2a2`](https://github.com/deisthree/workflow-e2e/commit/50ec2a2e60ea457740b3aa9ce4b762b02a005ae8) (workflow-e2e) - tests: update tests for new registration mode default
+- [`08f4c69`](https://github.com/deis/controller/commit/08f4c690d951f720b4152d8be1941296f430d3c1) (controller) - ci: remove travis, update build status (#1287)
+- [`59cce25`](https://github.com/deis/fluentd/commit/59cce25ada66ca7d549bdd8e5de9f7cd7952bbeb) (fluentd) - README: update link to deis graphic
+- [`6b7d85a`](https://github.com/deis/fluentd/commit/6b7d85a42369cc23b21eb6422cad794c15627911) (fluentd) - makefile: Update makefile to work with new chart structure
+- [`d59bedc`](https://github.com/deis/fluentd/commit/d59bedc58884eb77070b848b32b43d01270e8092) (fluentd) - ci: remove _scripts; add badge
+- [`0fcea4f`](https://github.com/deis/monitor/commit/0fcea4f07aef369b1fdb88b5586ac8ec17f13066) (monitor) - _scripts: remove unused scripts
+- [`511fa8c`](https://github.com/deis/redis/commit/511fa8c6111096e406a4eb64ed20e943c5866084) (redis) - README: switch to wabs container
+- [`5c7624c`](https://github.com/deis/redis/commit/5c7624ceb4c02a841de6bf89e0e43d5b0c6c7480) (redis) - ci: remove travis; add badge
+- [`cea7734`](https://github.com/deis/router/commit/cea7734ebe2c7c7d6570497d9d2be5a453fc787c) (router) - ci: remove travis; add badge
+- [`e8de27c`](https://github.com/deis/slugbuilder/commit/e8de27cae818c9a45cc322a34f24ea74bee44a1d) (slugbuilder) - ci: remove travis; update badge
+- [`bd0b1d9`](https://github.com/deis/workflow/commit/bd0b1d955ae5c102ade03a141dab1351b7d79ed0) (workflow) - azure/boot: export AZURE_DNS_PREFIX and use $HOME
+- [`8526e49`](https://github.com/deis/workflow/commit/8526e49c903112c971636d7c88174f09aeea49ac) (workflow) - ci: rm travis and unused scripts (#803)
+- [`008615a`](https://github.com/deis/workflow-cli/commit/008615abe0a336be0d74f0185f0771938ee401fd) (workflow-cli) - Jenkinsfile: disable win agent
+- [`50ec2a2`](https://github.com/deis/workflow-e2e/commit/50ec2a2e60ea457740b3aa9ce4b762b02a005ae8) (workflow-e2e) - tests: update tests for new registration mode default
 
 #### Fixes
 
-- [`960e899`](https://github.com/deisthree/controller/commit/960e89926e5021a6b62041dbe1fd6f8fce64bd8c) (controller) - ingress-test: Fixing make test-style
-- [`a9674a3`](https://github.com/deisthree/fluentd/commit/a9674a30904d85e4c85566644f5bb85d49e744d5) (fluentd) - charts: fix(charts) add quote around daemon_environment value
-- [`73effea`](https://github.com/deisthree/monitor/commit/73effead23c0fba26551b1e8e21597bbdb2296bf) (monitor) - telegraf/rootfs/start-telegraf: address shellcheck/style err
-- [`76134f7`](https://github.com/deisthree/redis/commit/76134f744bcdf1a4dc2d6dbaf80154b50f39eb7b) (redis) - rootfs/Dockerfile: force gunzip of copyright archive
-- [`e559768`](https://github.com/deisthree/router/commit/e5597683a18c0167ea044ba9d590edd46fc5ac43) (router) - charts: remove b64enc from dhparam
-- [`05866f6`](https://github.com/deisthree/workflow/commit/05866f620a6aed0ba548171cda1aa976ffc23121) (workflow) - hostname: Fixing hostname line
-- [`140ded9`](https://github.com/deisthree/workflow-e2e/commit/140ded9b62d926890892cac91c3518f790966f55) (workflow-e2e) - tests/auth: no interactive register for admin
+- [`960e899`](https://github.com/deis/controller/commit/960e89926e5021a6b62041dbe1fd6f8fce64bd8c) (controller) - ingress-test: Fixing make test-style
+- [`a9674a3`](https://github.com/deis/fluentd/commit/a9674a30904d85e4c85566644f5bb85d49e744d5) (fluentd) - charts: fix(charts) add quote around daemon_environment value
+- [`73effea`](https://github.com/deis/monitor/commit/73effead23c0fba26551b1e8e21597bbdb2296bf) (monitor) - telegraf/rootfs/start-telegraf: address shellcheck/style err
+- [`76134f7`](https://github.com/deis/redis/commit/76134f744bcdf1a4dc2d6dbaf80154b50f39eb7b) (redis) - rootfs/Dockerfile: force gunzip of copyright archive
+- [`e559768`](https://github.com/deis/router/commit/e5597683a18c0167ea044ba9d590edd46fc5ac43) (router) - charts: remove b64enc from dhparam
+- [`05866f6`](https://github.com/deis/workflow/commit/05866f620a6aed0ba548171cda1aa976ffc23121) (workflow) - hostname: Fixing hostname line
+- [`140ded9`](https://github.com/deis/workflow-e2e/commit/140ded9b62d926890892cac91c3518f790966f55) (workflow-e2e) - tests/auth: no interactive register for admin
 
 #### Documentation
 
-- [`32cd737`](https://github.com/deisthree/controller/commit/32cd7379f711b1f7a09f9b7480de500573769e48) (controller) - api: update doc pointers for Django 1.11
-- [`7d2c0ba`](https://github.com/deisthree/controller/commit/7d2c0badf19af7e11c551e274944622d616ab942) (controller) - README: remove old testing prerequisites
-- [`addf549`](https://github.com/deisthree/workflow/commit/addf5496036ac7820222fb3ae2b80adf975eaffc) (workflow) - gke/boot: Add info on obtaining credentials
-- [`29a86b0`](https://github.com/deisthree/workflow/commit/29a86b0ba41ac1b2e09f64f8b1a47a303901ca9f) (workflow) - system-requirements: warn users away from broken k8s versions
-- [`8c223b5`](https://github.com/deisthree/workflow/commit/8c223b547638723691184a8b6f63a9b17fcc6fef) (workflow) - platform-logging: Add section on custom fluentd plugins
-- [`218985f`](https://github.com/deisthree/workflow/commit/218985f97a5b912df987dfec550b901ca21d186b) (workflow) - monitoring: Update docs to reflect monitor chart changes
+- [`32cd737`](https://github.com/deis/controller/commit/32cd7379f711b1f7a09f9b7480de500573769e48) (controller) - api: update doc pointers for Django 1.11
+- [`7d2c0ba`](https://github.com/deis/controller/commit/7d2c0badf19af7e11c551e274944622d616ab942) (controller) - README: remove old testing prerequisites
+- [`addf549`](https://github.com/deis/workflow/commit/addf5496036ac7820222fb3ae2b80adf975eaffc) (workflow) - gke/boot: Add info on obtaining credentials
+- [`29a86b0`](https://github.com/deis/workflow/commit/29a86b0ba41ac1b2e09f64f8b1a47a303901ca9f) (workflow) - system-requirements: warn users away from broken k8s versions
+- [`8c223b5`](https://github.com/deis/workflow/commit/8c223b547638723691184a8b6f63a9b17fcc6fef) (workflow) - platform-logging: Add section on custom fluentd plugins
+- [`218985f`](https://github.com/deis/workflow/commit/218985f97a5b912df987dfec550b901ca21d186b) (workflow) - monitoring: Update docs to reflect monitor chart changes
 
 #### Maintenance
 
-- [`1f93f21`](https://github.com/deisthree/controller/commit/1f93f21c4d80e51bae363d48a1a8325b6fa68720) (controller) - requirements: update Django to 1.11 LTS
-- [`88846bf`](https://github.com/deisthree/controller/commit/88846bfaa00d36314afee31ec42e38ee5de34e47) (controller) - requirements: update pytz to 2017.2
-- [`99061ff`](https://github.com/deisthree/controller/commit/99061ffb19a545132f61db596e63f069b7d9748a) (controller) - requirements: update django-guardian to v1.4.8
-- [`49e741e`](https://github.com/deisthree/controller/commit/49e741e61ddec46cdbebeb778a9df89fe143ec97) (controller) - ingress: Adding unit tests
-- [`88bfcbd`](https://github.com/deisthree/controller/commit/88bfcbd4c980b52fd43602bb4c9fd5c7e87ab656) (controller) - requirements: update pyOpenSSL to v17.0.0
-- [`7a9c3e6`](https://github.com/deisthree/controller/commit/7a9c3e60c06f3651946e512e2f0782b7f62687cd) (controller) - dev_requirements: update codecov to v2.0.9
-- [`8ed937d`](https://github.com/deisthree/controller/commit/8ed937dd5eeaecbc6a04d0549e7e02d8f28f670b) (controller) - requirements: update django-auth-ldap to v1.2.11
-- [`51ac827`](https://github.com/deisthree/controller/commit/51ac82707c7bb9968fc39e9d8c70f9c0abb01a68) (controller) - requirements: update backoff library to v1.4.2
-- [`b8560e0`](https://github.com/deisthree/router/commit/b8560e048c554792db4955186eb9048ecc626b9b) (router) - Dockerfile: update nginx to 1.11.13
-- [`21aa475`](https://github.com/deisthree/router/commit/21aa475bfbdc76f9b5acbfb7ed4b71e1673ec973) (router) - Dockerfile: update nginx to 1.12.0 stable
-- [`2f7705c`](https://github.com/deisthree/router/commit/2f7705c6dc647270b9416176f5fc8e62dba749ab) (router) - Dockerfile: update nginx to 1.13.0
-- [`4a802e4`](https://github.com/deisthree/slugbuilder/commit/4a802e4b8f52ee84b40a026224805690845257e7) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v101
-- [`fb567ac`](https://github.com/deisthree/slugbuilder/commit/fb567ace7f646c53dcb3515700441324e7b37f3f) (slugbuilder) - buildpacks: update heroku-buildpack-go to v64
-- [`3c14ac2`](https://github.com/deisthree/slugbuilder/commit/3c14ac2ede6a8bf6ae611a1b75f872048a464443) (slugbuilder) - buildpacks: update heroku-buildpack-php to v121
-- [`32de3c1`](https://github.com/deisthree/slugbuilder/commit/32de3c1cc598801eda8cd8bc6365d9ac82a69ed9) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v159
-- [`3e09799`](https://github.com/deisthree/workflow-e2e/commit/3e097995a7b97e45d1d10e39926c01ce3cc43d69) (workflow-e2e) - README.md: update build status badge
+- [`1f93f21`](https://github.com/deis/controller/commit/1f93f21c4d80e51bae363d48a1a8325b6fa68720) (controller) - requirements: update Django to 1.11 LTS
+- [`88846bf`](https://github.com/deis/controller/commit/88846bfaa00d36314afee31ec42e38ee5de34e47) (controller) - requirements: update pytz to 2017.2
+- [`99061ff`](https://github.com/deis/controller/commit/99061ffb19a545132f61db596e63f069b7d9748a) (controller) - requirements: update django-guardian to v1.4.8
+- [`49e741e`](https://github.com/deis/controller/commit/49e741e61ddec46cdbebeb778a9df89fe143ec97) (controller) - ingress: Adding unit tests
+- [`88bfcbd`](https://github.com/deis/controller/commit/88bfcbd4c980b52fd43602bb4c9fd5c7e87ab656) (controller) - requirements: update pyOpenSSL to v17.0.0
+- [`7a9c3e6`](https://github.com/deis/controller/commit/7a9c3e60c06f3651946e512e2f0782b7f62687cd) (controller) - dev_requirements: update codecov to v2.0.9
+- [`8ed937d`](https://github.com/deis/controller/commit/8ed937dd5eeaecbc6a04d0549e7e02d8f28f670b) (controller) - requirements: update django-auth-ldap to v1.2.11
+- [`51ac827`](https://github.com/deis/controller/commit/51ac82707c7bb9968fc39e9d8c70f9c0abb01a68) (controller) - requirements: update backoff library to v1.4.2
+- [`b8560e0`](https://github.com/deis/router/commit/b8560e048c554792db4955186eb9048ecc626b9b) (router) - Dockerfile: update nginx to 1.11.13
+- [`21aa475`](https://github.com/deis/router/commit/21aa475bfbdc76f9b5acbfb7ed4b71e1673ec973) (router) - Dockerfile: update nginx to 1.12.0 stable
+- [`2f7705c`](https://github.com/deis/router/commit/2f7705c6dc647270b9416176f5fc8e62dba749ab) (router) - Dockerfile: update nginx to 1.13.0
+- [`4a802e4`](https://github.com/deis/slugbuilder/commit/4a802e4b8f52ee84b40a026224805690845257e7) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v101
+- [`fb567ac`](https://github.com/deis/slugbuilder/commit/fb567ace7f646c53dcb3515700441324e7b37f3f) (slugbuilder) - buildpacks: update heroku-buildpack-go to v64
+- [`3c14ac2`](https://github.com/deis/slugbuilder/commit/3c14ac2ede6a8bf6ae611a1b75f872048a464443) (slugbuilder) - buildpacks: update heroku-buildpack-php to v121
+- [`32de3c1`](https://github.com/deis/slugbuilder/commit/32de3c1cc598801eda8cd8bc6365d9ac82a69ed9) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v159
+- [`3e09799`](https://github.com/deis/workflow-e2e/commit/3e097995a7b97e45d1d10e39926c01ce3cc43d69) (workflow-e2e) - README.md: update build status badge

--- a/src/changelogs/v2.15.0.md
+++ b/src/changelogs/v2.15.0.md
@@ -24,72 +24,72 @@
 
 #### Features
 
-- [`c891804`](https://github.com/deisthree/builder/commit/c891804e65e48dbf6180439e9bda4672db3a8798) (builder) - RBAC support
-- [`c321669`](https://github.com/deisthree/controller/commit/c321669acb4130d6350fcf5c8c68fc74c2af89f8) (controller) - RBAC support
-- [`464bbd9`](https://github.com/deisthree/fluentd/commit/464bbd967ad8cc5283a72c72bc65ac0de8609d1a) (fluentd) - RBAC support
-- [`560b73d`](https://github.com/deisthree/fluentd/commit/560b73db575d2392856d7246bc3ab45f1554f882) (fluentd) - fluentd: add gelf plugin
-- [`e655622`](https://github.com/deisthree/fluentd/commit/e65562268ab7f15d656855fce24ccf5e60d5b629) (fluentd) - charts: add rollingUpdate functionality
-- [`ff4058d`](https://github.com/deisthree/monitor/commit/ff4058def1e49451602694bf9aa916f115b0251e) (monitor) - RBAC support
-- [`de49c15`](https://github.com/deisthree/monitor/commit/de49c151883b7edfa0f19601450acdb2bd03a6fc) (monitor) - charts: add rollingUpdate functionality to telegraf daemonset
-- [`ccf1364`](https://github.com/deisthree/monitor/commit/ccf13640fb01581b5a4eb6f1a79f8742dd956a2c) (monitor) - deploy.mk: Add deploy.mk for using the chart to upgrade/install monitor
-- [`c9769fe`](https://github.com/deisthree/router/commit/c9769fea98baefaccba9e65d7b7913de3bc3325f) (router) - RBAC support
-- [`356374f`](https://github.com/deisthree/workflow/commit/356374f616954d51e6775946dce1ae7c0dfcdcfa) (workflow) - RBAC support
-- [`f9c6a4a`](https://github.com/deisthree/workflow-e2e/commit/f9c6a4aa43d990f59e68a0cd40de4f46864584d2) (workflow-e2e) - chart: use upstream stable/spotify-docker-gc chart
+- [`c891804`](https://github.com/deis/builder/commit/c891804e65e48dbf6180439e9bda4672db3a8798) (builder) - RBAC support
+- [`c321669`](https://github.com/deis/controller/commit/c321669acb4130d6350fcf5c8c68fc74c2af89f8) (controller) - RBAC support
+- [`464bbd9`](https://github.com/deis/fluentd/commit/464bbd967ad8cc5283a72c72bc65ac0de8609d1a) (fluentd) - RBAC support
+- [`560b73d`](https://github.com/deis/fluentd/commit/560b73db575d2392856d7246bc3ab45f1554f882) (fluentd) - fluentd: add gelf plugin
+- [`e655622`](https://github.com/deis/fluentd/commit/e65562268ab7f15d656855fce24ccf5e60d5b629) (fluentd) - charts: add rollingUpdate functionality
+- [`ff4058d`](https://github.com/deis/monitor/commit/ff4058def1e49451602694bf9aa916f115b0251e) (monitor) - RBAC support
+- [`de49c15`](https://github.com/deis/monitor/commit/de49c151883b7edfa0f19601450acdb2bd03a6fc) (monitor) - charts: add rollingUpdate functionality to telegraf daemonset
+- [`ccf1364`](https://github.com/deis/monitor/commit/ccf13640fb01581b5a4eb6f1a79f8742dd956a2c) (monitor) - deploy.mk: Add deploy.mk for using the chart to upgrade/install monitor
+- [`c9769fe`](https://github.com/deis/router/commit/c9769fea98baefaccba9e65d7b7913de3bc3325f) (router) - RBAC support
+- [`356374f`](https://github.com/deis/workflow/commit/356374f616954d51e6775946dce1ae7c0dfcdcfa) (workflow) - RBAC support
+- [`f9c6a4a`](https://github.com/deis/workflow-e2e/commit/f9c6a4aa43d990f59e68a0cd40de4f46864584d2) (workflow-e2e) - chart: use upstream stable/spotify-docker-gc chart
 
 #### Refactors
 
-- [`270f168`](https://github.com/deisthree/builder/commit/270f168af6e61630cc5ed16c38e009d7621a16a0) (builder) - ci: remove travis, update build status
-- [`f832ba3`](https://github.com/deisthree/builder/commit/f832ba3504872c999ab7eb8dbcab2ddd51118367) (builder) - LICENSE: switch to MIT license
-- [`9af9322`](https://github.com/deisthree/controller/commit/9af9322d8decaf96871b9f644f75a7732e192928) (controller) - LICENSE: switch to MIT license
-- [`86e3a4a`](https://github.com/deisthree/dockerbuilder/commit/86e3a4a55b9bb153e05d3a5f8da6e9316a06ad7b) (dockerbuilder) - ci: remove travis; update badge
-- [`6eb4387`](https://github.com/deisthree/dockerbuilder/commit/6eb438723d4fcec51a0d46513d1b06fd4dd68f31) (dockerbuilder) - LICENSE: switch to MIT license
-- [`502d8b2`](https://github.com/deisthree/fluentd/commit/502d8b2d861caba30bc9b0c485511bea877244a3) (fluentd) - LICENSE: switch to MIT license
-- [`8e70aab`](https://github.com/deisthree/logger/commit/8e70aab293987666a6ecf474e14a04af3c805abf) (logger) - README: update link to deis graphic
-- [`c54e4b4`](https://github.com/deisthree/logger/commit/c54e4b4c536654662c210844721a82a8e6eb0adf) (logger) - ci: remove travis; update badge
-- [`5ec9e6f`](https://github.com/deisthree/logger/commit/5ec9e6fee9b81722be9698559c658583993e67b1) (logger) - LICENSE: switch to MIT license
-- [`40bfd95`](https://github.com/deisthree/minio/commit/40bfd95cf145cabf5185634f12c2dd6b550563be) (minio) - ci: remove travis; update badge
-- [`d9ba730`](https://github.com/deisthree/minio/commit/d9ba730d8c3c6685486f00141ded098f47e1f625) (minio) - LICENSE: switch to MIT license
-- [`cf5c393`](https://github.com/deisthree/monitor/commit/cf5c393fb2613c3826f90451480c6cc734a81c99) (monitor) - LICENSE: switch to MIT license
-- [`9655620`](https://github.com/deisthree/nsq/commit/9655620a3f4a13af0d4bfdd186424d8411f305c0) (nsq) - README: update deis graphic link
-- [`71f9cc9`](https://github.com/deisthree/nsq/commit/71f9cc9b63113282e12d8233324b915fa46c23a2) (nsq) - LICENSE: switch to MIT license
-- [`fc7d7a3`](https://github.com/deisthree/postgres/commit/fc7d7a36dccb674388ed95744a3ee11cb67fb1a6) (postgres) - ci: remove travis; update badge
-- [`e751af6`](https://github.com/deisthree/postgres/commit/e751af66cc18774c01b0795f3617f887e6a18bf9) (postgres) - LICENSE: switch to MIT license
-- [`2cec33f`](https://github.com/deisthree/redis/commit/2cec33f3620f92f8c6a4ccfac74b127bd9baa6e6) (redis) - LICENSE: switch to MIT license
-- [`a6894de`](https://github.com/deisthree/registry/commit/a6894de87578d010e14a3507eb95dfb6d2cc3180) (registry) - ci: remove travis; update badge
-- [`fdfeb9b`](https://github.com/deisthree/registry/commit/fdfeb9b406ae288a69ba092f67c6266e68d1ed75) (registry) - LICENSE: switch to MIT license
-- [`d494abf`](https://github.com/deisthree/registry-token-refresher/commit/d494abfeb3a6e6b5a0e452732d626d802708f0cb) (registry-token-refresher) - ci: remove travis; update badge
-- [`fe75c0d`](https://github.com/deisthree/registry-token-refresher/commit/fe75c0d31ef22f301c7b52eae1d6ed05e283d90f) (registry-token-refresher) - LICENSE: switch to MIT license
-- [`093863f`](https://github.com/deisthree/router/commit/093863f2e0489be93e2d59032592fe0728f2e0b9) (router) - LICENSE: switch to MIT license
-- [`a54877d`](https://github.com/deisthree/slugbuilder/commit/a54877d0086dac9128308a9986d950f350ab69c1) (slugbuilder) - LICENSE: switch to MIT license
-- [`ce0e082`](https://github.com/deisthree/slugrunner/commit/ce0e082a17831285d1fbaf6cd08875a948a64697) (slugrunner) - ci: remove travis; update badge
-- [`7e85553`](https://github.com/deisthree/slugrunner/commit/7e85553cf3a197fc62b706df4262404cf92b37b3) (slugrunner) - LICENSE: switch to MIT license
-- [`ffcd9b3`](https://github.com/deisthree/workflow/commit/ffcd9b3fdca423cc79fb5d8980ea549421439c37) (workflow) - LICENSE: switch to MIT license
-- [`a861b5e`](https://github.com/deisthree/workflow-cli/commit/a861b5ed7ad6f9b9cdde170481da6287a54662d7) (workflow-cli) - LICENSE: switch to MIT license
-- [`34d4a68`](https://github.com/deisthree/workflow-manager/commit/34d4a6835c40cc4b44873b270fab96500a6d6760) (workflow-manager) - LICENSE: switch to MIT license
+- [`270f168`](https://github.com/deis/builder/commit/270f168af6e61630cc5ed16c38e009d7621a16a0) (builder) - ci: remove travis, update build status
+- [`f832ba3`](https://github.com/deis/builder/commit/f832ba3504872c999ab7eb8dbcab2ddd51118367) (builder) - LICENSE: switch to MIT license
+- [`9af9322`](https://github.com/deis/controller/commit/9af9322d8decaf96871b9f644f75a7732e192928) (controller) - LICENSE: switch to MIT license
+- [`86e3a4a`](https://github.com/deis/dockerbuilder/commit/86e3a4a55b9bb153e05d3a5f8da6e9316a06ad7b) (dockerbuilder) - ci: remove travis; update badge
+- [`6eb4387`](https://github.com/deis/dockerbuilder/commit/6eb438723d4fcec51a0d46513d1b06fd4dd68f31) (dockerbuilder) - LICENSE: switch to MIT license
+- [`502d8b2`](https://github.com/deis/fluentd/commit/502d8b2d861caba30bc9b0c485511bea877244a3) (fluentd) - LICENSE: switch to MIT license
+- [`8e70aab`](https://github.com/deis/logger/commit/8e70aab293987666a6ecf474e14a04af3c805abf) (logger) - README: update link to deis graphic
+- [`c54e4b4`](https://github.com/deis/logger/commit/c54e4b4c536654662c210844721a82a8e6eb0adf) (logger) - ci: remove travis; update badge
+- [`5ec9e6f`](https://github.com/deis/logger/commit/5ec9e6fee9b81722be9698559c658583993e67b1) (logger) - LICENSE: switch to MIT license
+- [`40bfd95`](https://github.com/deis/minio/commit/40bfd95cf145cabf5185634f12c2dd6b550563be) (minio) - ci: remove travis; update badge
+- [`d9ba730`](https://github.com/deis/minio/commit/d9ba730d8c3c6685486f00141ded098f47e1f625) (minio) - LICENSE: switch to MIT license
+- [`cf5c393`](https://github.com/deis/monitor/commit/cf5c393fb2613c3826f90451480c6cc734a81c99) (monitor) - LICENSE: switch to MIT license
+- [`9655620`](https://github.com/deis/nsq/commit/9655620a3f4a13af0d4bfdd186424d8411f305c0) (nsq) - README: update deis graphic link
+- [`71f9cc9`](https://github.com/deis/nsq/commit/71f9cc9b63113282e12d8233324b915fa46c23a2) (nsq) - LICENSE: switch to MIT license
+- [`fc7d7a3`](https://github.com/deis/postgres/commit/fc7d7a36dccb674388ed95744a3ee11cb67fb1a6) (postgres) - ci: remove travis; update badge
+- [`e751af6`](https://github.com/deis/postgres/commit/e751af66cc18774c01b0795f3617f887e6a18bf9) (postgres) - LICENSE: switch to MIT license
+- [`2cec33f`](https://github.com/deis/redis/commit/2cec33f3620f92f8c6a4ccfac74b127bd9baa6e6) (redis) - LICENSE: switch to MIT license
+- [`a6894de`](https://github.com/deis/registry/commit/a6894de87578d010e14a3507eb95dfb6d2cc3180) (registry) - ci: remove travis; update badge
+- [`fdfeb9b`](https://github.com/deis/registry/commit/fdfeb9b406ae288a69ba092f67c6266e68d1ed75) (registry) - LICENSE: switch to MIT license
+- [`d494abf`](https://github.com/deis/registry-token-refresher/commit/d494abfeb3a6e6b5a0e452732d626d802708f0cb) (registry-token-refresher) - ci: remove travis; update badge
+- [`fe75c0d`](https://github.com/deis/registry-token-refresher/commit/fe75c0d31ef22f301c7b52eae1d6ed05e283d90f) (registry-token-refresher) - LICENSE: switch to MIT license
+- [`093863f`](https://github.com/deis/router/commit/093863f2e0489be93e2d59032592fe0728f2e0b9) (router) - LICENSE: switch to MIT license
+- [`a54877d`](https://github.com/deis/slugbuilder/commit/a54877d0086dac9128308a9986d950f350ab69c1) (slugbuilder) - LICENSE: switch to MIT license
+- [`ce0e082`](https://github.com/deis/slugrunner/commit/ce0e082a17831285d1fbaf6cd08875a948a64697) (slugrunner) - ci: remove travis; update badge
+- [`7e85553`](https://github.com/deis/slugrunner/commit/7e85553cf3a197fc62b706df4262404cf92b37b3) (slugrunner) - LICENSE: switch to MIT license
+- [`ffcd9b3`](https://github.com/deis/workflow/commit/ffcd9b3fdca423cc79fb5d8980ea549421439c37) (workflow) - LICENSE: switch to MIT license
+- [`a861b5e`](https://github.com/deis/workflow-cli/commit/a861b5ed7ad6f9b9cdde170481da6287a54662d7) (workflow-cli) - LICENSE: switch to MIT license
+- [`34d4a68`](https://github.com/deis/workflow-manager/commit/34d4a6835c40cc4b44873b270fab96500a6d6760) (workflow-manager) - LICENSE: switch to MIT license
 
 #### Fixes
 
-- [`ab68699`](https://github.com/deisthree/monitor/commit/ab6869973aacbdf069d976442ec6ca9fdf255dd4) (monitor) - telegraf/Dockerfile: Update telegraf download to 1.3.0
-- [`35551af`](https://github.com/deisthree/postgres/commit/35551af3a58cde4f73f024b4634d10aa2a5adaac) (postgres) - Dockerfile: pin azure-storage to version wal-e currently lusing
-- [`067e622`](https://github.com/deisthree/registry/commit/067e622dc339af38c3c11a7a412d13ac947677c7) (registry) - boto: don't set AWS env vars when they're empty
-- [`2dddbe1`](https://github.com/deisthree/workflow-cli/commit/2dddbe180e268f6e435c791d2cc198a88274aaf0) (workflow-cli) - .gitignore: ignore .DS_Store droppings
+- [`ab68699`](https://github.com/deis/monitor/commit/ab6869973aacbdf069d976442ec6ca9fdf255dd4) (monitor) - telegraf/Dockerfile: Update telegraf download to 1.3.0
+- [`35551af`](https://github.com/deis/postgres/commit/35551af3a58cde4f73f024b4634d10aa2a5adaac) (postgres) - Dockerfile: pin azure-storage to version wal-e currently lusing
+- [`067e622`](https://github.com/deis/registry/commit/067e622dc339af38c3c11a7a412d13ac947677c7) (registry) - boto: don't set AWS env vars when they're empty
+- [`2dddbe1`](https://github.com/deis/workflow-cli/commit/2dddbe180e268f6e435c791d2cc198a88274aaf0) (workflow-cli) - .gitignore: ignore .DS_Store droppings
 
 #### Documentation
 
-- [`7cc5a82`](https://github.com/deisthree/router/commit/7cc5a826c7cb8e5ae7b5de52656f433ef08d8f0c) (router) - README: update charts link/reference
+- [`7cc5a82`](https://github.com/deis/router/commit/7cc5a826c7cb8e5ae7b5de52656f433ef08d8f0c) (router) - README: update charts link/reference
 
 #### Maintenance
 
-- [`b4fe99e`](https://github.com/deisthree/controller/commit/b4fe99ec744951967c5dd1a096ff7609674eda37) (controller) - requirements: update Django to v1.11.1
-- [`47a9583`](https://github.com/deisthree/controller/commit/47a95836613cb9489d406db1dcc1a4762d108e4b) (controller) - requirements: update DRF to v3.6.3
-- [`d869595`](https://github.com/deisthree/controller/commit/d869595d1c740dbdc8a7fd4c55bf57ac037096a3) (controller) - requirements: update pyldap to v2.4.35
-- [`ac7baf2`](https://github.com/deisthree/controller/commit/ac7baf238ade7ac5bf9836f600ac8246a5fcd997) (controller) - requirements: update requests to v2.14.2
-- [`d183306`](https://github.com/deisthree/controller/commit/d1833066cd0fea7b0f6069a01d86d519d16f084a) (controller) - requirements: update requests-toolbelt to 0.8.0
-- [`989fe33`](https://github.com/deisthree/controller/commit/989fe33899982c43a5469c6fa12c90ebd6fa9719) (controller) - requirements: update django-auth-ldap to v1.2.12
-- [`35ed09f`](https://github.com/deisthree/postgres/commit/35ed09f6aa7a498f280399d3c91bd289585d1713) (postgres) - Dockerfile: bump postgres-9.4 version, update azure storage import
-- [`f0db059`](https://github.com/deisthree/slugbuilder/commit/f0db059e4985d10bab6185843d4b8af1ea83b050) (slugbuilder) - buildpacks: update heroku-buildpack-go to v65
-- [`ddeb83c`](https://github.com/deisthree/slugbuilder/commit/ddeb83c6d22b3767000459c75d32feb5967c21b2) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v104
-- [`d957649`](https://github.com/deisthree/slugbuilder/commit/d95764959f4d1bda97f5275c30d2d57e966736bd) (slugbuilder) - buildpacks: update heroku-buildpack-python to v103
-- [`2cb83f2`](https://github.com/deisthree/slugbuilder/commit/2cb83f2648e1a9be8873ecbc20a4552878389993) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v163
-- [`6575cb0`](https://github.com/deisthree/workflow/commit/6575cb06930053d29a04500e5aabff07b4fe1a9f) (workflow) - remove the services url navigation
-- [`5cd8648`](https://github.com/deisthree/workflow-e2e/commit/5cd8648b3dc056784e0adc1d52e1b185a6af8adc) (workflow-e2e) - Dockerfile: bump k8s version
+- [`b4fe99e`](https://github.com/deis/controller/commit/b4fe99ec744951967c5dd1a096ff7609674eda37) (controller) - requirements: update Django to v1.11.1
+- [`47a9583`](https://github.com/deis/controller/commit/47a95836613cb9489d406db1dcc1a4762d108e4b) (controller) - requirements: update DRF to v3.6.3
+- [`d869595`](https://github.com/deis/controller/commit/d869595d1c740dbdc8a7fd4c55bf57ac037096a3) (controller) - requirements: update pyldap to v2.4.35
+- [`ac7baf2`](https://github.com/deis/controller/commit/ac7baf238ade7ac5bf9836f600ac8246a5fcd997) (controller) - requirements: update requests to v2.14.2
+- [`d183306`](https://github.com/deis/controller/commit/d1833066cd0fea7b0f6069a01d86d519d16f084a) (controller) - requirements: update requests-toolbelt to 0.8.0
+- [`989fe33`](https://github.com/deis/controller/commit/989fe33899982c43a5469c6fa12c90ebd6fa9719) (controller) - requirements: update django-auth-ldap to v1.2.12
+- [`35ed09f`](https://github.com/deis/postgres/commit/35ed09f6aa7a498f280399d3c91bd289585d1713) (postgres) - Dockerfile: bump postgres-9.4 version, update azure storage import
+- [`f0db059`](https://github.com/deis/slugbuilder/commit/f0db059e4985d10bab6185843d4b8af1ea83b050) (slugbuilder) - buildpacks: update heroku-buildpack-go to v65
+- [`ddeb83c`](https://github.com/deis/slugbuilder/commit/ddeb83c6d22b3767000459c75d32feb5967c21b2) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v104
+- [`d957649`](https://github.com/deis/slugbuilder/commit/d95764959f4d1bda97f5275c30d2d57e966736bd) (slugbuilder) - buildpacks: update heroku-buildpack-python to v103
+- [`2cb83f2`](https://github.com/deis/slugbuilder/commit/2cb83f2648e1a9be8873ecbc20a4552878389993) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v163
+- [`6575cb0`](https://github.com/deis/workflow/commit/6575cb06930053d29a04500e5aabff07b4fe1a9f) (workflow) - remove the services url navigation
+- [`5cd8648`](https://github.com/deis/workflow-e2e/commit/5cd8648b3dc056784e0adc1d52e1b185a6af8adc) (workflow-e2e) - Dockerfile: bump k8s version

--- a/src/changelogs/v2.16.0.md
+++ b/src/changelogs/v2.16.0.md
@@ -12,40 +12,40 @@
 
 #### Features
 
-- [`46002f4`](https://github.com/deisthree/workflow-cli/commit/46002f4440bfbb2614f779375ba12d6a3e0cf80b) (workflow-cli) - cmd: Support Base64 encoded SSH_KEY
-- [`88397a1`](https://github.com/deisthree/workflow-cli/commit/88397a12bf716d788c7b5468d9833a448452d39f) (workflow-cli) - cmd: test SSH_KEY mangling in ConfigSet
-- [`f9c6a4a`](https://github.com/deisthree/workflow-e2e/commit/f9c6a4aa43d990f59e68a0cd40de4f46864584d2) (workflow-e2e) - chart: use upstream stable/spotify-docker-gc chart
+- [`46002f4`](https://github.com/deis/workflow-cli/commit/46002f4440bfbb2614f779375ba12d6a3e0cf80b) (workflow-cli) - cmd: Support Base64 encoded SSH_KEY
+- [`88397a1`](https://github.com/deis/workflow-cli/commit/88397a12bf716d788c7b5468d9833a448452d39f) (workflow-cli) - cmd: test SSH_KEY mangling in ConfigSet
+- [`f9c6a4a`](https://github.com/deis/workflow-e2e/commit/f9c6a4aa43d990f59e68a0cd40de4f46864584d2) (workflow-e2e) - chart: use upstream stable/spotify-docker-gc chart
 
 #### Refactors
 
-- [`ce0e082`](https://github.com/deisthree/slugrunner/commit/ce0e082a17831285d1fbaf6cd08875a948a64697) (slugrunner) - ci: remove travis; update badge
-- [`7e85553`](https://github.com/deisthree/slugrunner/commit/7e85553cf3a197fc62b706df4262404cf92b37b3) (slugrunner) - LICENSE: switch to MIT license
-- [`345d5ae`](https://github.com/deisthree/workflow/commit/345d5aec07f64c04ccdf0f4fd1ad4622cf89b4b4) (workflow) - mkdocs.yml: alphabetize cloud providers in quickstart
+- [`ce0e082`](https://github.com/deis/slugrunner/commit/ce0e082a17831285d1fbaf6cd08875a948a64697) (slugrunner) - ci: remove travis; update badge
+- [`7e85553`](https://github.com/deis/slugrunner/commit/7e85553cf3a197fc62b706df4262404cf92b37b3) (slugrunner) - LICENSE: switch to MIT license
+- [`345d5ae`](https://github.com/deis/workflow/commit/345d5aec07f64c04ccdf0f4fd1ad4622cf89b4b4) (workflow) - mkdocs.yml: alphabetize cloud providers in quickstart
 
 #### Fixes
 
-- [`73f844b`](https://github.com/deisthree/builder/commit/73f844b5a8ac61f5f54422d34b779728db679bf3) *: Remove RC4 based ciphers.
-- [`344b43e`](https://github.com/deisthree/builder/commit/344b43e4c6e4f350706121300910e24160d78b8d) *: Fix linter issues
-- [`c81dbf9`](https://github.com/deisthree/controller/commit/c81dbf97827adf7fd54c9d8a9f055b92211f295e) (controller) - controller: Persist ssl.enforce header on service creation
-- [`1f5e242`](https://github.com/deisthree/workflow-cli/commit/1f5e2424947e75aba94158941d058e589d779916) (workflow-cli) - cmd: fix(cmd) Fix proctype regex for setting limits
-- [`f82cf83`](https://github.com/deisthree/workflow-cli/commit/f82cf8373b2742ac4a354220dd25a458c9bf160d) (workflow-cli) - cmd: fix(cmd) Fix proctype regex for scaling
+- [`73f844b`](https://github.com/deis/builder/commit/73f844b5a8ac61f5f54422d34b779728db679bf3) *: Remove RC4 based ciphers.
+- [`344b43e`](https://github.com/deis/builder/commit/344b43e4c6e4f350706121300910e24160d78b8d) *: Fix linter issues
+- [`c81dbf9`](https://github.com/deis/controller/commit/c81dbf97827adf7fd54c9d8a9f055b92211f295e) (controller) - controller: Persist ssl.enforce header on service creation
+- [`1f5e242`](https://github.com/deis/workflow-cli/commit/1f5e2424947e75aba94158941d058e589d779916) (workflow-cli) - cmd: fix(cmd) Fix proctype regex for setting limits
+- [`f82cf83`](https://github.com/deis/workflow-cli/commit/f82cf8373b2742ac4a354220dd25a458c9bf160d) (workflow-cli) - cmd: fix(cmd) Fix proctype regex for scaling
 
 #### Documentation
 
-- [`25329be`](https://github.com/deisthree/workflow/commit/25329be86bec3bd8b2b9d0dc0ba92c56775284fa) (workflow) - quickstart: update Azure ACS installation steps
-- [`4cfa9d5`](https://github.com/deisthree/workflow/commit/4cfa9d589312e336544ae7dc44bfed09e1a61aab) (workflow) - *: rm no longer needed pipe to sed (#817)
-- [`5145f12`](https://github.com/deisthree/workflow/commit/5145f123417126f7a84873a55ca7db46d59ee1f1) (workflow) - configuring-registry.md: add setup instructions for acr (#818)
-- [`b456870`](https://github.com/deisthree/workflow/commit/b4568706a37b33de33a1fe61ee6040d978fb095a) (workflow) - installing-workflow: helm init upgrade note (#819)
-- [`61a5cca`](https://github.com/deisthree/workflow/commit/61a5cca8b08f50eb08c2f3f1b1324babe8f8d26d) (workflow) - chart-provenance.md: fix chart repo name (#830)
-- [`2a7f756`](https://github.com/deisthree/workflow/commit/2a7f756f883107a0dcc7e0e8aee9d74bb9914f36) (workflow) - *: specify Helm v2.5.0 or later
-- [`ef4bc3e`](https://github.com/deisthree/workflow/commit/ef4bc3eae925558107cb269e5f8b09338a469ee2) (workflow) - *: updates/changelog for v2.16.0 release
+- [`25329be`](https://github.com/deis/workflow/commit/25329be86bec3bd8b2b9d0dc0ba92c56775284fa) (workflow) - quickstart: update Azure ACS installation steps
+- [`4cfa9d5`](https://github.com/deis/workflow/commit/4cfa9d589312e336544ae7dc44bfed09e1a61aab) (workflow) - *: rm no longer needed pipe to sed (#817)
+- [`5145f12`](https://github.com/deis/workflow/commit/5145f123417126f7a84873a55ca7db46d59ee1f1) (workflow) - configuring-registry.md: add setup instructions for acr (#818)
+- [`b456870`](https://github.com/deis/workflow/commit/b4568706a37b33de33a1fe61ee6040d978fb095a) (workflow) - installing-workflow: helm init upgrade note (#819)
+- [`61a5cca`](https://github.com/deis/workflow/commit/61a5cca8b08f50eb08c2f3f1b1324babe8f8d26d) (workflow) - chart-provenance.md: fix chart repo name (#830)
+- [`2a7f756`](https://github.com/deis/workflow/commit/2a7f756f883107a0dcc7e0e8aee9d74bb9914f36) (workflow) - *: specify Helm v2.5.0 or later
+- [`ef4bc3e`](https://github.com/deis/workflow/commit/ef4bc3eae925558107cb269e5f8b09338a469ee2) (workflow) - *: updates/changelog for v2.16.0 release
 
 #### Maintenance
 
-- [`c2fd577`](https://github.com/deisthree/controller/commit/c2fd5775ee28f0bed00014f0c6b8d2693f14927b) (controller) - requirements: update Django to v1.11.2
-- [`fe6e6e5`](https://github.com/deisthree/controller/commit/fe6e6e5280a83209b626d10492d07073b027ac52) (controller) - requirements: update pyldap to v2.4.35.1
-- [`cac5e60`](https://github.com/deisthree/controller/commit/cac5e602b617c4fd26737f11e87ff10601192146) (controller) - requirements: update jmespath to 0.9.3
-- [`1fcf61b`](https://github.com/deisthree/controller/commit/1fcf61bb7e33dc6da54f6a0d1b1918abab5255ba) (controller) - requirements: update backoff to 1.4.3
-- [`410e1d3`](https://github.com/deisthree/controller/commit/410e1d38f94dede6bab8fc4412380073b638be26) (controller) - requirements: update Django to v1.11.3
-- [`516a529`](https://github.com/deisthree/monitor/commit/516a5291aac544c7bd79a30c276be48d44174343) (monitor) - Dockerfile: update Grafana to 4.3.2
-- [`5cd8648`](https://github.com/deisthree/workflow-e2e/commit/5cd8648b3dc056784e0adc1d52e1b185a6af8adc) (workflow-e2e) - Dockerfile: bump k8s version
+- [`c2fd577`](https://github.com/deis/controller/commit/c2fd5775ee28f0bed00014f0c6b8d2693f14927b) (controller) - requirements: update Django to v1.11.2
+- [`fe6e6e5`](https://github.com/deis/controller/commit/fe6e6e5280a83209b626d10492d07073b027ac52) (controller) - requirements: update pyldap to v2.4.35.1
+- [`cac5e60`](https://github.com/deis/controller/commit/cac5e602b617c4fd26737f11e87ff10601192146) (controller) - requirements: update jmespath to 0.9.3
+- [`1fcf61b`](https://github.com/deis/controller/commit/1fcf61bb7e33dc6da54f6a0d1b1918abab5255ba) (controller) - requirements: update backoff to 1.4.3
+- [`410e1d3`](https://github.com/deis/controller/commit/410e1d38f94dede6bab8fc4412380073b638be26) (controller) - requirements: update Django to v1.11.3
+- [`516a529`](https://github.com/deis/monitor/commit/516a5291aac544c7bd79a30c276be48d44174343) (monitor) - Dockerfile: update Grafana to 4.3.2
+- [`5cd8648`](https://github.com/deis/workflow-e2e/commit/5cd8648b3dc056784e0adc1d52e1b185a6af8adc) (workflow-e2e) - Dockerfile: bump k8s version

--- a/src/changelogs/v2.17.0.md
+++ b/src/changelogs/v2.17.0.md
@@ -12,44 +12,44 @@
 
 #### Features
 
-- [`4e0c17c`](https://github.com/deisthree/slugbuilder/commit/4e0c17cc7e514dad5d9e1fe290c528dcdebd5785) (slugbuilder) - normalize_storage: use `MINIO_BUCKET` env-var
-- [`92ef1b7`](https://github.com/deisthree/slugrunner/commit/92ef1b7817f51197f3995b5d0822302062bfe6a9) (slugrunner) - get_object: use `MINIO_BUCKET` env-var
+- [`4e0c17c`](https://github.com/deis/slugbuilder/commit/4e0c17cc7e514dad5d9e1fe290c528dcdebd5785) (slugbuilder) - normalize_storage: use `MINIO_BUCKET` env-var
+- [`92ef1b7`](https://github.com/deis/slugrunner/commit/92ef1b7817f51197f3995b5d0822302062bfe6a9) (slugrunner) - get_object: use `MINIO_BUCKET` env-var
 
 #### Refactors
 
-- [`ce0e082`](https://github.com/deisthree/slugrunner/commit/ce0e082a17831285d1fbaf6cd08875a948a64697) (slugrunner) - ci: remove travis; update badge
-- [`7e85553`](https://github.com/deisthree/slugrunner/commit/7e85553cf3a197fc62b706df4262404cf92b37b3) (slugrunner) - LICENSE: switch to MIT license
+- [`ce0e082`](https://github.com/deis/slugrunner/commit/ce0e082a17831285d1fbaf6cd08875a948a64697) (slugrunner) - ci: remove travis; update badge
+- [`7e85553`](https://github.com/deis/slugrunner/commit/7e85553cf3a197fc62b706df4262404cf92b37b3) (slugrunner) - LICENSE: switch to MIT license
 
 #### Fixes
 
-- [`c02eb51`](https://github.com/deisthree/controller/commit/c02eb51312db4454548d3e39452f59cd1c9355f9) (controller) - api/models/app: Catch unhandled error (#1317)
-- [`d5c70f4`](https://github.com/deisthree/workflow-e2e/commit/d5c70f4fedd88855d42ef1a1cfedbd79938b5e7f) (workflow-e2e) - apps_test.go: temporarily disable spec that fails on GKE
+- [`c02eb51`](https://github.com/deis/controller/commit/c02eb51312db4454548d3e39452f59cd1c9355f9) (controller) - api/models/app: Catch unhandled error (#1317)
+- [`d5c70f4`](https://github.com/deis/workflow-e2e/commit/d5c70f4fedd88855d42ef1a1cfedbd79938b5e7f) (workflow-e2e) - apps_test.go: temporarily disable spec that fails on GKE
 
 #### Documentation
 
-- [`f40f3cf`](https://github.com/deisthree/workflow/commit/f40f3cfea3bba3c1e2f11f55c4c25dd162b4aeb6) (workflow) - changelogs: add builder release and workflow commit
-- [`5c83dd2`](https://github.com/deisthree/workflow/commit/5c83dd2a187eb0014de502170fc1100f23c6d1a1) (workflow) - managing-app-processes: Fix 404 for HPA algorithm link (#846)
+- [`f40f3cf`](https://github.com/deis/workflow/commit/f40f3cfea3bba3c1e2f11f55c4c25dd162b4aeb6) (workflow) - changelogs: add builder release and workflow commit
+- [`5c83dd2`](https://github.com/deis/workflow/commit/5c83dd2a187eb0014de502170fc1100f23c6d1a1) (workflow) - managing-app-processes: Fix 404 for HPA algorithm link (#846)
 
 #### Maintenance
 
-- [`435aa2b`](https://github.com/deisthree/controller/commit/435aa2bc4562bc776ad895e2f08a0311703e8e55) (controller) - requirements: update django-auth-ldap to 1.2.14
-- [`76b1233`](https://github.com/deisthree/controller/commit/76b1233ba6b81f5b22420e5872ca1a9ea73bd07a) (controller) - requirements: update pyldap to 2.4.37
-- [`c17ad2c`](https://github.com/deisthree/controller/commit/c17ad2ce8391f62d883f6cee5734acf25eb56522) (controller) - requirements: update django-jsonfield to 2.0.2
-- [`732d4f4`](https://github.com/deisthree/controller/commit/732d4f462329d92dfd0ae801aa6fca96e97b8ae8) (controller) - requirements: update django-guardian to 1.4.9
-- [`f914d98`](https://github.com/deisthree/controller/commit/f914d98f96e023d69771c365326aff6186f57b50) (controller) - requirements: update pyOpenSSL to 17.2.0
-- [`48b1be1`](https://github.com/deisthree/controller/commit/48b1be18c59755771d0908c1627eb2278996d43c) (controller) - requirements: update requests to 2.18.2
-- [`b79a32a`](https://github.com/deisthree/controller/commit/b79a32a00503cb7124573411fb5d469ae3c9766b) (controller) - dev_requirements: update coverage lib to 4.4.1
-- [`efefc5f`](https://github.com/deisthree/router/commit/efefc5f51a812507191f0e91303f36527965ec4e) (router) - Dockerfile: update nginx to 1.13.3
-- [`c1364b3`](https://github.com/deisthree/slugbuilder/commit/c1364b39d2619bd14c7714ed9547a7e4fff1104d) (slugbuilder) - buildpacks: update heroku-buildpack-go to v70
-- [`cb073da`](https://github.com/deisthree/slugbuilder/commit/cb073da9c2541f3759a81da0395f2fe28164ea34) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v22
-- [`f82db90`](https://github.com/deisthree/slugbuilder/commit/f82db90f3f8882425dcfd8bbf8d60ec9148d1b21) (slugbuilder) - buildpacks: update heroku-buildpack-java to v52
-- [`c260552`](https://github.com/deisthree/slugbuilder/commit/c2605521fb3b61071ca261b2214106cc96c092f6) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v106
-- [`c4b586b`](https://github.com/deisthree/slugbuilder/commit/c4b586bdb301f354a4c97e5bbf3197e0955bf29d) (slugbuilder) - buildpacks: update heroku-buildpack-python to v109
-- [`ef63934`](https://github.com/deisthree/slugbuilder/commit/ef639343ca83dd7d6401a34484b73fae26481dfa) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v164
-- [`6ef590c`](https://github.com/deisthree/slugbuilder/commit/6ef590c0d803dbf91feb8ae6ee9a0de163cac192) (slugbuilder) - buildpacks: update heroku-buildpack-clojure to v77
-- [`3f3e4b9`](https://github.com/deisthree/slugbuilder/commit/3f3e4b9cd260d1ee2bc41fea85f96d11749f3872) (slugbuilder) - buildpacks: update heroku-buildpack-go to v71
-- [`8ded076`](https://github.com/deisthree/slugbuilder/commit/8ded07664af2d2a76855e6e686be90b479b671ab) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v23
-- [`04a1649`](https://github.com/deisthree/slugbuilder/commit/04a16495abe52c79014dcaf18f37b8c06bf2a5b5) (slugbuilder) - buildpacks: update heroku-buildpack-java to v53
-- [`22e02d2`](https://github.com/deisthree/slugbuilder/commit/22e02d22b75ab99880727fe71755021a74b6e222) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v110
-- [`e5ffff7`](https://github.com/deisthree/slugbuilder/commit/e5ffff7849623dba69236cd1227162fd633c24b4) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v167
-- [`1e3f424`](https://github.com/deisthree/slugbuilder/commit/1e3f424130d018e511791a2051106a1eb049bc77) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v77
+- [`435aa2b`](https://github.com/deis/controller/commit/435aa2bc4562bc776ad895e2f08a0311703e8e55) (controller) - requirements: update django-auth-ldap to 1.2.14
+- [`76b1233`](https://github.com/deis/controller/commit/76b1233ba6b81f5b22420e5872ca1a9ea73bd07a) (controller) - requirements: update pyldap to 2.4.37
+- [`c17ad2c`](https://github.com/deis/controller/commit/c17ad2ce8391f62d883f6cee5734acf25eb56522) (controller) - requirements: update django-jsonfield to 2.0.2
+- [`732d4f4`](https://github.com/deis/controller/commit/732d4f462329d92dfd0ae801aa6fca96e97b8ae8) (controller) - requirements: update django-guardian to 1.4.9
+- [`f914d98`](https://github.com/deis/controller/commit/f914d98f96e023d69771c365326aff6186f57b50) (controller) - requirements: update pyOpenSSL to 17.2.0
+- [`48b1be1`](https://github.com/deis/controller/commit/48b1be18c59755771d0908c1627eb2278996d43c) (controller) - requirements: update requests to 2.18.2
+- [`b79a32a`](https://github.com/deis/controller/commit/b79a32a00503cb7124573411fb5d469ae3c9766b) (controller) - dev_requirements: update coverage lib to 4.4.1
+- [`efefc5f`](https://github.com/deis/router/commit/efefc5f51a812507191f0e91303f36527965ec4e) (router) - Dockerfile: update nginx to 1.13.3
+- [`c1364b3`](https://github.com/deis/slugbuilder/commit/c1364b39d2619bd14c7714ed9547a7e4fff1104d) (slugbuilder) - buildpacks: update heroku-buildpack-go to v70
+- [`cb073da`](https://github.com/deis/slugbuilder/commit/cb073da9c2541f3759a81da0395f2fe28164ea34) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v22
+- [`f82db90`](https://github.com/deis/slugbuilder/commit/f82db90f3f8882425dcfd8bbf8d60ec9148d1b21) (slugbuilder) - buildpacks: update heroku-buildpack-java to v52
+- [`c260552`](https://github.com/deis/slugbuilder/commit/c2605521fb3b61071ca261b2214106cc96c092f6) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v106
+- [`c4b586b`](https://github.com/deis/slugbuilder/commit/c4b586bdb301f354a4c97e5bbf3197e0955bf29d) (slugbuilder) - buildpacks: update heroku-buildpack-python to v109
+- [`ef63934`](https://github.com/deis/slugbuilder/commit/ef639343ca83dd7d6401a34484b73fae26481dfa) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v164
+- [`6ef590c`](https://github.com/deis/slugbuilder/commit/6ef590c0d803dbf91feb8ae6ee9a0de163cac192) (slugbuilder) - buildpacks: update heroku-buildpack-clojure to v77
+- [`3f3e4b9`](https://github.com/deis/slugbuilder/commit/3f3e4b9cd260d1ee2bc41fea85f96d11749f3872) (slugbuilder) - buildpacks: update heroku-buildpack-go to v71
+- [`8ded076`](https://github.com/deis/slugbuilder/commit/8ded07664af2d2a76855e6e686be90b479b671ab) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v23
+- [`04a1649`](https://github.com/deis/slugbuilder/commit/04a16495abe52c79014dcaf18f37b8c06bf2a5b5) (slugbuilder) - buildpacks: update heroku-buildpack-java to v53
+- [`22e02d2`](https://github.com/deis/slugbuilder/commit/22e02d22b75ab99880727fe71755021a74b6e222) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v110
+- [`e5ffff7`](https://github.com/deis/slugbuilder/commit/e5ffff7849623dba69236cd1227162fd633c24b4) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v167
+- [`1e3f424`](https://github.com/deis/slugbuilder/commit/1e3f424130d018e511791a2051106a1eb049bc77) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v77

--- a/src/changelogs/v2.2.0.md
+++ b/src/changelogs/v2.2.0.md
@@ -2,62 +2,62 @@
 
 ### Features
 
-- [`b59bbbc`](https://github.com/deisthree/fluentd/commit/b59bbbc308628b356291984e3506e233ec1227ed) (fluentd) - fluentd: Adding sumologic plugin support
-- [`424523c`](https://github.com/deisthree/logger/commit/424523c50cb893ae6048fe8a7b35c3486a4e5e07) (logger) - storage: Add redis storage adapter
-- [`2da72a5`](https://github.com/deisthree/logger/commit/2da72a5f99ff58c723b92fd9ff5b1cc3a4caec6b) (logger) - redis: Optimize with more aggresive pipelining
-- [`0c82466`](https://github.com/deisthree/logger/commit/0c82466f929a096df0f19c30ea56e250b9b0062c) (logger) - storage: Make redis the default storage adapter
-- [`2f92eca`](https://github.com/deisthree/monitor/commit/2f92eca55942e5fef07c9b295843e4fd73c9a294) (monitor) - telegraf, grafana: Start collecting redis metrics
-- [`c9718e4`](https://github.com/deisthree/charts/commit/c9718e4c6bb373fb34e80e0c5fb05bbf21b11374) (charts) - logger: Add redis instance for use by logger
-- [`7d40069`](https://github.com/deisthree/charts/commit/7d400693b352803b8e3695cba3bf54a00ad1dcf4) (charts) - swift: add support for swift storage
-- [`d6992e1`](https://github.com/deisthree/charts/commit/d6992e199cd30544caa820ce5aa85626534e7eb3) (charts) - telegraf: Configure telegraf to start fetching redis metrics
-- [`0ae9d90`](https://github.com/deisthree/workflow-cli/commit/0ae9d909881ee7eac18d3f943ecaa473ad865df3) (workflow-cli) - deis: add `deis shortcuts` command
-- [`2862f05`](https://github.com/deisthree/workflow-cli/commit/2862f056e278996a74bea224ec246366c5952528) (workflow-cli) - colors: reserve magenta for controller log messages (#132)
-- [`8a61e63`](https://github.com/deisthree/controller/commit/8a61e63d207c9dc76066fd119110696a6e034f87) (controller) - scheduler: add support for set based requirement filtering via the kubernetes API
-- [`47b5b08`](https://github.com/deisthree/controller/commit/47b5b086ef268d80cc8d91ce0b49423bacb8e75b) (controller) - IDN: add support for international domains
-- [`32be50a`](https://github.com/deisthree/controller/commit/32be50a323bb73683474ad3dd03b4dada6589bdf) (controller) - scheduler: sort env vars and secrets by keys for easier hashing
-- [`c3c2494`](https://github.com/deisthree/controller/commit/c3c2494514547d328fc933ba3eb4bf3db723ab82) (controller) - add Deployments support behind a feature flag
-- [`edb0383`](https://github.com/deisthree/controller/commit/edb0383a6446d048d2a9b14512534caccd74d2d1) (controller) - scheduler: feat(scheduler) prepend [namespace] to Scheduler log message for better traceability
-- [`84b8080`](https://github.com/deisthree/controller/commit/84b80803ad201bf04f7bf3c031413d90794ace4d) (controller) - app: make deploy timeout configurable globally/per-app via DEIS_DEPLOY_TIMEOUT, default is 2 minutes
+- [`b59bbbc`](https://github.com/deis/fluentd/commit/b59bbbc308628b356291984e3506e233ec1227ed) (fluentd) - fluentd: Adding sumologic plugin support
+- [`424523c`](https://github.com/deis/logger/commit/424523c50cb893ae6048fe8a7b35c3486a4e5e07) (logger) - storage: Add redis storage adapter
+- [`2da72a5`](https://github.com/deis/logger/commit/2da72a5f99ff58c723b92fd9ff5b1cc3a4caec6b) (logger) - redis: Optimize with more aggresive pipelining
+- [`0c82466`](https://github.com/deis/logger/commit/0c82466f929a096df0f19c30ea56e250b9b0062c) (logger) - storage: Make redis the default storage adapter
+- [`2f92eca`](https://github.com/deis/monitor/commit/2f92eca55942e5fef07c9b295843e4fd73c9a294) (monitor) - telegraf, grafana: Start collecting redis metrics
+- [`c9718e4`](https://github.com/deis/charts/commit/c9718e4c6bb373fb34e80e0c5fb05bbf21b11374) (charts) - logger: Add redis instance for use by logger
+- [`7d40069`](https://github.com/deis/charts/commit/7d400693b352803b8e3695cba3bf54a00ad1dcf4) (charts) - swift: add support for swift storage
+- [`d6992e1`](https://github.com/deis/charts/commit/d6992e199cd30544caa820ce5aa85626534e7eb3) (charts) - telegraf: Configure telegraf to start fetching redis metrics
+- [`0ae9d90`](https://github.com/deis/workflow-cli/commit/0ae9d909881ee7eac18d3f943ecaa473ad865df3) (workflow-cli) - deis: add `deis shortcuts` command
+- [`2862f05`](https://github.com/deis/workflow-cli/commit/2862f056e278996a74bea224ec246366c5952528) (workflow-cli) - colors: reserve magenta for controller log messages (#132)
+- [`8a61e63`](https://github.com/deis/controller/commit/8a61e63d207c9dc76066fd119110696a6e034f87) (controller) - scheduler: add support for set based requirement filtering via the kubernetes API
+- [`47b5b08`](https://github.com/deis/controller/commit/47b5b086ef268d80cc8d91ce0b49423bacb8e75b) (controller) - IDN: add support for international domains
+- [`32be50a`](https://github.com/deis/controller/commit/32be50a323bb73683474ad3dd03b4dada6589bdf) (controller) - scheduler: sort env vars and secrets by keys for easier hashing
+- [`c3c2494`](https://github.com/deis/controller/commit/c3c2494514547d328fc933ba3eb4bf3db723ab82) (controller) - add Deployments support behind a feature flag
+- [`edb0383`](https://github.com/deis/controller/commit/edb0383a6446d048d2a9b14512534caccd74d2d1) (controller) - scheduler: feat(scheduler) prepend [namespace] to Scheduler log message for better traceability
+- [`84b8080`](https://github.com/deis/controller/commit/84b80803ad201bf04f7bf3c031413d90794ace4d) (controller) - app: make deploy timeout configurable globally/per-app via DEIS_DEPLOY_TIMEOUT, default is 2 minutes
 
 ### Fixes
 
-- [`65f8714`](https://github.com/deisthree/dockerbuilder/commit/65f8714d6909bf23b4952544b8b0e10e54871571) (dockerbuilder) - objectstore: set properly builder bucket file environment variable
-- [`9179923`](https://github.com/deisthree/dockerbuilder/commit/91799230f043c81e726c23fe232d3e80c24b31eb) (dockerbuilder) - deploy.py: handle chunked output errors
-- [`02112ed`](https://github.com/deisthree/dockerbuilder/commit/02112edb7603ba2c2be3e764d9d107ef645329a8) (dockerbuilder) - deploy.py: delay so stderr is logged before pod exits
-- [`93b9c5c`](https://github.com/deisthree/logger/commit/93b9c5ce1496654432d35bf4bb51503e4b3a9805) (logger) - redis: Pass style checks
-- [`7144c4e`](https://github.com/deisthree/logger/commit/7144c4ef742844b6a5ab4c8d3420d5d86a0ac7d7) (logger) - rc: Specify use of redis storage adapter
-- [`9dae9cc`](https://github.com/deisthree/monitor/commit/9dae9cc9dbefb1314e68de79fe1db3d33ac7f8f2) (monitor) - telegraf: Create nsq topic at startup
-- [`a9b2275`](https://github.com/deisthree/monitor/commit/a9b2275da4eb892b986b0d16b44b77f1cfae05f6) (monitor) - telegraf: Update image default image tag in manifests
-- [`8fd5ada`](https://github.com/deisthree/monitor/commit/8fd5adaae198cf88e84abfa84e038ef04f21f3f5) (monitor) - grafana: Fix blank dashboards from appearing in dropdown
-- [`7de06cc`](https://github.com/deisthree/monitor/commit/7de06cc302beae72d986b11e28cac319e8a8bc7d) (monitor) - grafana: Redis cpu graph was not selecting right data
-- [`0492bf8`](https://github.com/deisthree/charts/commit/0492bf8972b8ffe1e7cf0685fe5eed2874ea5bd0) (charts) - database: Fix logic for selecting off-cluster db
-- [`6fd8407`](https://github.com/deisthree/charts/commit/6fd840784bccfe8d42130117252adafe62627e33) (charts) - logger: Do not helm keep rc deis-logger-redis
-- [`c425baf`](https://github.com/deisthree/workflow-cli/commit/c425baf440d283ec1f5434da00b46d56663f5d2f) (workflow-cli) - ps: restarting a single pod created by Deployments was not working
-- [`bcb8b01`](https://github.com/deisthree/workflow-cli/commit/bcb8b01dc42f0ce438be2a9da3584ba136af02ac) (workflow-cli) - ps: give ps:restart a better understanding between RC and Deployment pods
-- [`4b2c6d4`](https://github.com/deisthree/workflow-cli/commit/4b2c6d43e45eb926fa67dddb23b306999a486c4d) (workflow-cli) - scale: dont call controller if there is no valid scale pattern
-- [`32177aa`](https://github.com/deisthree/workflow-cli/commit/32177aa142642dd41d59d2ed322131fc61d2ebbc) (workflow-cli) - settings: don't panic on empty settings file (#134)
-- [`6214d96`](https://github.com/deisthree/controller/commit/6214d96d52fd9a0e9b0ee6ab098590316f51cd84) (controller) - scheduler: if one RC fails to scale then ensure all other RCs are at the right level
-- [`0bcea13`](https://github.com/deisthree/controller/commit/0bcea133f95e097b073c55e0c44445023c135887) (controller) - scale: return error message in proper format
-- [`7d24923`](https://github.com/deisthree/controller/commit/7d24923a06e51dcd1fe5c4a0a3148cb6a1dac37e) (controller) - restart: wait for the pods to be scheduled
-- [`7647569`](https://github.com/deisthree/controller/commit/76475691f622e413f33c3b866f2e4ae81aa22b85) (controller) - scheduler: cast port to an int from environment (#857)
-- [`b27c816`](https://github.com/deisthree/controller/commit/b27c816e9ef21a989c68db23c0c98c02f726cf7b) (controller) - boot: change group ownership of docker socket to deis (#804)
-- [`d4415c9`](https://github.com/deisthree/controller/commit/d4415c9e6f0fa6c92b4b3ac2b70857d2c9c8f78a) (controller) - api: fail when rolling back to v1 (#762)
-- [`1ac6b54`](https://github.com/deisthree/controller/commit/1ac6b5489c84f68ace7a0a0050f8fc8988d339c7) (controller) - release: return port from get_port for non-routable process types
-- [`a0567ea`](https://github.com/deisthree/controller/commit/a0567eaae4747c466a191fbbe83c846cc521fb0c) (controller) - api: remove command escaping from v1 (#822)
-- [`f403efb`](https://github.com/deisthree/controller/commit/f403efb610787faee46225aa9e63f0ae8abeb525) (controller) - tests: sort domains in tests to get past occasional ordering problems which cause test failures
+- [`65f8714`](https://github.com/deis/dockerbuilder/commit/65f8714d6909bf23b4952544b8b0e10e54871571) (dockerbuilder) - objectstore: set properly builder bucket file environment variable
+- [`9179923`](https://github.com/deis/dockerbuilder/commit/91799230f043c81e726c23fe232d3e80c24b31eb) (dockerbuilder) - deploy.py: handle chunked output errors
+- [`02112ed`](https://github.com/deis/dockerbuilder/commit/02112edb7603ba2c2be3e764d9d107ef645329a8) (dockerbuilder) - deploy.py: delay so stderr is logged before pod exits
+- [`93b9c5c`](https://github.com/deis/logger/commit/93b9c5ce1496654432d35bf4bb51503e4b3a9805) (logger) - redis: Pass style checks
+- [`7144c4e`](https://github.com/deis/logger/commit/7144c4ef742844b6a5ab4c8d3420d5d86a0ac7d7) (logger) - rc: Specify use of redis storage adapter
+- [`9dae9cc`](https://github.com/deis/monitor/commit/9dae9cc9dbefb1314e68de79fe1db3d33ac7f8f2) (monitor) - telegraf: Create nsq topic at startup
+- [`a9b2275`](https://github.com/deis/monitor/commit/a9b2275da4eb892b986b0d16b44b77f1cfae05f6) (monitor) - telegraf: Update image default image tag in manifests
+- [`8fd5ada`](https://github.com/deis/monitor/commit/8fd5adaae198cf88e84abfa84e038ef04f21f3f5) (monitor) - grafana: Fix blank dashboards from appearing in dropdown
+- [`7de06cc`](https://github.com/deis/monitor/commit/7de06cc302beae72d986b11e28cac319e8a8bc7d) (monitor) - grafana: Redis cpu graph was not selecting right data
+- [`0492bf8`](https://github.com/deis/charts/commit/0492bf8972b8ffe1e7cf0685fe5eed2874ea5bd0) (charts) - database: Fix logic for selecting off-cluster db
+- [`6fd8407`](https://github.com/deis/charts/commit/6fd840784bccfe8d42130117252adafe62627e33) (charts) - logger: Do not helm keep rc deis-logger-redis
+- [`c425baf`](https://github.com/deis/workflow-cli/commit/c425baf440d283ec1f5434da00b46d56663f5d2f) (workflow-cli) - ps: restarting a single pod created by Deployments was not working
+- [`bcb8b01`](https://github.com/deis/workflow-cli/commit/bcb8b01dc42f0ce438be2a9da3584ba136af02ac) (workflow-cli) - ps: give ps:restart a better understanding between RC and Deployment pods
+- [`4b2c6d4`](https://github.com/deis/workflow-cli/commit/4b2c6d43e45eb926fa67dddb23b306999a486c4d) (workflow-cli) - scale: dont call controller if there is no valid scale pattern
+- [`32177aa`](https://github.com/deis/workflow-cli/commit/32177aa142642dd41d59d2ed322131fc61d2ebbc) (workflow-cli) - settings: don't panic on empty settings file (#134)
+- [`6214d96`](https://github.com/deis/controller/commit/6214d96d52fd9a0e9b0ee6ab098590316f51cd84) (controller) - scheduler: if one RC fails to scale then ensure all other RCs are at the right level
+- [`0bcea13`](https://github.com/deis/controller/commit/0bcea133f95e097b073c55e0c44445023c135887) (controller) - scale: return error message in proper format
+- [`7d24923`](https://github.com/deis/controller/commit/7d24923a06e51dcd1fe5c4a0a3148cb6a1dac37e) (controller) - restart: wait for the pods to be scheduled
+- [`7647569`](https://github.com/deis/controller/commit/76475691f622e413f33c3b866f2e4ae81aa22b85) (controller) - scheduler: cast port to an int from environment (#857)
+- [`b27c816`](https://github.com/deis/controller/commit/b27c816e9ef21a989c68db23c0c98c02f726cf7b) (controller) - boot: change group ownership of docker socket to deis (#804)
+- [`d4415c9`](https://github.com/deis/controller/commit/d4415c9e6f0fa6c92b4b3ac2b70857d2c9c8f78a) (controller) - api: fail when rolling back to v1 (#762)
+- [`1ac6b54`](https://github.com/deis/controller/commit/1ac6b5489c84f68ace7a0a0050f8fc8988d339c7) (controller) - release: return port from get_port for non-routable process types
+- [`a0567ea`](https://github.com/deis/controller/commit/a0567eaae4747c466a191fbbe83c846cc521fb0c) (controller) - api: remove command escaping from v1 (#822)
+- [`f403efb`](https://github.com/deis/controller/commit/f403efb610787faee46225aa9e63f0ae8abeb525) (controller) - tests: sort domains in tests to get past occasional ordering problems which cause test failures
 
 ### Documentation
 
-- [`dd2b505`](https://github.com/deisthree/workflow/commit/dd2b505b51da34bb972a474dcc6ffba632d12d26) (workflow) - logging,monitoring: Update platform-logging and monitoring docs with recent changes
-- [`dfb6c8e`](https://github.com/deisthree/workflow/commit/dfb6c8ee8851a2af3847eecb5473b6d2dcc5ce65) (workflow) - install-workflow: note that k8s 1.2.x is required
-- [`aa40a49`](https://github.com/deisthree/workflow/commit/aa40a49f199b83373c38497e2638107644299498) (workflow) - swift: Add swift as an object storage
-- [`3e7e865`](https://github.com/deisthree/workflow/commit/3e7e865edaaffda156f0f6a595757bf0c81ed0d3) (workflow) - deployments: add Deployments documentation
-- [`ee03d28`](https://github.com/deisthree/workflow/commit/ee03d284316287c2f473503afe0375eb975a1377) (workflow) - apps: document `DEIS_DEPLOY_TIMEOUT` and the nuances around that
+- [`dd2b505`](https://github.com/deis/workflow/commit/dd2b505b51da34bb972a474dcc6ffba632d12d26) (workflow) - logging,monitoring: Update platform-logging and monitoring docs with recent changes
+- [`dfb6c8e`](https://github.com/deis/workflow/commit/dfb6c8ee8851a2af3847eecb5473b6d2dcc5ce65) (workflow) - install-workflow: note that k8s 1.2.x is required
+- [`aa40a49`](https://github.com/deis/workflow/commit/aa40a49f199b83373c38497e2638107644299498) (workflow) - swift: Add swift as an object storage
+- [`3e7e865`](https://github.com/deis/workflow/commit/3e7e865edaaffda156f0f6a595757bf0c81ed0d3) (workflow) - deployments: add Deployments documentation
+- [`ee03d28`](https://github.com/deis/workflow/commit/ee03d284316287c2f473503afe0375eb975a1377) (workflow) - apps: document `DEIS_DEPLOY_TIMEOUT` and the nuances around that
 
 ### Maintenance
 
-- [`5c289c4`](https://github.com/deisthree/slugbuilder/commit/5c289c4cfda9815e0629d8b5f1e3848a612c481f) (slugbuilder) - buildpacks: update heroku-buildpack-go to v42
-- [`d5cdd0b`](https://github.com/deisthree/slugbuilder/commit/d5cdd0b83801d3302afbbe7ee9fa04fadc29caca) (slugbuilder) - buildpacks: update heroku-buildpack-php to v108
-- [`85c8292`](https://github.com/deisthree/slugbuilder/commit/85c82926352390150b72a15efd7826295f23475d) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v91
-- [`165105f`](https://github.com/deisthree/slugbuilder/commit/165105f366bdfc7a8a33e0c7be2e465a9799d4f3) (slugbuilder) - buildpacks: update heroku-buildpack-python to v81
-- [`9bbed87`](https://github.com/deisthree/slugbuilder/commit/9bbed872679ff038ad63f9c4c7b6ee043d0e4b76) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v71
+- [`5c289c4`](https://github.com/deis/slugbuilder/commit/5c289c4cfda9815e0629d8b5f1e3848a612c481f) (slugbuilder) - buildpacks: update heroku-buildpack-go to v42
+- [`d5cdd0b`](https://github.com/deis/slugbuilder/commit/d5cdd0b83801d3302afbbe7ee9fa04fadc29caca) (slugbuilder) - buildpacks: update heroku-buildpack-php to v108
+- [`85c8292`](https://github.com/deis/slugbuilder/commit/85c82926352390150b72a15efd7826295f23475d) (slugbuilder) - buildpacks: update heroku-buildpack-nodejs to v91
+- [`165105f`](https://github.com/deis/slugbuilder/commit/165105f366bdfc7a8a33e0c7be2e465a9799d4f3) (slugbuilder) - buildpacks: update heroku-buildpack-python to v81
+- [`9bbed87`](https://github.com/deis/slugbuilder/commit/9bbed872679ff038ad63f9c4c7b6ee043d0e4b76) (slugbuilder) - buildpacks: update heroku-buildpack-scala to v71

--- a/src/changelogs/v2.3.0.md
+++ b/src/changelogs/v2.3.0.md
@@ -1,110 +1,110 @@
 ### Workflow v2.2.0 -> v2.3.0
 
 #### Features
-- [`7fbeb3f`](https://github.com/deisthree/charts/commit/7fbeb3f6ed55512a7b032b8d3cb6b735a5abbe80) router: move deis-router to use Deployments
-- [`69831ed`](https://github.com/deisthree/charts/commit/69831edd177517883c110cc049d8ae0d1e5150e7) workflow-manager: move deis-workflow-manager to use Deployments
-- [`31cbcc9`](https://github.com/deisthree/charts/commit/31cbcc92952cb581f2a8222c07ac601d4a78c997) registry: move deis-registry to use Deployments
-- [`4173034`](https://github.com/deisthree/charts/commit/4173034bfd2a0324018dcf85a4a989b0cc56e90b) controller: move deis-controller to use Deployments
-- [`106e022`](https://github.com/deisthree/charts/commit/106e022b1721874838e4570c809a214068fbe17f) builder: move deis-builder to use Deployments
-- [`1692748`](https://github.com/deisthree/charts/commit/16927489219f8dc04ac253cabaff075600b01791) test: add TEST env variable to workflow e2e chart
-- [`78e77cb`](https://github.com/deisthree/charts/commit/78e77cb8e7ce5e096829a12c205bd659ae53cab3) workflow-dev: re-introduce registry-proxy
-- [`38c80bb`](https://github.com/deisthree/charts/commit/38c80bbd74cdc64781ebffb19532ccadffe43027) registry: Add support for private registry
-- [`79a26ec`](https://github.com/deisthree/charts/commit/79a26ec1b717e71d4bb80a3a70d7bbce4eab35cc) *: add helm-keep to all Deployments, like router already has
-- [`ed96f15`](https://github.com/deisthree/builder/commit/ed96f1550945218b10b615e3706f3aa94a41ece9) makefile: add deploy command to deploy image to k8s (#396)
-- [`a849301`](https://github.com/deisthree/builder/commit/a84930170ed9428c00931da89482b782a9df0cd1) makefile: add formating and linting tests (#394)
-- [`2f5642a`](https://github.com/deisthree/builder/commit/2f5642a4e7e5239ed5d05c819bb75b07a1d55a41) registry: Add support for external registry
-- [`ecfcea6`](https://github.com/deisthree/controller/commit/ecfcea6129e5ddced353aaa369cfd656f733d9bd) api: added auth/whoami endpoint (#737)
-- [`ba12d09`](https://github.com/deisthree/controller/commit/ba12d0971f43a085ce1d6d4db0c8bc264968eb96) boot: background the loading of DB data into Kubernetes
-- [`63c8f4d`](https://github.com/deisthree/controller/commit/63c8f4dfdfe9943801724ffacffb56b70129d063) app: during ps:restart run pod delete in parallel
-- [`ccf988b`](https://github.com/deisthree/controller/commit/ccf988b3657ac0076b4ec88ef6ce7ee2d6afd8e9) apps: scale / deploy run all process types in parallel instead of sequantially
-- [`7473e16`](https://github.com/deisthree/dockerbuilder/commit/7473e16ba3a30fc31d51bea80bf1c561d2864aa5) regsitry: Add support for private registry
-- [`76ea246`](https://github.com/deisthree/router/commit/76ea246732f6987951913877a7d0a24ed0619c9c) IDN: add support for international domains
-- [`7003286`](https://github.com/deisthree/router/commit/7003286a001933f14625730fd7e3ccc64567142a) Dockerfile: verify nginx pgp key (#219)
-- [`1f652ae`](https://github.com/deisthree/slugbuilder/commit/1f652aecc7e689eb6b23699ef5f3f8763350c75b) builder: add pre-compile/post-compile hooks
-- [`827a411`](https://github.com/deisthree/slugbuilder/commit/827a41174d8de6155fa98a0c7b8c619bfa65ac9b) builder: inject ENV_DIR into the environment
-- [`4e49625`](https://github.com/deisthree/workflow-manager/commit/4e49625317eb3abf415d2d6653b28463121a71ce) auth: basic auth for /v3/doctor/{id} API endpoint (#88)
-- [`84206b2`](https://github.com/deisthree/workflow-manager/commit/84206b2cac6e5065b6c0bda84a269f1582a06b66) deis doctor includes lots of k8s data
-- [`a8e23b6`](https://github.com/deisthree/workflow/commit/a8e23b696ba744a39c5a37afd8d0d13c2abfbbd0) registry: Add docs for configuring private registry
-- [`540c4ec`](https://github.com/deisthree/workflow/commit/540c4ec1dfcfe021bdbe7fa3631d21fdaeb06056) update: update docs to reflect v2.3.0
-- [`5615bb4`](https://github.com/deisthree/workflow-cli/commit/5615bb40c59ee68217631132b49c731efe8f6a6e) ci: send emails to slack on e2e failure (#133)
-- [`6e2954d`](https://github.com/deisthree/workflow-cli/commit/6e2954dd656aa385af75867262566091cb2bffce) shortcuts: add shortcuts test
-- [`f59bb66`](https://github.com/deisthree/workflow-cli/commit/f59bb66a1bf55a88bd198171bfdef776e5433d85) Jenkinsfile: no retry prompt if master
-- [`8168ea1`](https://github.com/deisthree/workflow-cli/commit/8168ea1e9b02f7c553d7d6578d90305dd47bd3fd) cmd: add auth:whoami --all
-- [`5e78fc4`](https://github.com/deisthree/workflow-cli/commit/5e78fc47c5f7d2b9fb9235a023288d8b42b2b863) Jenkinsfile: override 'sh' to add colorized output
-- [`fb6ed28`](https://github.com/deisthree/workflow-cli/commit/fb6ed281f2425a60fd9c04a2f3d31d06c328c944) Jenkinsfile: get actual PR commit, if PR
-- [`1199b9e`](https://github.com/deisthree/workflow-cli/commit/1199b9e0ad14453d1eea84dc55d7db58d0e74209) ci: add codecov (#146)
-- [`caf1fd0`](https://github.com/deisthree/workflow-cli/commit/caf1fd02f267f746be90742ba7ad653f495ad1d0) git: add more flags to the git command (#141)
+- [`7fbeb3f`](https://github.com/deis/charts/commit/7fbeb3f6ed55512a7b032b8d3cb6b735a5abbe80) router: move deis-router to use Deployments
+- [`69831ed`](https://github.com/deis/charts/commit/69831edd177517883c110cc049d8ae0d1e5150e7) workflow-manager: move deis-workflow-manager to use Deployments
+- [`31cbcc9`](https://github.com/deis/charts/commit/31cbcc92952cb581f2a8222c07ac601d4a78c997) registry: move deis-registry to use Deployments
+- [`4173034`](https://github.com/deis/charts/commit/4173034bfd2a0324018dcf85a4a989b0cc56e90b) controller: move deis-controller to use Deployments
+- [`106e022`](https://github.com/deis/charts/commit/106e022b1721874838e4570c809a214068fbe17f) builder: move deis-builder to use Deployments
+- [`1692748`](https://github.com/deis/charts/commit/16927489219f8dc04ac253cabaff075600b01791) test: add TEST env variable to workflow e2e chart
+- [`78e77cb`](https://github.com/deis/charts/commit/78e77cb8e7ce5e096829a12c205bd659ae53cab3) workflow-dev: re-introduce registry-proxy
+- [`38c80bb`](https://github.com/deis/charts/commit/38c80bbd74cdc64781ebffb19532ccadffe43027) registry: Add support for private registry
+- [`79a26ec`](https://github.com/deis/charts/commit/79a26ec1b717e71d4bb80a3a70d7bbce4eab35cc) *: add helm-keep to all Deployments, like router already has
+- [`ed96f15`](https://github.com/deis/builder/commit/ed96f1550945218b10b615e3706f3aa94a41ece9) makefile: add deploy command to deploy image to k8s (#396)
+- [`a849301`](https://github.com/deis/builder/commit/a84930170ed9428c00931da89482b782a9df0cd1) makefile: add formating and linting tests (#394)
+- [`2f5642a`](https://github.com/deis/builder/commit/2f5642a4e7e5239ed5d05c819bb75b07a1d55a41) registry: Add support for external registry
+- [`ecfcea6`](https://github.com/deis/controller/commit/ecfcea6129e5ddced353aaa369cfd656f733d9bd) api: added auth/whoami endpoint (#737)
+- [`ba12d09`](https://github.com/deis/controller/commit/ba12d0971f43a085ce1d6d4db0c8bc264968eb96) boot: background the loading of DB data into Kubernetes
+- [`63c8f4d`](https://github.com/deis/controller/commit/63c8f4dfdfe9943801724ffacffb56b70129d063) app: during ps:restart run pod delete in parallel
+- [`ccf988b`](https://github.com/deis/controller/commit/ccf988b3657ac0076b4ec88ef6ce7ee2d6afd8e9) apps: scale / deploy run all process types in parallel instead of sequantially
+- [`7473e16`](https://github.com/deis/dockerbuilder/commit/7473e16ba3a30fc31d51bea80bf1c561d2864aa5) regsitry: Add support for private registry
+- [`76ea246`](https://github.com/deis/router/commit/76ea246732f6987951913877a7d0a24ed0619c9c) IDN: add support for international domains
+- [`7003286`](https://github.com/deis/router/commit/7003286a001933f14625730fd7e3ccc64567142a) Dockerfile: verify nginx pgp key (#219)
+- [`1f652ae`](https://github.com/deis/slugbuilder/commit/1f652aecc7e689eb6b23699ef5f3f8763350c75b) builder: add pre-compile/post-compile hooks
+- [`827a411`](https://github.com/deis/slugbuilder/commit/827a41174d8de6155fa98a0c7b8c619bfa65ac9b) builder: inject ENV_DIR into the environment
+- [`4e49625`](https://github.com/deis/workflow-manager/commit/4e49625317eb3abf415d2d6653b28463121a71ce) auth: basic auth for /v3/doctor/{id} API endpoint (#88)
+- [`84206b2`](https://github.com/deis/workflow-manager/commit/84206b2cac6e5065b6c0bda84a269f1582a06b66) deis doctor includes lots of k8s data
+- [`a8e23b6`](https://github.com/deis/workflow/commit/a8e23b696ba744a39c5a37afd8d0d13c2abfbbd0) registry: Add docs for configuring private registry
+- [`540c4ec`](https://github.com/deis/workflow/commit/540c4ec1dfcfe021bdbe7fa3631d21fdaeb06056) update: update docs to reflect v2.3.0
+- [`5615bb4`](https://github.com/deis/workflow-cli/commit/5615bb40c59ee68217631132b49c731efe8f6a6e) ci: send emails to slack on e2e failure (#133)
+- [`6e2954d`](https://github.com/deis/workflow-cli/commit/6e2954dd656aa385af75867262566091cb2bffce) shortcuts: add shortcuts test
+- [`f59bb66`](https://github.com/deis/workflow-cli/commit/f59bb66a1bf55a88bd198171bfdef776e5433d85) Jenkinsfile: no retry prompt if master
+- [`8168ea1`](https://github.com/deis/workflow-cli/commit/8168ea1e9b02f7c553d7d6578d90305dd47bd3fd) cmd: add auth:whoami --all
+- [`5e78fc4`](https://github.com/deis/workflow-cli/commit/5e78fc47c5f7d2b9fb9235a023288d8b42b2b863) Jenkinsfile: override 'sh' to add colorized output
+- [`fb6ed28`](https://github.com/deis/workflow-cli/commit/fb6ed281f2425a60fd9c04a2f3d31d06c328c944) Jenkinsfile: get actual PR commit, if PR
+- [`1199b9e`](https://github.com/deis/workflow-cli/commit/1199b9e0ad14453d1eea84dc55d7db58d0e74209) ci: add codecov (#146)
+- [`caf1fd0`](https://github.com/deis/workflow-cli/commit/caf1fd02f267f746be90742ba7ad653f495ad1d0) git: add more flags to the git command (#141)
 
 #### Fixes
-- [`93098d6`](https://github.com/deisthree/charts/commit/93098d6727a11e6fba88b5d982f789ee9d724c06) registry: registry token refresher shouldn't be uninstalled when using in-cluster
-- [`e0e5712`](https://github.com/deisthree/builder/commit/e0e5712be8c094a5a685e7fcbf700c31d112f46a) k8s_util: proxy registry host/port information to dockerbuilder
-- [`766d73a`](https://github.com/deisthree/controller/commit/766d73af2b9e16798a9eedb63ce0683daa84dc94) release: old release shouldn't be deleted if new release fails
-- [`cf16d56`](https://github.com/deisthree/controller/commit/cf16d565e6d40110d6dfdfe029b8040290a5a79f) scheduler: only get logs for run pods when possible
-- [`a2c00ed`](https://github.com/deisthree/controller/commit/a2c00edeeea9eb6aa782f88cf466c29c92f9b21e) app: round the log message wait time using bankers rounding
-- [`4f9efb0`](https://github.com/deisthree/controller/commit/4f9efb042e33e62b9d75eb37c7a8cf8fe118a906) pull: release and build should be deleted on failed deis pull
-- [`e36f796`](https://github.com/deisthree/controller/commit/e36f796bc0e7153d1f5649f6b66f8c362c04e785) registry: User should be able to pull the image from internal registry
-- [`e99b852`](https://github.com/deisthree/controller/commit/e99b852607e0b9b9e74c3d9f9b415d34e03a1a77) boot: show a warning instead of error if a Deployment is in progress when Deis Workflow is starting up
-- [`02d9bb2`](https://github.com/deisthree/controller/commit/02d9bb20e358a2cc36fbc3d5170dbcfb099909bc) scheduler: check if an event stream was returned before pop()ing it
-- [`ffef759`](https://github.com/deisthree/controller/commit/ffef7591a3b4d601ccf4cb37ea304926ee5a00a8) scheduler: lower case CPU limits and upper case first char in Memory limits for Kubernetes
-- [`17a0ef0`](https://github.com/deisthree/controller/commit/17a0ef03dc20cdf06e192cfe8b7ba19b42bba236) registry: catch docker timeouts and show a nicer error
-- [`1d24ed6`](https://github.com/deisthree/controller/commit/1d24ed6f651aa19ea58e69f2b3dc647688e25b54) registry: Use proper hostname for dockerhub images
-- [`418eef7`](https://github.com/deisthree/controller/commit/418eef75539d9c8f3eb25b4b19070925263bffbf) registry: Add unit tests
-- [`a4d58d8`](https://github.com/deisthree/controller/commit/a4d58d86c22c2c17889a2580c575f8243af45307) validation: success threshold can only be equal to one when setting liveness probe. Error properly
-- [`d7c4632`](https://github.com/deisthree/controller/commit/d7c46324c1606d66f48b640ea061ac94866bc34a) models: add more sensible ordering to various API responses
-- [`f3bbc11`](https://github.com/deisthree/controller/commit/f3bbc11dbd2359bb4cde7e2b6d01520f3f66f35e) app: add verbose_name to App model due to a DRF 3.4.1 fix
-- [`a044e94`](https://github.com/deisthree/controller/commit/a044e947b9c411945b0984b17fe6d4652c4a55df) scale: return a 404 instead of 400 when scale uses a proc type that does not exist
-- [`6d6a10e`](https://github.com/deisthree/controller/commit/6d6a10e0533c17d16b2e8911cf3080e3e6f53234) middleware: remove unused server side version check (#937)
-- [`bab3632`](https://github.com/deisthree/controller/commit/bab36325f7f153aa4d1f12bef2adc2f338ae5a37) controller: only load latest config
-- [`8de5f6c`](https://github.com/deisthree/controller/commit/8de5f6c11bd74afdf53cc8aa8013593a91b71e13) secret: handle the secret value if it is None
-- [`614feb7`](https://github.com/deisthree/dockerbuilder/commit/614feb79c13aaa79888e581da627106ddd543659) deploy.py: remove insecure-registry requirement
-- [`38f839a`](https://github.com/deisthree/postgres/commit/38f839a2bfc6ffdc531aa62e1ac900e86189fe77) rootfs: check if recovery.conf is present
-- [`920afe5`](https://github.com/deisthree/router/commit/920afe5a510718bf4fcfbbdfec2d2ad9ef387459) router: BodySize config can be "0"
-- [`152680b`](https://github.com/deisthree/slugbuilder/commit/152680b054132d472f3edecda15a10b0d830be00) builder: remove CACHE_DIR from /bin/release
-- [`6aa120a`](https://github.com/deisthree/workflow-manager/commit/6aa120a6caab3e3c2a507a3eb826ecc2080b6e98) jobs: run periodic jobs once at start time (#89)
-- [`7fd06ce`](https://github.com/deisthree/workflow/commit/7fd06cec90270907f932f0f2fcf0bbaa606851e8) quickstart: fix link to buildpack documentation
-- [`e8dd0b5`](https://github.com/deisthree/workflow/commit/e8dd0b5cf676b48bc2186d93e6f9592a1a08fbed) releases: remove old milestone step
-- [`89e4177`](https://github.com/deisthree/workflow-cli/commit/89e41771867c88808a89d405b51e9a626a55fcf1) tests: set owner of files created by containers to the local user (#151)
-- [`c655ea0`](https://github.com/deisthree/workflow-cli/commit/c655ea0ceba12a077c6110ff10b873c1c48a4a35) test-style: make fmt fail style-test and fix existing formatting errors (#135)
-- [`f94b05f`](https://github.com/deisthree/workflow-cli/commit/f94b05f23ffd3f76833f866894c5b62d4eaeed8e) CI: don't allow untrusted commands when uploading (#154)
-- [`9d52c27`](https://github.com/deisthree/workflow-cli/commit/9d52c27824a6ec0cb38c54de0209df6cfcb79c34) git: fix linting error (#159)
-- [`1f412af`](https://github.com/deisthree/workflow-cli/commit/1f412afd5351b799c7b48a1caa26de472a4179c5) CI: False doesn't abort build (#158)
-- [`8c843a6`](https://github.com/deisthree/workflow-cli/commit/8c843a61edfb897a1281d28826b134d5f1f5336a) CI: add false to retry loop (#162)
+- [`93098d6`](https://github.com/deis/charts/commit/93098d6727a11e6fba88b5d982f789ee9d724c06) registry: registry token refresher shouldn't be uninstalled when using in-cluster
+- [`e0e5712`](https://github.com/deis/builder/commit/e0e5712be8c094a5a685e7fcbf700c31d112f46a) k8s_util: proxy registry host/port information to dockerbuilder
+- [`766d73a`](https://github.com/deis/controller/commit/766d73af2b9e16798a9eedb63ce0683daa84dc94) release: old release shouldn't be deleted if new release fails
+- [`cf16d56`](https://github.com/deis/controller/commit/cf16d565e6d40110d6dfdfe029b8040290a5a79f) scheduler: only get logs for run pods when possible
+- [`a2c00ed`](https://github.com/deis/controller/commit/a2c00edeeea9eb6aa782f88cf466c29c92f9b21e) app: round the log message wait time using bankers rounding
+- [`4f9efb0`](https://github.com/deis/controller/commit/4f9efb042e33e62b9d75eb37c7a8cf8fe118a906) pull: release and build should be deleted on failed deis pull
+- [`e36f796`](https://github.com/deis/controller/commit/e36f796bc0e7153d1f5649f6b66f8c362c04e785) registry: User should be able to pull the image from internal registry
+- [`e99b852`](https://github.com/deis/controller/commit/e99b852607e0b9b9e74c3d9f9b415d34e03a1a77) boot: show a warning instead of error if a Deployment is in progress when Deis Workflow is starting up
+- [`02d9bb2`](https://github.com/deis/controller/commit/02d9bb20e358a2cc36fbc3d5170dbcfb099909bc) scheduler: check if an event stream was returned before pop()ing it
+- [`ffef759`](https://github.com/deis/controller/commit/ffef7591a3b4d601ccf4cb37ea304926ee5a00a8) scheduler: lower case CPU limits and upper case first char in Memory limits for Kubernetes
+- [`17a0ef0`](https://github.com/deis/controller/commit/17a0ef03dc20cdf06e192cfe8b7ba19b42bba236) registry: catch docker timeouts and show a nicer error
+- [`1d24ed6`](https://github.com/deis/controller/commit/1d24ed6f651aa19ea58e69f2b3dc647688e25b54) registry: Use proper hostname for dockerhub images
+- [`418eef7`](https://github.com/deis/controller/commit/418eef75539d9c8f3eb25b4b19070925263bffbf) registry: Add unit tests
+- [`a4d58d8`](https://github.com/deis/controller/commit/a4d58d86c22c2c17889a2580c575f8243af45307) validation: success threshold can only be equal to one when setting liveness probe. Error properly
+- [`d7c4632`](https://github.com/deis/controller/commit/d7c46324c1606d66f48b640ea061ac94866bc34a) models: add more sensible ordering to various API responses
+- [`f3bbc11`](https://github.com/deis/controller/commit/f3bbc11dbd2359bb4cde7e2b6d01520f3f66f35e) app: add verbose_name to App model due to a DRF 3.4.1 fix
+- [`a044e94`](https://github.com/deis/controller/commit/a044e947b9c411945b0984b17fe6d4652c4a55df) scale: return a 404 instead of 400 when scale uses a proc type that does not exist
+- [`6d6a10e`](https://github.com/deis/controller/commit/6d6a10e0533c17d16b2e8911cf3080e3e6f53234) middleware: remove unused server side version check (#937)
+- [`bab3632`](https://github.com/deis/controller/commit/bab36325f7f153aa4d1f12bef2adc2f338ae5a37) controller: only load latest config
+- [`8de5f6c`](https://github.com/deis/controller/commit/8de5f6c11bd74afdf53cc8aa8013593a91b71e13) secret: handle the secret value if it is None
+- [`614feb7`](https://github.com/deis/dockerbuilder/commit/614feb79c13aaa79888e581da627106ddd543659) deploy.py: remove insecure-registry requirement
+- [`38f839a`](https://github.com/deis/postgres/commit/38f839a2bfc6ffdc531aa62e1ac900e86189fe77) rootfs: check if recovery.conf is present
+- [`920afe5`](https://github.com/deis/router/commit/920afe5a510718bf4fcfbbdfec2d2ad9ef387459) router: BodySize config can be "0"
+- [`152680b`](https://github.com/deis/slugbuilder/commit/152680b054132d472f3edecda15a10b0d830be00) builder: remove CACHE_DIR from /bin/release
+- [`6aa120a`](https://github.com/deis/workflow-manager/commit/6aa120a6caab3e3c2a507a3eb826ecc2080b6e98) jobs: run periodic jobs once at start time (#89)
+- [`7fd06ce`](https://github.com/deis/workflow/commit/7fd06cec90270907f932f0f2fcf0bbaa606851e8) quickstart: fix link to buildpack documentation
+- [`e8dd0b5`](https://github.com/deis/workflow/commit/e8dd0b5cf676b48bc2186d93e6f9592a1a08fbed) releases: remove old milestone step
+- [`89e4177`](https://github.com/deis/workflow-cli/commit/89e41771867c88808a89d405b51e9a626a55fcf1) tests: set owner of files created by containers to the local user (#151)
+- [`c655ea0`](https://github.com/deis/workflow-cli/commit/c655ea0ceba12a077c6110ff10b873c1c48a4a35) test-style: make fmt fail style-test and fix existing formatting errors (#135)
+- [`f94b05f`](https://github.com/deis/workflow-cli/commit/f94b05f23ffd3f76833f866894c5b62d4eaeed8e) CI: don't allow untrusted commands when uploading (#154)
+- [`9d52c27`](https://github.com/deis/workflow-cli/commit/9d52c27824a6ec0cb38c54de0209df6cfcb79c34) git: fix linting error (#159)
+- [`1f412af`](https://github.com/deis/workflow-cli/commit/1f412afd5351b799c7b48a1caa26de472a4179c5) CI: False doesn't abort build (#158)
+- [`8c843a6`](https://github.com/deis/workflow-cli/commit/8c843a61edfb897a1281d28826b134d5f1f5336a) CI: add false to retry loop (#162)
 
 #### Documentation
-- [`ed7c6de`](https://github.com/deisthree/controller/commit/ed7c6de26243a327882a2cd80fbc65b295f1c8a9) PR Template: switch from refs to requires as per new syntax
-- [`dc4e0ba`](https://github.com/deisthree/controller/commit/dc4e0ba3180cf1a46d0e5ea73377e858ffa5a81a) README: add debian installation instructions (#837)
-- [`feef1e4`](https://github.com/deisthree/workflow/commit/feef1e4b39f82b39a2f9f3d41d781adbe9c5dea9) dockerfiles: Add Bash to requirements list of Dockerfile/image
-- [`a3bd63b`](https://github.com/deisthree/workflow/commit/a3bd63bbde6224aa36a02a3981a055af523a9bfc) dockerfiles: Re-word bash requirement annotation
-- [`e7a25b5`](https://github.com/deisthree/workflow/commit/e7a25b56bcde14c3760749b59da699ea3d9d0a34) applications: reword deployments description
-- [`1cc7347`](https://github.com/deisthree/workflow/commit/1cc734727a48ada1a0f045dbdac85ef0439fe0fa) applications: add pre-compile/post-compile hook docs
-- [`2a63431`](https://github.com/deisthree/workflow/commit/2a63431ebdf9849317fde02b29ef50bf921e95aa) configuring-postgres: fix typo (of -> or)
-- [`835c9f3`](https://github.com/deisthree/workflow/commit/835c9f3543447a515c5596a2bf8cb993f40242a1) applications: fix up grammar under "Compile Hooks"
-- [`3cbe544`](https://github.com/deisthree/workflow/commit/3cbe5447a5723891e80a59e445078e56649f55c8) roadmap: rewrite for new release process
-- [`cb8c8d1`](https://github.com/deisthree/workflow/commit/cb8c8d1646e9f8040b7b8a41abf60586ebf4bec6) installing-workflow: remove insecure-registry documentation
-- [`9404953`](https://github.com/deisthree/workflow/commit/94049530a56dc49194b0651004d409272f9f22b6) reference: add /v2/auth/whoami endpoint
-- [`e28bc0f`](https://github.com/deisthree/workflow/commit/e28bc0f0f82b01056e77f9f929bf5b331271ff85) releases: add deisrel command to query released components
-- [`85d34d5`](https://github.com/deisthree/workflow/commit/85d34d563e8c45a3eed51e2abec68f7afadaf227) applications: explain how to add user ssh key
-- [`a3c749b`](https://github.com/deisthree/workflow/commit/a3c749bc645e2e16f8666d07401720678a2eb7cc) installing: add k8s 1.3.4+ as supported
-- [`272a8af`](https://github.com/deisthree/workflow/commit/272a8af57f3a1026b4662ab918deca92f447d233) releases: paste CHANGELOG into tag annotation
-- [`e4065f7`](https://github.com/deisthree/workflow/commit/e4065f7f814410ed6aec122050fc477ddaf511fe) release: restore seed-repo milestone step
-- [`e84fb14`](https://github.com/deisthree/workflow/commit/e84fb14a4f1d96d206ac09922cbba22903cd25a6) releases: tag workflow-* repositories
-- [`d637f06`](https://github.com/deisthree/workflow/commit/d637f0688f81d23a235d893609783d27a82efde1) styles: remove light shadow from doc text links
+- [`ed7c6de`](https://github.com/deis/controller/commit/ed7c6de26243a327882a2cd80fbc65b295f1c8a9) PR Template: switch from refs to requires as per new syntax
+- [`dc4e0ba`](https://github.com/deis/controller/commit/dc4e0ba3180cf1a46d0e5ea73377e858ffa5a81a) README: add debian installation instructions (#837)
+- [`feef1e4`](https://github.com/deis/workflow/commit/feef1e4b39f82b39a2f9f3d41d781adbe9c5dea9) dockerfiles: Add Bash to requirements list of Dockerfile/image
+- [`a3bd63b`](https://github.com/deis/workflow/commit/a3bd63bbde6224aa36a02a3981a055af523a9bfc) dockerfiles: Re-word bash requirement annotation
+- [`e7a25b5`](https://github.com/deis/workflow/commit/e7a25b56bcde14c3760749b59da699ea3d9d0a34) applications: reword deployments description
+- [`1cc7347`](https://github.com/deis/workflow/commit/1cc734727a48ada1a0f045dbdac85ef0439fe0fa) applications: add pre-compile/post-compile hook docs
+- [`2a63431`](https://github.com/deis/workflow/commit/2a63431ebdf9849317fde02b29ef50bf921e95aa) configuring-postgres: fix typo (of -> or)
+- [`835c9f3`](https://github.com/deis/workflow/commit/835c9f3543447a515c5596a2bf8cb993f40242a1) applications: fix up grammar under "Compile Hooks"
+- [`3cbe544`](https://github.com/deis/workflow/commit/3cbe5447a5723891e80a59e445078e56649f55c8) roadmap: rewrite for new release process
+- [`cb8c8d1`](https://github.com/deis/workflow/commit/cb8c8d1646e9f8040b7b8a41abf60586ebf4bec6) installing-workflow: remove insecure-registry documentation
+- [`9404953`](https://github.com/deis/workflow/commit/94049530a56dc49194b0651004d409272f9f22b6) reference: add /v2/auth/whoami endpoint
+- [`e28bc0f`](https://github.com/deis/workflow/commit/e28bc0f0f82b01056e77f9f929bf5b331271ff85) releases: add deisrel command to query released components
+- [`85d34d5`](https://github.com/deis/workflow/commit/85d34d563e8c45a3eed51e2abec68f7afadaf227) applications: explain how to add user ssh key
+- [`a3c749b`](https://github.com/deis/workflow/commit/a3c749bc645e2e16f8666d07401720678a2eb7cc) installing: add k8s 1.3.4+ as supported
+- [`272a8af`](https://github.com/deis/workflow/commit/272a8af57f3a1026b4662ab918deca92f447d233) releases: paste CHANGELOG into tag annotation
+- [`e4065f7`](https://github.com/deis/workflow/commit/e4065f7f814410ed6aec122050fc477ddaf511fe) release: restore seed-repo milestone step
+- [`e84fb14`](https://github.com/deis/workflow/commit/e84fb14a4f1d96d206ac09922cbba22903cd25a6) releases: tag workflow-* repositories
+- [`d637f06`](https://github.com/deis/workflow/commit/d637f0688f81d23a235d893609783d27a82efde1) styles: remove light shadow from doc text links
 
 #### Maintenance
-- [`a327912`](https://github.com/deisthree/charts/commit/a327912c68147de2dada421ca142e239b2429ed9) *: remove old charts that reference pre 2.0.0 release
-- [`c82f3eb`](https://github.com/deisthree/charts/commit/c82f3ebe005fb94729dceaf86917fc97aa199e46) workflow-v2.3.0: Release workflow and workflow-e2e version 2.3.0
-- [`c102d81`](https://github.com/deisthree/builder/commit/c102d81ec265196aef68807812f9764cf85d102c) Makefile: update docker-go-dev to 0.14.0 (#393)
-- [`c4c00bc`](https://github.com/deisthree/controller/commit/c4c00bc4f766f5ce6810aebadafb3b2ea8bededa) requirements: update requests-toolbelt to 0.7.0
-- [`122d2de`](https://github.com/deisthree/controller/commit/122d2de8dd1664345e876869128f9dee16c72343) requirements: update ndg-httpsclient to 0.4.2
-- [`b606adb`](https://github.com/deisthree/controller/commit/b606adb899a57c053a1de9b75e4c70ef2976aa7c) requirements: update Django REST Framework to 3.4.0
-- [`2196b58`](https://github.com/deisthree/controller/commit/2196b581ab39727884a057dcf4bc7a92d4f92b61) requirements: update Django to 1.9.8
-- [`f530e2b`](https://github.com/deisthree/controller/commit/f530e2b7b6a9243ace32b4068ae1e889b7ab8b72) requirements: update to docker-py 1.9.0
-- [`c19cdfc`](https://github.com/deisthree/controller/commit/c19cdfcf332032be3e4a8a7222153b176999f1e5) dev_requirements: update coverage lib to 4.2.0
-- [`745d6d0`](https://github.com/deisthree/controller/commit/745d6d0e6ee4278eeb6c5f0b5120fd8c886994b9) requirements: Update to DRF 3.4.1
-- [`72f0df8`](https://github.com/deisthree/controller/commit/72f0df83a8b364869a543639eb8a6730fb167f91) requirements: move from django-cors-headers to django-cors-middleware
-- [`f6bfbeb`](https://github.com/deisthree/controller/commit/f6bfbeb31c5b96c1529b7bb0ddaeef2fb01d93b4) api: bump API version to v2.2.0
-- [`58a837a`](https://github.com/deisthree/dockerbuilder/commit/58a837a0ec5e2d5b3725ff442fd7641f2fd748b3) Dockerfile: update pip to 8.1.2
-- [`a948381`](https://github.com/deisthree/router/commit/a948381dcbff07c0f23a24121a8b24cd3c6db69e) *: update docker-go-dev and switch to using new linter (#220)
-- [`a5e8416`](https://github.com/deisthree/workflow/commit/a5e8416800e531caa59b0f29459de2bae3404c68) english language: upgrade != total uninstall
-- [`cc4f07e`](https://github.com/deisthree/workflow-cli/commit/cc4f07e2b89caabfc8947f77a9f2c1a1d7716ba6) *: upgrade docker-go-dev and use new linter (#155)
-- [`87820c4`](https://github.com/deisthree/workflow-cli/commit/87820c4a0dd1866a8110daa3021e7f8cf766bcdc) glide: update controller-sdk-go
+- [`a327912`](https://github.com/deis/charts/commit/a327912c68147de2dada421ca142e239b2429ed9) *: remove old charts that reference pre 2.0.0 release
+- [`c82f3eb`](https://github.com/deis/charts/commit/c82f3ebe005fb94729dceaf86917fc97aa199e46) workflow-v2.3.0: Release workflow and workflow-e2e version 2.3.0
+- [`c102d81`](https://github.com/deis/builder/commit/c102d81ec265196aef68807812f9764cf85d102c) Makefile: update docker-go-dev to 0.14.0 (#393)
+- [`c4c00bc`](https://github.com/deis/controller/commit/c4c00bc4f766f5ce6810aebadafb3b2ea8bededa) requirements: update requests-toolbelt to 0.7.0
+- [`122d2de`](https://github.com/deis/controller/commit/122d2de8dd1664345e876869128f9dee16c72343) requirements: update ndg-httpsclient to 0.4.2
+- [`b606adb`](https://github.com/deis/controller/commit/b606adb899a57c053a1de9b75e4c70ef2976aa7c) requirements: update Django REST Framework to 3.4.0
+- [`2196b58`](https://github.com/deis/controller/commit/2196b581ab39727884a057dcf4bc7a92d4f92b61) requirements: update Django to 1.9.8
+- [`f530e2b`](https://github.com/deis/controller/commit/f530e2b7b6a9243ace32b4068ae1e889b7ab8b72) requirements: update to docker-py 1.9.0
+- [`c19cdfc`](https://github.com/deis/controller/commit/c19cdfcf332032be3e4a8a7222153b176999f1e5) dev_requirements: update coverage lib to 4.2.0
+- [`745d6d0`](https://github.com/deis/controller/commit/745d6d0e6ee4278eeb6c5f0b5120fd8c886994b9) requirements: Update to DRF 3.4.1
+- [`72f0df8`](https://github.com/deis/controller/commit/72f0df83a8b364869a543639eb8a6730fb167f91) requirements: move from django-cors-headers to django-cors-middleware
+- [`f6bfbeb`](https://github.com/deis/controller/commit/f6bfbeb31c5b96c1529b7bb0ddaeef2fb01d93b4) api: bump API version to v2.2.0
+- [`58a837a`](https://github.com/deis/dockerbuilder/commit/58a837a0ec5e2d5b3725ff442fd7641f2fd748b3) Dockerfile: update pip to 8.1.2
+- [`a948381`](https://github.com/deis/router/commit/a948381dcbff07c0f23a24121a8b24cd3c6db69e) *: update docker-go-dev and switch to using new linter (#220)
+- [`a5e8416`](https://github.com/deis/workflow/commit/a5e8416800e531caa59b0f29459de2bae3404c68) english language: upgrade != total uninstall
+- [`cc4f07e`](https://github.com/deis/workflow-cli/commit/cc4f07e2b89caabfc8947f77a9f2c1a1d7716ba6) *: upgrade docker-go-dev and use new linter (#155)
+- [`87820c4`](https://github.com/deis/workflow-cli/commit/87820c4a0dd1866a8110daa3021e7f8cf766bcdc) glide: update controller-sdk-go

--- a/src/changelogs/v2.4.0.md
+++ b/src/changelogs/v2.4.0.md
@@ -4,168 +4,168 @@
 
 #### Features
 
-- [`e292969`](https://github.com/deisthree/builder/commit/e2929696cb46cb49099b666709f2f8bb92179404) *: switch to using controller-sdk-go for controller interactions (#402)
+- [`e292969`](https://github.com/deis/builder/commit/e2929696cb46cb49099b666709f2f8bb92179404) *: switch to using controller-sdk-go for controller interactions (#402)
 
 #### Fixes
 
-- [`d340772`](https://github.com/deisthree/builder/commit/d340772453bcb38b7e5241818b4e7a10a7bde308) pod: log pod error status and message instead of pod struct
-- [`0690f89`](https://github.com/deisthree/builder/commit/0690f89f5e0c3d35817610336cc1e26b878cbe77) _tests: remove out of date functional tests (#406)
-- [`e791c1d`](https://github.com/deisthree/builder/commit/e791c1d3f066597afc5cb0370bdaf9a30107a844) gitreceive: change target name to Workflow
+- [`d340772`](https://github.com/deis/builder/commit/d340772453bcb38b7e5241818b4e7a10a7bde308) pod: log pod error status and message instead of pod struct
+- [`0690f89`](https://github.com/deis/builder/commit/0690f89f5e0c3d35817610336cc1e26b878cbe77) _tests: remove out of date functional tests (#406)
+- [`e791c1d`](https://github.com/deis/builder/commit/e791c1d3f066597afc5cb0370bdaf9a30107a844) gitreceive: change target name to Workflow
 
 
 ### Controller v2.3.1 -> v2.4.0
 
 #### Features
-- [`a7cff7e`](https://github.com/deisthree/controller/commit/a7cff7e92c8ad0c158708c24db66babc68d1fcb8) models: add routable flag to Config (#934)
-- [`cebd736`](https://github.com/deisthree/controller/commit/cebd7364c929f920a6414f6d1629c9877309bdea) scheduler: add scheduler tests that do not go through normal api tests (#965)
-- [`2a41942`](https://github.com/deisthree/controller/commit/2a41942f211849fb57b7e5e15723a2b2c97a46a4) healthcheck: Add support to create healthcheck per proctype Requires workflow-cli#160
-- [`3e988ea`](https://github.com/deisthree/controller/commit/3e988ea55ff43c25ea6165431120affddaf7ec43) model: Add new model to store settings
+- [`a7cff7e`](https://github.com/deis/controller/commit/a7cff7e92c8ad0c158708c24db66babc68d1fcb8) models: add routable flag to Config (#934)
+- [`cebd736`](https://github.com/deis/controller/commit/cebd7364c929f920a6414f6d1629c9877309bdea) scheduler: add scheduler tests that do not go through normal api tests (#965)
+- [`2a41942`](https://github.com/deis/controller/commit/2a41942f211849fb57b7e5e15723a2b2c97a46a4) healthcheck: Add support to create healthcheck per proctype Requires workflow-cli#160
+- [`3e988ea`](https://github.com/deis/controller/commit/3e988ea55ff43c25ea6165431120affddaf7ec43) model: Add new model to store settings
 
 #### Fixes
-- [`54f0f75`](https://github.com/deisthree/controller/commit/54f0f75eb6f43a42aaa6f9afc2191039b22961e3) app: adjust async for better usage and to account for asyncio bug
-- [`855bb59`](https://github.com/deisthree/controller/commit/855bb59db379dcf5b673c2b2d596662cc2d34fa9) scheduler: create application config (env secrets) outside of deploy / scale to reduce k8s thrasing
-- [`996be37`](https://github.com/deisthree/controller/commit/996be37e07d78b2295cca2e3ba8944f31e006f15) mock: mock scheduler could not gracefully handle the concurrent deploy / scale
-- [`7da5212`](https://github.com/deisthree/controller/commit/7da521242908154ffdc28a40655fde1b03e60fd5) run: return a 400 if command is empty (#952)
-- [`c91f361`](https://github.com/deisthree/controller/commit/c91f361d4842a0c2964ce85a999cf781219cd3ce) passwd: raise 400 when password is not a parameter (#850)
-- [`544f492`](https://github.com/deisthree/controller/commit/544f4925241f48b0f08fe9b5b087bfa511d67993) scheduler: in scheduler::run check if pod state is an object or a string before acing on it (#957)
-- [`a4ee5a8`](https://github.com/deisthree/controller/commit/a4ee5a8019efa13e1e27ebe892f49ff7fbc8ec6e) health: Add healthchecks only for routable apps or proctypes
-- [`37ea65c`](https://github.com/deisthree/controller/commit/37ea65cba01e07361ba2a45924662a5c455d9f38) Makefile: add deis namespace to make deploy (#969)
-- [`7f19c48`](https://github.com/deisthree/controller/commit/7f19c48a9bfd6e4a00fb7dd124d89d235763a1f8) scheduler: make app un-routable (#974)
-- [`6cfeba0`](https://github.com/deisthree/controller/commit/6cfeba03855795e08f488d3f5b08567be1c96131) scheduler: when user asks for limits beyond their allowance then error out faster (#975)
-- [`7a152a6`](https://github.com/deisthree/controller/commit/7a152a6f3fbe2359d2a391c2ab7476e4def6a9e1) scheduler: allow Deployment "in progress" to be bypassed in case of errors or timeout (#978)
-- [`bf82529`](https://github.com/deisthree/controller/commit/bf8252925a5f5f6864d8884f8726e466c9ba608f) registry: retry pull/push/tag 3 times - should help with slow networks and slow registries (#979)
+- [`54f0f75`](https://github.com/deis/controller/commit/54f0f75eb6f43a42aaa6f9afc2191039b22961e3) app: adjust async for better usage and to account for asyncio bug
+- [`855bb59`](https://github.com/deis/controller/commit/855bb59db379dcf5b673c2b2d596662cc2d34fa9) scheduler: create application config (env secrets) outside of deploy / scale to reduce k8s thrasing
+- [`996be37`](https://github.com/deis/controller/commit/996be37e07d78b2295cca2e3ba8944f31e006f15) mock: mock scheduler could not gracefully handle the concurrent deploy / scale
+- [`7da5212`](https://github.com/deis/controller/commit/7da521242908154ffdc28a40655fde1b03e60fd5) run: return a 400 if command is empty (#952)
+- [`c91f361`](https://github.com/deis/controller/commit/c91f361d4842a0c2964ce85a999cf781219cd3ce) passwd: raise 400 when password is not a parameter (#850)
+- [`544f492`](https://github.com/deis/controller/commit/544f4925241f48b0f08fe9b5b087bfa511d67993) scheduler: in scheduler::run check if pod state is an object or a string before acing on it (#957)
+- [`a4ee5a8`](https://github.com/deis/controller/commit/a4ee5a8019efa13e1e27ebe892f49ff7fbc8ec6e) health: Add healthchecks only for routable apps or proctypes
+- [`37ea65c`](https://github.com/deis/controller/commit/37ea65cba01e07361ba2a45924662a5c455d9f38) Makefile: add deis namespace to make deploy (#969)
+- [`7f19c48`](https://github.com/deis/controller/commit/7f19c48a9bfd6e4a00fb7dd124d89d235763a1f8) scheduler: make app un-routable (#974)
+- [`6cfeba0`](https://github.com/deis/controller/commit/6cfeba03855795e08f488d3f5b08567be1c96131) scheduler: when user asks for limits beyond their allowance then error out faster (#975)
+- [`7a152a6`](https://github.com/deis/controller/commit/7a152a6f3fbe2359d2a391c2ab7476e4def6a9e1) scheduler: allow Deployment "in progress" to be bypassed in case of errors or timeout (#978)
+- [`bf82529`](https://github.com/deis/controller/commit/bf8252925a5f5f6864d8884f8726e466c9ba608f) registry: retry pull/push/tag 3 times - should help with slow networks and slow registries (#979)
 
 #### Documentation
-- [`cc6617e`](https://github.com/deisthree/controller/commit/cc6617ed52262e22f377a7e2a37ed419811a2393) README.md: add postgresql prereq
+- [`cc6617e`](https://github.com/deis/controller/commit/cc6617ed52262e22f377a7e2a37ed419811a2393) README.md: add postgresql prereq
 
 #### Maintenance
-- [`e0a3f02`](https://github.com/deisthree/controller/commit/e0a3f027d1a6a217eb1138a89ceaf73d91171a24) requirements: Django REST Framework 3.4.3
-- [`77dbf94`](https://github.com/deisthree/controller/commit/77dbf94c454bf44f6c5fd3d9785eaf8d394e67aa) travis: cache pip in travis runs (#944)
-- [`b66948d`](https://github.com/deisthree/controller/commit/b66948d5dfbcfdb6adbf9da2e4ad0e4739ba4e9f) requirements: requests update to 2.11.0 (#962)
-- [`6e6d257`](https://github.com/deisthree/controller/commit/6e6d25744f5ea3c58919c47a67d4a561b2c2fe5b) requirements: update to django-guardian 1.4.5 (#964)
-- [`87a92f6`](https://github.com/deisthree/controller/commit/87a92f694bfa32fd1ca20be07b5b160aeab173b3) requirements: update backoff 1.3.1 (#963)
-- [`c6e3eb3`](https://github.com/deisthree/controller/commit/c6e3eb30987b39a7584596a0f13d2cf52587cc43) migrations: create a migration for various alterations that do not touch schema (#967)
-- [`a16aa8c`](https://github.com/deisthree/controller/commit/a16aa8c7790aea3676f392e9b4ca5d973912c7f0) requirements: Update Django REST Framework to 3.4.4 (#976)
+- [`e0a3f02`](https://github.com/deis/controller/commit/e0a3f027d1a6a217eb1138a89ceaf73d91171a24) requirements: Django REST Framework 3.4.3
+- [`77dbf94`](https://github.com/deis/controller/commit/77dbf94c454bf44f6c5fd3d9785eaf8d394e67aa) travis: cache pip in travis runs (#944)
+- [`b66948d`](https://github.com/deis/controller/commit/b66948d5dfbcfdb6adbf9da2e4ad0e4739ba4e9f) requirements: requests update to 2.11.0 (#962)
+- [`6e6d257`](https://github.com/deis/controller/commit/6e6d25744f5ea3c58919c47a67d4a561b2c2fe5b) requirements: update to django-guardian 1.4.5 (#964)
+- [`87a92f6`](https://github.com/deis/controller/commit/87a92f694bfa32fd1ca20be07b5b160aeab173b3) requirements: update backoff 1.3.1 (#963)
+- [`c6e3eb3`](https://github.com/deis/controller/commit/c6e3eb30987b39a7584596a0f13d2cf52587cc43) migrations: create a migration for various alterations that do not touch schema (#967)
+- [`a16aa8c`](https://github.com/deis/controller/commit/a16aa8c7790aea3676f392e9b4ca5d973912c7f0) requirements: Update Django REST Framework to 3.4.4 (#976)
 
 
 ### Database v2.2.1 -> v2.2.2
 
 #### Maintenance
-- [`022f2c5`](https://github.com/deisthree/postgres/commit/022f2c5496fb9488df4f5c5f782140ab136d0e30) Update the postgres version
+- [`022f2c5`](https://github.com/deis/postgres/commit/022f2c5496fb9488df4f5c5f782140ab136d0e30) Update the postgres version
 
 
 ### Dockerbuilder v2.3.0 -> v2.3.1
 
 #### Maintenance
-- [`31065a3`](https://github.com/deisthree/dockerbuilder/commit/31065a39ba84ddffbadaef97f52e7c8511e599f4) Dockerfile: update deis/base to 0.3.0
+- [`31065a3`](https://github.com/deis/dockerbuilder/commit/31065a39ba84ddffbadaef97f52e7c8511e599f4) Dockerfile: update deis/base to 0.3.0
 
 
 ### Monitoring v2.2.0 -> v2.3.0
 
 #### Features
-- [`527d4dd`](https://github.com/deisthree/monitor/commit/527d4dd91b25332315d8601862d363b54a1a6605) dashboards: create dashboards for all deis components
+- [`527d4dd`](https://github.com/deis/monitor/commit/527d4dd91b25332315d8601862d363b54a1a6605) dashboards: create dashboards for all deis components
 
 #### Fixes
-- [`3b15224`](https://github.com/deisthree/monitor/commit/3b15224c6136ceb00496afbe4fe583b8e4582ad8) ini: a stray quote was causing INI parsing to break
-- [`a21e7e4`](https://github.com/deisthree/monitor/commit/a21e7e49f5f6db1326f5d7a2674b1610bba8bd21) start-grafana: Create dashboard directory when starting grafana
+- [`3b15224`](https://github.com/deis/monitor/commit/3b15224c6136ceb00496afbe4fe583b8e4582ad8) ini: a stray quote was causing INI parsing to break
+- [`a21e7e4`](https://github.com/deis/monitor/commit/a21e7e49f5f6db1326f5d7a2674b1610bba8bd21) start-grafana: Create dashboard directory when starting grafana
 
 #### Documentation
-- [`2548941`](https://github.com/deisthree/monitor/commit/2548941c3bc11526aa6c09096186b08edc6d1860) readme: Provide a configuration section in grafana readme
+- [`2548941`](https://github.com/deis/monitor/commit/2548941c3bc11526aa6c09096186b08edc6d1860) readme: Provide a configuration section in grafana readme
 
 
 ### Router v2.3.0 -> v2.4.0
 
 #### Features
-- [`01cf487`](https://github.com/deisthree/router/commit/01cf487346a0e120d18e21ecc301284e8449163f) *: Update nginx to 1.11.2
-- [`571dfea`](https://github.com/deisthree/router/commit/571dfeacb2fbd1ee21645a1de42d18c103288ad3) router: Get the annotations from the deployment object instead of RC
-- [`59e753c`](https://github.com/deisthree/router/commit/59e753cbafed64a2e39b40f426457cfe95331def) maintenance: Add support for maintenance mode for apps
+- [`01cf487`](https://github.com/deis/router/commit/01cf487346a0e120d18e21ecc301284e8449163f) *: Update nginx to 1.11.2
+- [`571dfea`](https://github.com/deis/router/commit/571dfeacb2fbd1ee21645a1de42d18c103288ad3) router: Get the annotations from the deployment object instead of RC
+- [`59e753c`](https://github.com/deis/router/commit/59e753cbafed64a2e39b40f426457cfe95331def) maintenance: Add support for maintenance mode for apps
 
 #### Fixes
-- [`1769d2d`](https://github.com/deisthree/router/commit/1769d2dcbe6a51ad735484cea1b9164b373725dc) model: Improve regex for SSL ciphers
-- [`e085023`](https://github.com/deisthree/router/commit/e0850238d814eedc8f33baa383b8a6a17e9f5a79) routable: Use correct label key for routable
-- [`c00da10`](https://github.com/deisthree/router/commit/c00da102576463a1a40b4e02b1a72d3fd57f9a5f) model: Specify a default ssl cipher list
+- [`1769d2d`](https://github.com/deis/router/commit/1769d2dcbe6a51ad735484cea1b9164b373725dc) model: Improve regex for SSL ciphers
+- [`e085023`](https://github.com/deis/router/commit/e0850238d814eedc8f33baa383b8a6a17e9f5a79) routable: Use correct label key for routable
+- [`c00da10`](https://github.com/deis/router/commit/c00da102576463a1a40b4e02b1a72d3fd57f9a5f) model: Specify a default ssl cipher list
 
 #### Documentation
-- [`7cbf93e`](https://github.com/deisthree/router/commit/7cbf93ea9e3593a811a0101042a74436c1f607b9) readme: Clarify that routable services must expose port 80
+- [`7cbf93e`](https://github.com/deis/router/commit/7cbf93ea9e3593a811a0101042a74436c1f607b9) readme: Clarify that routable services must expose port 80
 
 #### Maintenance
-- [`541b19b`](https://github.com/deisthree/router/commit/541b19bbcfded5d8cce970c209533474baff994e) .gitignore: Update to ignore deis-router-deployment.tmp.yaml
+- [`541b19b`](https://github.com/deis/router/commit/541b19bbcfded5d8cce970c209533474baff994e) .gitignore: Update to ignore deis-router-deployment.tmp.yaml
 
 
 ### Slugbuilder v2.3.0 -> v2.3.1
 
 #### Maintenance
-- [`815d0a7`](https://github.com/deisthree/slugbuilder/commit/815d0a792be0c296f6d524145687bf86f3166b46) buildpacks: update heroku-buildpack-go to v44
-- [`7b34cb5`](https://github.com/deisthree/slugbuilder/commit/7b34cb58e9e43011d52cd27517b1704fdabab923) buildpacks: update heroku-buildpack-scala to v72
-- [`f647afe`](https://github.com/deisthree/slugbuilder/commit/f647afe86d1c9ec70129073613b692d4abb72d08) buildpacks: update php buildpack
+- [`815d0a7`](https://github.com/deis/slugbuilder/commit/815d0a792be0c296f6d524145687bf86f3166b46) buildpacks: update heroku-buildpack-go to v44
+- [`7b34cb5`](https://github.com/deis/slugbuilder/commit/7b34cb58e9e43011d52cd27517b1704fdabab923) buildpacks: update heroku-buildpack-scala to v72
+- [`f647afe`](https://github.com/deis/slugbuilder/commit/f647afe86d1c9ec70129073613b692d4abb72d08) buildpacks: update php buildpack
 
 
 ### Workflow CLI v2.3.0 -> v2.4.0
 
 #### Features
-- [`f37432b`](https://github.com/deisthree/workflow-cli/commit/f37432bb3b7422bc9db510fa785fdd04fadcc26c) Jenkinsfile: send COMPONENT_REPO param to e2e job
-- [`dfe19e0`](https://github.com/deisthree/workflow-cli/commit/dfe19e0f03fd726d9e5ef2022d562826ff0ee72c) logging: extract logging to its own package and write tests (#166)
-- [`7b4c48d`](https://github.com/deisthree/workflow-cli/commit/7b4c48de2d63b9661c3af552661c0efe9dd39718) cmd: add deis routing
-- [`37cdb52`](https://github.com/deisthree/workflow-cli/commit/37cdb52576f78692030d11f4357b038766763251) healthcheck: Add support for healthcheck per proctype
-- [`4df89d2`](https://github.com/deisthree/workflow-cli/commit/4df89d2e6a36926beca68f2cc20b6a9ca4de94d7) maintenance: Add support for maintenance mode for apps
-- [`7a9ebf4`](https://github.com/deisthree/workflow-cli/commit/7a9ebf48ab8f139e864c3e5cacab5f885e709c7d) Jenkinsfile: wipe vendor dir if bootstrap fails
-- [`47def28`](https://github.com/deisthree/workflow-cli/commit/47def285be17a4fe8b8ffd6b758e82a9bd948e0a) Makefile: add git branch and sha information to the uploaded blob
-- [`2103657`](https://github.com/deisthree/workflow-cli/commit/2103657bde803f2d03011d5f0b0c3497da5e2b42) *: allow configuration flag (#169)
+- [`f37432b`](https://github.com/deis/workflow-cli/commit/f37432bb3b7422bc9db510fa785fdd04fadcc26c) Jenkinsfile: send COMPONENT_REPO param to e2e job
+- [`dfe19e0`](https://github.com/deis/workflow-cli/commit/dfe19e0f03fd726d9e5ef2022d562826ff0ee72c) logging: extract logging to its own package and write tests (#166)
+- [`7b4c48d`](https://github.com/deis/workflow-cli/commit/7b4c48de2d63b9661c3af552661c0efe9dd39718) cmd: add deis routing
+- [`37cdb52`](https://github.com/deis/workflow-cli/commit/37cdb52576f78692030d11f4357b038766763251) healthcheck: Add support for healthcheck per proctype
+- [`4df89d2`](https://github.com/deis/workflow-cli/commit/4df89d2e6a36926beca68f2cc20b6a9ca4de94d7) maintenance: Add support for maintenance mode for apps
+- [`7a9ebf4`](https://github.com/deis/workflow-cli/commit/7a9ebf48ab8f139e864c3e5cacab5f885e709c7d) Jenkinsfile: wipe vendor dir if bootstrap fails
+- [`47def28`](https://github.com/deis/workflow-cli/commit/47def285be17a4fe8b8ffd6b758e82a9bd948e0a) Makefile: add git branch and sha information to the uploaded blob
+- [`2103657`](https://github.com/deis/workflow-cli/commit/2103657bde803f2d03011d5f0b0c3497da5e2b42) *: allow configuration flag (#169)
 
 #### Fixes
-- [`6745e75`](https://github.com/deisthree/workflow-cli/commit/6745e755148aeba5ddc464b0a2b7cecc65e44af0) version: move all version logic to git (#167)
-- [`4f2d342`](https://github.com/deisthree/workflow-cli/commit/4f2d34227541dd8dcec5144192320ced65ba905c) healthcheck: Don't fail if there is no healthcheck for a proctype
-- [`ba9d5d7`](https://github.com/deisthree/workflow-cli/commit/ba9d5d70396581636cf930a7b1d3eb4e330cf731) CI: don't cache latest binaries (#175)
-- [`36df5d4`](https://github.com/deisthree/workflow-cli/commit/36df5d45b87b7c1c4c92abad5355bfbad57f8961) CI: delete artifacts when cleaning up (#179)
+- [`6745e75`](https://github.com/deis/workflow-cli/commit/6745e755148aeba5ddc464b0a2b7cecc65e44af0) version: move all version logic to git (#167)
+- [`4f2d342`](https://github.com/deis/workflow-cli/commit/4f2d34227541dd8dcec5144192320ced65ba905c) healthcheck: Don't fail if there is no healthcheck for a proctype
+- [`ba9d5d7`](https://github.com/deis/workflow-cli/commit/ba9d5d70396581636cf930a7b1d3eb4e330cf731) CI: don't cache latest binaries (#175)
+- [`36df5d4`](https://github.com/deis/workflow-cli/commit/36df5d45b87b7c1c4c92abad5355bfbad57f8961) CI: delete artifacts when cleaning up (#179)
 
 
 ### Workflow Documentation v2.3.0 -> v2.4.0
 
 #### Features
-- [`af7cf12`](https://github.com/deisthree/workflow/commit/af7cf12cc5765e638dc3ee0ce02523e42abf21b0) healthcheck: Add docs for applying healthchecks per proctype
-- [`d84c0a1`](https://github.com/deisthree/workflow/commit/d84c0a1f45afd886cb760bf913c0608cc62cef1e) troubleshooting: add troubleshooting applications
-- [`7477ae7`](https://github.com/deisthree/workflow/commit/7477ae7526760deff9ec36b19d2a633a94356a25) docs: add documentation for limits
-- [`4ea0719`](https://github.com/deisthree/workflow/commit/4ea07191debf5f8af1a2823d33ff9de7835c11b7) CLI: document new behavior of  variable (#440)
-- [`c41f71e`](https://github.com/deisthree/workflow/commit/c41f71e0b2765a2bfa185edc08987db7c1c0a5d6) maintenance: Add docs for maintenance mode support
+- [`af7cf12`](https://github.com/deis/workflow/commit/af7cf12cc5765e638dc3ee0ce02523e42abf21b0) healthcheck: Add docs for applying healthchecks per proctype
+- [`d84c0a1`](https://github.com/deis/workflow/commit/d84c0a1f45afd886cb760bf913c0608cc62cef1e) troubleshooting: add troubleshooting applications
+- [`7477ae7`](https://github.com/deis/workflow/commit/7477ae7526760deff9ec36b19d2a633a94356a25) docs: add documentation for limits
+- [`4ea0719`](https://github.com/deis/workflow/commit/4ea07191debf5f8af1a2823d33ff9de7835c11b7) CLI: document new behavior of  variable (#440)
+- [`c41f71e`](https://github.com/deis/workflow/commit/c41f71e0b2765a2bfa185edc08987db7c1c0a5d6) maintenance: Add docs for maintenance mode support
 
 #### Fixes
-- [`fde9a81`](https://github.com/deisthree/workflow/commit/fde9a810c58b4483583a743e0a701238209bcb3e) installing: Add configuring registry docs to doc tree
-- [`4480831`](https://github.com/deisthree/workflow/commit/4480831fdeb19fa70e6280c55507154973fa2d3c) applications: use admonition styling
-- [`d097233`](https://github.com/deisthree/workflow/commit/d0972339c7145ed4d6fbfa205288e77c051b82eb) user: supply a kubectl patch function to simplify registration mode setting
+- [`fde9a81`](https://github.com/deis/workflow/commit/fde9a810c58b4483583a743e0a701238209bcb3e) installing: Add configuring registry docs to doc tree
+- [`4480831`](https://github.com/deis/workflow/commit/4480831fdeb19fa70e6280c55507154973fa2d3c) applications: use admonition styling
+- [`d097233`](https://github.com/deis/workflow/commit/d0972339c7145ed4d6fbfa205288e77c051b82eb) user: supply a kubectl patch function to simplify registration mode setting
 
 #### Documentation
-- [`fb9db75`](https://github.com/deisthree/workflow/commit/fb9db752259ead7414f537c8dcc78dc81bb020eb) applications: add deis routing docs
-- [`12fd1d7`](https://github.com/deisthree/workflow/commit/12fd1d72392166cfaa0e37dce647d0a3582b285e) registration: update registration for 2.3 behavior (#448)
-- [`8d271ca`](https://github.com/deisthree/workflow/commit/8d271caf9a7c1ada468c9f0f0b970cbd68e1f8b1) upgrading: expand and clarify workflow upgrade instructions (#447)
-- [`5fdf2da`](https://github.com/deisthree/workflow/commit/5fdf2daa225c49331e1a42655ab2e4808439d6ab) storage: cleanup storage docs (#454)
+- [`fb9db75`](https://github.com/deis/workflow/commit/fb9db752259ead7414f537c8dcc78dc81bb020eb) applications: add deis routing docs
+- [`12fd1d7`](https://github.com/deis/workflow/commit/12fd1d72392166cfaa0e37dce647d0a3582b285e) registration: update registration for 2.3 behavior (#448)
+- [`8d271ca`](https://github.com/deis/workflow/commit/8d271caf9a7c1ada468c9f0f0b970cbd68e1f8b1) upgrading: expand and clarify workflow upgrade instructions (#447)
+- [`5fdf2da`](https://github.com/deis/workflow/commit/5fdf2daa225c49331e1a42655ab2e4808439d6ab) storage: cleanup storage docs (#454)
 
 #### Maintenance
-- [`88167c5`](https://github.com/deisthree/workflow/commit/88167c5ffae37764c513795a9cfe73949fdf1c02) roadmap: update roadmap for 2.x (#417)
-- [`8befc2a`](https://github.com/deisthree/workflow/commit/8befc2a4691dd19e9528c3b3df96e7e916792547) docs: update docs to reflect fixed issue (#455)
+- [`88167c5`](https://github.com/deis/workflow/commit/88167c5ffae37764c513795a9cfe73949fdf1c02) roadmap: update roadmap for 2.x (#417)
+- [`8befc2a`](https://github.com/deis/workflow/commit/8befc2a4691dd19e9528c3b3df96e7e916792547) docs: update docs to reflect fixed issue (#455)
 
 
 ### Workflow E2E Tests v2.3.0 -> v2.4.0
 
 #### Features
-- [`6f76da5`](https://github.com/deisthree/workflow-e2e/commit/6f76da5232ade274ab6ebfb570e96b477ccc718a) procfile: create a build with a procfile
-- [`94a884a`](https://github.com/deisthree/workflow-e2e/commit/94a884a9ed4c7350f24d69fb3f128fe74fd4538e) skip: make procfile test pending
-- [`09c1c33`](https://github.com/deisthree/workflow-e2e/commit/09c1c3306a1f7668bb378891f3669a4ca0c75b89) tests: add deis routing e2e tests (#304)
+- [`6f76da5`](https://github.com/deis/workflow-e2e/commit/6f76da5232ade274ab6ebfb570e96b477ccc718a) procfile: create a build with a procfile
+- [`94a884a`](https://github.com/deis/workflow-e2e/commit/94a884a9ed4c7350f24d69fb3f128fe74fd4538e) skip: make procfile test pending
+- [`09c1c33`](https://github.com/deis/workflow-e2e/commit/09c1c3306a1f7668bb378891f3669a4ca0c75b89) tests: add deis routing e2e tests (#304)
 
 #### Fixes
-- [`7e0d1cc`](https://github.com/deisthree/workflow-e2e/commit/7e0d1ccabe7a1734f9b3abba07a6bace88b67f98) CLI: log cli version after installing to check revision (#284)
-- [`47a6907`](https://github.com/deisthree/workflow-e2e/commit/47a6907ae1da37b9ec30f6e54a5b6f9d71be1b6d) deployments: proc type regex changed due to Deployments
-- [`b22274e`](https://github.com/deisthree/workflow-e2e/commit/b22274e29b7019f7a0414d1b9ded52657f161d7b) limits: ask for 500m instead of 1024 cores in the limits CPU test
-- [`2cd045a`](https://github.com/deisthree/workflow-e2e/commit/2cd045a20b0644031a84436e2d793d0283150675) Makefile: add retrying to workflow CLI download
-- [`a56611c`](https://github.com/deisthree/workflow-e2e/commit/a56611c1c8e51f8e67a976fd7b84937bdf369de6) docker-test-integration: show curl errors (#311)
-- [`807d110`](https://github.com/deisthree/workflow-e2e/commit/807d1109c58f47cfbe255f20157db6d85aab4e80) auth: update to new missing config error message (#301)
+- [`7e0d1cc`](https://github.com/deis/workflow-e2e/commit/7e0d1ccabe7a1734f9b3abba07a6bace88b67f98) CLI: log cli version after installing to check revision (#284)
+- [`47a6907`](https://github.com/deis/workflow-e2e/commit/47a6907ae1da37b9ec30f6e54a5b6f9d71be1b6d) deployments: proc type regex changed due to Deployments
+- [`b22274e`](https://github.com/deis/workflow-e2e/commit/b22274e29b7019f7a0414d1b9ded52657f161d7b) limits: ask for 500m instead of 1024 cores in the limits CPU test
+- [`2cd045a`](https://github.com/deis/workflow-e2e/commit/2cd045a20b0644031a84436e2d793d0283150675) Makefile: add retrying to workflow CLI download
+- [`a56611c`](https://github.com/deis/workflow-e2e/commit/a56611c1c8e51f8e67a976fd7b84937bdf369de6) docker-test-integration: show curl errors (#311)
+- [`807d110`](https://github.com/deis/workflow-e2e/commit/807d1109c58f47cfbe255f20157db6d85aab4e80) auth: update to new missing config error message (#301)
 
 #### Maintenance
-- [`ce08b1c`](https://github.com/deisthree/workflow-e2e/commit/ce08b1cf179ed3bf241d613192e09a0f319dd416) travis: Remove .travis.yml
+- [`ce08b1c`](https://github.com/deis/workflow-e2e/commit/ce08b1cf179ed3bf241d613192e09a0f319dd416) travis: Remove .travis.yml
 
 
 ### Workflow Manager v2.3.1 -> v2.4.0
 
 #### Fixes
-- [`7d859f5`](https://github.com/deisthree/workflow-manager/commit/7d859f582e4f0d3c049072352902638e58133157) feature(data): add deployments, daemonsets to cluster data (#95)
-- [`31fe3bc`](https://github.com/deisthree/workflow-manager/commit/31fe3bccbdde134a185752e53380330d16053f7f) cluster_id is vulnerable to race condition when called concurrently (#94)
-- [`2582640`](https://github.com/deisthree/workflow-manager/commit/2582640c2c13c5f5f9b860d62d2b7c3bc7f4826b) bug(k8s): unintentional variable shadowing (#92)
+- [`7d859f5`](https://github.com/deis/workflow-manager/commit/7d859f582e4f0d3c049072352902638e58133157) feature(data): add deployments, daemonsets to cluster data (#95)
+- [`31fe3bc`](https://github.com/deis/workflow-manager/commit/31fe3bccbdde134a185752e53380330d16053f7f) cluster_id is vulnerable to race condition when called concurrently (#94)
+- [`2582640`](https://github.com/deis/workflow-manager/commit/2582640c2c13c5f5f9b860d62d2b7c3bc7f4826b) bug(k8s): unintentional variable shadowing (#92)

--- a/src/changelogs/v2.4.1.md
+++ b/src/changelogs/v2.4.1.md
@@ -2,8 +2,8 @@
 
 ### Maintenance
 
-[`af1c969`](https://github.com/deisthree/charts/commit/af1c96989ad97bbb4eac61ea3c1bf1c6a903f620) workflow-v2.4.1: releasing workflow-v2.4.1(-e2e)
+[`af1c969`](https://github.com/deis/charts/commit/af1c96989ad97bbb4eac61ea3c1bf1c6a903f620) workflow-v2.4.1: releasing workflow-v2.4.1(-e2e)
 
 ### Fixes
 
-[`3f3be4d`](https://github.com/deisthree/controller/commit/3f3be4d410c7f6b9e70825179827a7b305998464) controller: scheduler: check if RC exists during a deploy before trying to use Deployments [#996](https://github.com/deisthree/controller/pull/996)
+[`3f3be4d`](https://github.com/deis/controller/commit/3f3be4d410c7f6b9e70825179827a7b305998464) controller: scheduler: check if RC exists during a deploy before trying to use Deployments [#996](https://github.com/deis/controller/pull/996)

--- a/src/changelogs/v2.4.2.md
+++ b/src/changelogs/v2.4.2.md
@@ -3,6 +3,6 @@
 ### Controller v2.4.1 -> v2.4.2
 
 #### Fixes
-- [`eb2f32b`](https://github.com/deisthree/controller/commit/eb2f32baeb7442f085f596a10d29bd4bb1e85463) registry: tell a user they need PORT when using off-cluster native iaas registry (#988)
-- [`e9352a3`](https://github.com/deisthree/controller/commit/e9352a38f6c4e9472c89648f9ea61e0fd88daa85) proctypes: update service after all the proctypes are deployed
-- [`f7fb2f6`](https://github.com/deisthree/controller/commit/f7fb2f6026a5727c28010b655ca74c296fe3f0d5) release: during cleanup let pod deletion 404 in case Kubernetes cleaned up as well (#1005)
+- [`eb2f32b`](https://github.com/deis/controller/commit/eb2f32baeb7442f085f596a10d29bd4bb1e85463) registry: tell a user they need PORT when using off-cluster native iaas registry (#988)
+- [`e9352a3`](https://github.com/deis/controller/commit/e9352a38f6c4e9472c89648f9ea61e0fd88daa85) proctypes: update service after all the proctypes are deployed
+- [`f7fb2f6`](https://github.com/deis/controller/commit/f7fb2f6026a5727c28010b655ca74c296fe3f0d5) release: during cleanup let pod deletion 404 in case Kubernetes cleaned up as well (#1005)

--- a/src/changelogs/v2.5.0.md
+++ b/src/changelogs/v2.5.0.md
@@ -5,314 +5,314 @@
 
 #### Features
 
-- [`f99a28e`](https://github.com/deisthree/builder/commit/f99a28e6caeb8f84173a597c205c05790662c15c) slugbuilder-cache: Add CACHE_PATH variable
-- [`05522a0`](https://github.com/deisthree/builder/commit/05522a05a66420f1e0c0ad7a4e616f2a5dcd9470) source_version: add SOURCE_VERSION env var
-- [`f2c28ef`](https://github.com/deisthree/builder/commit/f2c28ef4bc398a8fadfc1402e8c59e8a550b93c6) slugbuilder-cache: allow turning caching off completely
-- [`47432ea`](https://github.com/deisthree/builder/commit/47432ead77eb5087ffe79d6da4035f31c854ad34) builder: delete cache if the cache is disabled (#422)
+- [`f99a28e`](https://github.com/deis/builder/commit/f99a28e6caeb8f84173a597c205c05790662c15c) slugbuilder-cache: Add CACHE_PATH variable
+- [`05522a0`](https://github.com/deis/builder/commit/05522a05a66420f1e0c0ad7a4e616f2a5dcd9470) source_version: add SOURCE_VERSION env var
+- [`f2c28ef`](https://github.com/deis/builder/commit/f2c28ef4bc398a8fadfc1402e8c59e8a550b93c6) slugbuilder-cache: allow turning caching off completely
+- [`47432ea`](https://github.com/deis/builder/commit/47432ead77eb5087ffe79d6da4035f31c854ad34) builder: delete cache if the cache is disabled (#422)
 
 #### Refactors
 
-- [`797243e`](https://github.com/deisthree/builder/commit/797243e6ce9c942b8f50ca75127243038a8e9fb0) util_test: placate linter by replacing test PK
+- [`797243e`](https://github.com/deis/builder/commit/797243e6ce9c942b8f50ca75127243038a8e9fb0) util_test: placate linter by replacing test PK
 
 #### Fixes
 
-- [`65a7de8`](https://github.com/deisthree/builder/commit/65a7de8ec9c6528e31ed907224400d1d81d9c2d1) README.md: correct coverage badge URL
-- [`c776995`](https://github.com/deisthree/builder/commit/c776995ab487463691a2399870ea5d141de28c64) slugbuilder-cache: fix typo in comments (#417)
+- [`65a7de8`](https://github.com/deis/builder/commit/65a7de8ec9c6528e31ed907224400d1d81d9c2d1) README.md: correct coverage badge URL
+- [`c776995`](https://github.com/deis/builder/commit/c776995ab487463691a2399870ea5d141de28c64) slugbuilder-cache: fix typo in comments (#417)
 
 #### Documentation
 
-- [`6b04ee5`](https://github.com/deisthree/builder/commit/6b04ee5b1c28ef361afa68039b09cc637b07dc43) CONTRIBUTING: update contributing docs (#413)
+- [`6b04ee5`](https://github.com/deis/builder/commit/6b04ee5b1c28ef361afa68039b09cc637b07dc43) CONTRIBUTING: update contributing docs (#413)
 
 #### Maintenance
 
-- [`db92af5`](https://github.com/deisthree/builder/commit/db92af5533ae2571d712003db5505e89f8e6d8a4) rootfs/Dockerfile: update to latest base image
-- [`b916723`](https://github.com/deisthree/builder/commit/b916723d3933568c1a2d11305b5312403b2bbd0e) Makefile: update to go-dev 0.17.0
-- [`0e50147`](https://github.com/deisthree/builder/commit/0e501478c4f0506ffbf9bdbf98f98563e5b19577) glide: update Controller SDK (#423)
+- [`db92af5`](https://github.com/deis/builder/commit/db92af5533ae2571d712003db5505e89f8e6d8a4) rootfs/Dockerfile: update to latest base image
+- [`b916723`](https://github.com/deis/builder/commit/b916723d3933568c1a2d11305b5312403b2bbd0e) Makefile: update to go-dev 0.17.0
+- [`0e50147`](https://github.com/deis/builder/commit/0e501478c4f0506ffbf9bdbf98f98563e5b19577) glide: update Controller SDK (#423)
 
 
 ### Controller v2.4.2 -> v2.5.2
 
 #### Features
 
-- [`cc0a4d5`](https://github.com/deisthree/controller/commit/cc0a4d58704d97fbf379c8808685581d1f5b95a4) whitelist: Add support for IP whitelist
-- [`50811a2`](https://github.com/deisthree/controller/commit/50811a2d3c195265467aa0d4a87b2d1bdd6736c4) api: add deis tls (#1004)
-- [`689df78`](https://github.com/deisthree/controller/commit/689df78084d669be214ac94d9573e61936215555) scheduler: add the ability to set KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS per application (#1026)
-- [`5c83d80`](https://github.com/deisthree/controller/commit/5c83d80d3da7b5854e26498a8f0299381a7225d8) autoscale: add autoscaling support to application on per proc type basis (#1018)
-- [`1db6146`](https://github.com/deisthree/controller/commit/1db6146ade0b1883509dd0ab26e1b2fbf79b2023) scheduler: use /scale endpoints for RC and Deployments to only update replicas during scale events (#1029)
+- [`cc0a4d5`](https://github.com/deis/controller/commit/cc0a4d58704d97fbf379c8808685581d1f5b95a4) whitelist: Add support for IP whitelist
+- [`50811a2`](https://github.com/deis/controller/commit/50811a2d3c195265467aa0d4a87b2d1bdd6736c4) api: add deis tls (#1004)
+- [`689df78`](https://github.com/deis/controller/commit/689df78084d669be214ac94d9573e61936215555) scheduler: add the ability to set KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS per application (#1026)
+- [`5c83d80`](https://github.com/deis/controller/commit/5c83d80d3da7b5854e26498a8f0299381a7225d8) autoscale: add autoscaling support to application on per proc type basis (#1018)
+- [`1db6146`](https://github.com/deis/controller/commit/1db6146ade0b1883509dd0ab26e1b2fbf79b2023) scheduler: use /scale endpoints for RC and Deployments to only update replicas during scale events (#1029)
 
 #### Refactors
 
-- [`f7a3e02`](https://github.com/deisthree/controller/commit/f7a3e02943854becf3d8eaff9e0bc16a6cbaf1c8) hooks: remove push hook model as the builder stopped using it (#985)
-- [`4e0c5a3`](https://github.com/deisthree/controller/commit/4e0c5a3526d5e5232eb1f4a6a9933c8c60927a56) scheduler: update_application_service had an unused name argument (#983)
-- [`d155e92`](https://github.com/deisthree/controller/commit/d155e9210974ebfb065c695c72c4341209f2b313) apps: move AppSettings scheduler logic to App model for simplicity (#993)
-- [`d3d18d2`](https://github.com/deisthree/controller/commit/d3d18d2f8916c88aac49c68e049fad2e6783e0f0) scheduler: use scheduler module session singleton to add session mock (#1009)
-- [`7306202`](https://github.com/deisthree/controller/commit/7306202c34d67218c9080f8545de660da32723ff) scheduler: split up the scheduler code into individual resources and to be modular (#1016)
-- [`98d809a`](https://github.com/deisthree/controller/commit/98d809a32680e027c3b90e2969613fa49dd8d442) scheduler: scheduler passes the kubernetes endpoint to resources instead of getting it from global settings (#1039)
+- [`f7a3e02`](https://github.com/deis/controller/commit/f7a3e02943854becf3d8eaff9e0bc16a6cbaf1c8) hooks: remove push hook model as the builder stopped using it (#985)
+- [`4e0c5a3`](https://github.com/deis/controller/commit/4e0c5a3526d5e5232eb1f4a6a9933c8c60927a56) scheduler: update_application_service had an unused name argument (#983)
+- [`d155e92`](https://github.com/deis/controller/commit/d155e9210974ebfb065c695c72c4341209f2b313) apps: move AppSettings scheduler logic to App model for simplicity (#993)
+- [`d3d18d2`](https://github.com/deis/controller/commit/d3d18d2f8916c88aac49c68e049fad2e6783e0f0) scheduler: use scheduler module session singleton to add session mock (#1009)
+- [`7306202`](https://github.com/deis/controller/commit/7306202c34d67218c9080f8545de660da32723ff) scheduler: split up the scheduler code into individual resources and to be modular (#1016)
+- [`98d809a`](https://github.com/deis/controller/commit/98d809a32680e027c3b90e2969613fa49dd8d442) scheduler: scheduler passes the kubernetes endpoint to resources instead of getting it from global settings (#1039)
 
 #### Fixes
 
-- [`d66c20c`](https://github.com/deisthree/controller/commit/d66c20c3b85e1e1f554e4f78908f89a686249dff) whitelist: Handle empty whitelist from user gracefully
-- [`dbde253`](https://github.com/deisthree/controller/commit/dbde253e10b821a7805371008782f6d5111a25de) tls: Update the value properly to work with morph
-- [`2f5c019`](https://github.com/deisthree/controller/commit/2f5c019b4a3ee50ea93e1c3c67b63008cb7a8fee) api: create TLS object on app create (#1043)
-- [`0d454ee`](https://github.com/deisthree/controller/commit/0d454ee54a2926bb27925c6b294a47f0191a0d08) middleware: move to 1.10 style middleware (#955)
-- [`899e008`](https://github.com/deisthree/controller/commit/899e0085e7aad47353b6d5753fb17fde466864be) models: add "added" log function, lowercase class name (#1017)
-- [`ffa9040`](https://github.com/deisthree/controller/commit/ffa90402da6869f4aaec4df9863528aa10bf2a73) certs: allow empty Common Name in certificates (#1024)
-- [`8408c1f`](https://github.com/deisthree/controller/commit/8408c1f4a4083fc70df566afe4ed3fa6e506aade) healthcheck: update healthchecks for non default process type
-- [`1ca970b`](https://github.com/deisthree/controller/commit/1ca970beb61f122feca697ae6d607ed8be0b8598) app: create image pull secrets outside of the async deploy loop (#1032)
-- [`7f16439`](https://github.com/deisthree/controller/commit/7f16439932a2cb06428165ce9f441439f9bf6c56) imagepullpolicy: Use correct environment variable for image pull policy
-- [`83df91e`](https://github.com/deisthree/controller/commit/83df91e4fab77cf4eea2dddeb900069b60bb312e) logs: app logs endpoint was returning binary string instead of a normal string (#1035)
-- [`3f3a228`](https://github.com/deisthree/controller/commit/3f3a228cba46818769e7b0858daead5c3a759795) scheduler: pass down the right variable for Deployment revision history limit (#1037)
-- [`ad7fc55`](https://github.com/deisthree/controller/commit/ad7fc5578f13fd6e2b33c0633df12216c132de21) app: rollback all process types to previous version when one (or more) process type fails a deploy (#1027)
-- [`a303f25`](https://github.com/deisthree/controller/commit/a303f25d9a149c0d5dca42614613f731e7713447) release: change release cleanup to only remove secrets related to Deployments that are no longer active (#1038)
-- [`ffc9f8c`](https://github.com/deisthree/controller/commit/ffc9f8c36ae3ca04dea54b731d8b40c57ae7c7a9) healthcheck: check if the healthchecks are failing on a new deploy
+- [`d66c20c`](https://github.com/deis/controller/commit/d66c20c3b85e1e1f554e4f78908f89a686249dff) whitelist: Handle empty whitelist from user gracefully
+- [`dbde253`](https://github.com/deis/controller/commit/dbde253e10b821a7805371008782f6d5111a25de) tls: Update the value properly to work with morph
+- [`2f5c019`](https://github.com/deis/controller/commit/2f5c019b4a3ee50ea93e1c3c67b63008cb7a8fee) api: create TLS object on app create (#1043)
+- [`0d454ee`](https://github.com/deis/controller/commit/0d454ee54a2926bb27925c6b294a47f0191a0d08) middleware: move to 1.10 style middleware (#955)
+- [`899e008`](https://github.com/deis/controller/commit/899e0085e7aad47353b6d5753fb17fde466864be) models: add "added" log function, lowercase class name (#1017)
+- [`ffa9040`](https://github.com/deis/controller/commit/ffa90402da6869f4aaec4df9863528aa10bf2a73) certs: allow empty Common Name in certificates (#1024)
+- [`8408c1f`](https://github.com/deis/controller/commit/8408c1f4a4083fc70df566afe4ed3fa6e506aade) healthcheck: update healthchecks for non default process type
+- [`1ca970b`](https://github.com/deis/controller/commit/1ca970beb61f122feca697ae6d607ed8be0b8598) app: create image pull secrets outside of the async deploy loop (#1032)
+- [`7f16439`](https://github.com/deis/controller/commit/7f16439932a2cb06428165ce9f441439f9bf6c56) imagepullpolicy: Use correct environment variable for image pull policy
+- [`83df91e`](https://github.com/deis/controller/commit/83df91e4fab77cf4eea2dddeb900069b60bb312e) logs: app logs endpoint was returning binary string instead of a normal string (#1035)
+- [`3f3a228`](https://github.com/deis/controller/commit/3f3a228cba46818769e7b0858daead5c3a759795) scheduler: pass down the right variable for Deployment revision history limit (#1037)
+- [`ad7fc55`](https://github.com/deis/controller/commit/ad7fc5578f13fd6e2b33c0633df12216c132de21) app: rollback all process types to previous version when one (or more) process type fails a deploy (#1027)
+- [`a303f25`](https://github.com/deis/controller/commit/a303f25d9a149c0d5dca42614613f731e7713447) release: change release cleanup to only remove secrets related to Deployments that are no longer active (#1038)
+- [`ffc9f8c`](https://github.com/deis/controller/commit/ffc9f8c36ae3ca04dea54b731d8b40c57ae7c7a9) healthcheck: check if the healthchecks are failing on a new deploy
 
 #### Documentation
 
-- [`757a8ae`](https://github.com/deisthree/controller/commit/757a8ae441d5a599b1bfad7f625ba474067ff232) CONTRIBUTING: update contributing doc (#1006)
+- [`757a8ae`](https://github.com/deis/controller/commit/757a8ae441d5a599b1bfad7f625ba474067ff232) CONTRIBUTING: update contributing doc (#1006)
 
 #### Maintenance
 
-- [`af7fe18`](https://github.com/deisthree/controller/commit/af7fe18d4f06a3032b4f61168cdcf4996e2a0bfc) requirements: update Requests to 2.11.1 (#990)
-- [`5853532`](https://github.com/deisthree/controller/commit/58535323b10182172821d00ec86f066bef29bca5) rootfs/Dockerfile: update to latest base image
-- [`9ced97c`](https://github.com/deisthree/controller/commit/9ced97ca1391099af9d5905f06d388e90326157e) requirements: Update DRF to 3.4.5 (#997)
-- [`6afa4f2`](https://github.com/deisthree/controller/commit/6afa4f20f228477823f6ee6e1c509e474bca3323) requirements: update DRF to 3.4.6 (#1007)
-- [`a2b8428`](https://github.com/deisthree/controller/commit/a2b8428581956beef91556eb59579dc690250b71) requirements: update PyOpenSSL to 16.1.0 (#1022)
-- [`cfe2f1c`](https://github.com/deisthree/controller/commit/cfe2f1cb18363280f359feb5737281a5ecb23d6e) requirements: update to Django 1.10.1 (#1040)
+- [`af7fe18`](https://github.com/deis/controller/commit/af7fe18d4f06a3032b4f61168cdcf4996e2a0bfc) requirements: update Requests to 2.11.1 (#990)
+- [`5853532`](https://github.com/deis/controller/commit/58535323b10182172821d00ec86f066bef29bca5) rootfs/Dockerfile: update to latest base image
+- [`9ced97c`](https://github.com/deis/controller/commit/9ced97ca1391099af9d5905f06d388e90326157e) requirements: Update DRF to 3.4.5 (#997)
+- [`6afa4f2`](https://github.com/deis/controller/commit/6afa4f20f228477823f6ee6e1c509e474bca3323) requirements: update DRF to 3.4.6 (#1007)
+- [`a2b8428`](https://github.com/deis/controller/commit/a2b8428581956beef91556eb59579dc690250b71) requirements: update PyOpenSSL to 16.1.0 (#1022)
+- [`cfe2f1c`](https://github.com/deis/controller/commit/cfe2f1cb18363280f359feb5737281a5ecb23d6e) requirements: update to Django 1.10.1 (#1040)
 
 
 ### Dockerbuilder v2.3.1 -> v2.3.2
 
 #### Features
 
-- [`4273b5c`](https://github.com/deisthree/dockerbuilder/commit/4273b5c6bd7ff76dc659d02868ec3c698ba0a624) tests: feat(tests) Add flake8 linting for python code (#91)
+- [`4273b5c`](https://github.com/deis/dockerbuilder/commit/4273b5c6bd7ff76dc659d02868ec3c698ba0a624) tests: feat(tests) Add flake8 linting for python code (#91)
 
 #### Maintenance
 
-- [`a67d22c`](https://github.com/deisthree/dockerbuilder/commit/a67d22c07503341d6192f79931472d95b85c967c) Makefile: clean up and update makefile (#90)
+- [`a67d22c`](https://github.com/deis/dockerbuilder/commit/a67d22c07503341d6192f79931472d95b85c967c) Makefile: clean up and update makefile (#90)
 
 
 ### Logger v2.2.0 -> v2.3.0
 
 #### Features
 
-- [`d1ad7c1`](https://github.com/deisthree/logger/commit/d1ad7c1edf16a74fe720c68797fde04dc14055bc) pprof: Add pprof endpoint
+- [`d1ad7c1`](https://github.com/deis/logger/commit/d1ad7c1edf16a74fe720c68797fde04dc14055bc) pprof: Add pprof endpoint
 
 #### Documentation
 
-- [`6596685`](https://github.com/deisthree/logger/commit/6596685324c00991a16e17713e9c8bc5f240aefa) readme: Update readme with new architecture
+- [`6596685`](https://github.com/deis/logger/commit/6596685324c00991a16e17713e9c8bc5f240aefa) readme: Update readme with new architecture
 
 #### Maintenance
 
-- [`d869a2e`](https://github.com/deisthree/logger/commit/d869a2e53229c6ffb744c35349182e0e07a1b7fe) rootfs/Dockerfile: update to latest base image
-- [`c79bb98`](https://github.com/deisthree/logger/commit/c79bb98b76e0c71bcd891c6df99308ce46eb2d7c) Makefile: update to go-dev 0.17.0
+- [`d869a2e`](https://github.com/deis/logger/commit/d869a2e53229c6ffb744c35349182e0e07a1b7fe) rootfs/Dockerfile: update to latest base image
+- [`c79bb98`](https://github.com/deis/logger/commit/c79bb98b76e0c71bcd891c6df99308ce46eb2d7c) Makefile: update to go-dev 0.17.0
 
 
 ### Minio v2.2.0 -> v2.2.1
 
 #### Fixes
 
-- [`22debea`](https://github.com/deisthree/minio/commit/22debea9967565d4d366bfc1b9ccb22dbd4c6942) .travis.yml: unset DEIS_REGISTRY before building image
+- [`22debea`](https://github.com/deis/minio/commit/22debea9967565d4d366bfc1b9ccb22dbd4c6942) .travis.yml: unset DEIS_REGISTRY before building image
 
 #### Maintenance
 
-- [`4e55f42`](https://github.com/deisthree/minio/commit/4e55f4270ed1612d17f568bb1b341b3b7cfe678e) Makefile: update to go-dev 0.17.0
-- [`a686c8a`](https://github.com/deisthree/minio/commit/a686c8a3361ed9c6f4c3ab8236ba1dc1a651f35b) rootfs/Dockerfile: update to latest base image
-- [`4a5315c`](https://github.com/deisthree/minio/commit/4a5315c5d0934c2fa34c541483334a54995f6e99) glide: update glide files
+- [`4e55f42`](https://github.com/deis/minio/commit/4e55f4270ed1612d17f568bb1b341b3b7cfe678e) Makefile: update to go-dev 0.17.0
+- [`a686c8a`](https://github.com/deis/minio/commit/a686c8a3361ed9c6f4c3ab8236ba1dc1a651f35b) rootfs/Dockerfile: update to latest base image
+- [`4a5315c`](https://github.com/deis/minio/commit/4a5315c5d0934c2fa34c541483334a54995f6e99) glide: update glide files
 
 
 ### Monitoring v2.3.0 -> v2.4.0
 
 #### Refactors
 
-- [`1dfc015`](https://github.com/deisthree/monitor/commit/1dfc015c8e45a5ca50aacb69c5082b4d45debfe3) deis component health: Refactored deis components health dashboards
+- [`1dfc015`](https://github.com/deis/monitor/commit/1dfc015c8e45a5ca50aacb69c5082b4d45debfe3) deis component health: Refactored deis components health dashboards
 
 #### Maintenance
 
-- [`254249a`](https://github.com/deisthree/monitor/commit/254249ac3b1398747408d15e18b3f20f4f04faef) Dockerfile: update to latest base image
+- [`254249a`](https://github.com/deis/monitor/commit/254249ac3b1398747408d15e18b3f20f4f04faef) Dockerfile: update to latest base image
 
 
 ### Registry v2.2.0 -> v2.2.1
 
 #### Maintenance
 
-- [`412b4e2`](https://github.com/deisthree/registry/commit/412b4e274101995f7f9f2fa9af4531620396ac21) Makefile: update to go-dev 0.17.0
-- [`4b14708`](https://github.com/deisthree/registry/commit/4b147080adfe14f1b779bf2bf0e0eee6d1abfda1) .travis.yml: use current Go 1.7 compiler
-- [`10d8308`](https://github.com/deisthree/registry/commit/10d8308dccd869794608bab9fd542e57c14ff1d2) rootfs/Dockerfile: update to latest base image
+- [`412b4e2`](https://github.com/deis/registry/commit/412b4e274101995f7f9f2fa9af4531620396ac21) Makefile: update to go-dev 0.17.0
+- [`4b14708`](https://github.com/deis/registry/commit/4b147080adfe14f1b779bf2bf0e0eee6d1abfda1) .travis.yml: use current Go 1.7 compiler
+- [`10d8308`](https://github.com/deis/registry/commit/10d8308dccd869794608bab9fd542e57c14ff1d2) rootfs/Dockerfile: update to latest base image
 
 
 ### Router v2.4.0 -> v2.5.0
 
 #### Features
 
-- [`bd25b82`](https://github.com/deisthree/router/commit/bd25b8289ea95a64b9ac38f69ec3e0763f9cc2a0) router: add app SSL config
+- [`bd25b82`](https://github.com/deis/router/commit/bd25b8289ea95a64b9ac38f69ec3e0763f9cc2a0) router: add app SSL config
 
 #### Refactors
 
-- [`a7da253`](https://github.com/deisthree/router/commit/a7da253486b7511a83235fedb44bfa057fd2867a) fix new linter errors
-- [`ef9a5bf`](https://github.com/deisthree/router/commit/ef9a5bf7b5e518f6ab01f39db6333ee16e7dc65e) Dockerfile: copy the router binary after building ngnix binary
+- [`a7da253`](https://github.com/deis/router/commit/a7da253486b7511a83235fedb44bfa057fd2867a) fix new linter errors
+- [`ef9a5bf`](https://github.com/deis/router/commit/ef9a5bf7b5e518f6ab01f39db6333ee16e7dc65e) Dockerfile: copy the router binary after building ngnix binary
 
 #### Maintenance
 
-- [`ea7fffc`](https://github.com/deisthree/router/commit/ea7fffc54e3a4fba06d64e298827907e315e9a5e) Makefile: update to go-dev 0.17.0
-- [`8c3aded`](https://github.com/deisthree/router/commit/8c3adedbabe8ec077db8bcd0d183152457e1eb33) rootfs/Dockerfile: update to latest base image
+- [`ea7fffc`](https://github.com/deis/router/commit/ea7fffc54e3a4fba06d64e298827907e315e9a5e) Makefile: update to go-dev 0.17.0
+- [`8c3aded`](https://github.com/deis/router/commit/8c3adedbabe8ec077db8bcd0d183152457e1eb33) rootfs/Dockerfile: update to latest base image
 
 
 ### Slugbuilder v2.3.1 -> v2.4.1
 
 #### Features
 
-- [`4d634a3`](https://github.com/deisthree/slugbuilder/commit/4d634a366500e8521e1c4b17231a1af9905c7479) Makefile: add --pull flag to docker-build
-- [`b6a2f12`](https://github.com/deisthree/slugbuilder/commit/b6a2f12f71c755b6e02e2134485067df3fbcef45) cache: allow cache to be persisted
+- [`4d634a3`](https://github.com/deis/slugbuilder/commit/4d634a366500e8521e1c4b17231a1af9905c7479) Makefile: add --pull flag to docker-build
+- [`b6a2f12`](https://github.com/deis/slugbuilder/commit/b6a2f12f71c755b6e02e2134485067df3fbcef45) cache: allow cache to be persisted
 
 #### Fixes
 
-- [`37c5109`](https://github.com/deisthree/slugbuilder/commit/37c5109557a3005e3f0afd5f224781c609a8f6b4) build.sh: switch to build_root before running hooks
-- [`dcad3f0`](https://github.com/deisthree/slugbuilder/commit/dcad3f0e3a6e3bddde4f1af5f9d3b421a9fba7a9) build: check if release yaml is nil before accessing hash (#105)
+- [`37c5109`](https://github.com/deis/slugbuilder/commit/37c5109557a3005e3f0afd5f224781c609a8f6b4) build.sh: switch to build_root before running hooks
+- [`dcad3f0`](https://github.com/deis/slugbuilder/commit/dcad3f0e3a6e3bddde4f1af5f9d3b421a9fba7a9) build: check if release yaml is nil before accessing hash (#105)
 
 #### Documentation
 
-- [`116da05`](https://github.com/deisthree/slugbuilder/commit/116da0537ed12b3b7f802a8bc92087ae767a1e59) readme: fix formatting in readme
-- [`d05c3e4`](https://github.com/deisthree/slugbuilder/commit/d05c3e42a5f6c045ef08ef8ae6f62e10aa9d209d) build.sh: simplify and formalize cache message
-- [`49fecd9`](https://github.com/deisthree/slugbuilder/commit/49fecd96abca9ce1e0cd5427b50c182c9d572ec4) CONTRIBUTING: update contributing doc (#107)
+- [`116da05`](https://github.com/deis/slugbuilder/commit/116da0537ed12b3b7f802a8bc92087ae767a1e59) readme: fix formatting in readme
+- [`d05c3e4`](https://github.com/deis/slugbuilder/commit/d05c3e42a5f6c045ef08ef8ae6f62e10aa9d209d) build.sh: simplify and formalize cache message
+- [`49fecd9`](https://github.com/deis/slugbuilder/commit/49fecd96abca9ce1e0cd5427b50c182c9d572ec4) CONTRIBUTING: update contributing doc (#107)
 
 #### Maintenance
 
-- [`c6f948a`](https://github.com/deisthree/slugbuilder/commit/c6f948a6e892f82f32e85b0f53ad7dfb8ecad929) buildpacks: update heroku-buildpack-go to v46
+- [`c6f948a`](https://github.com/deis/slugbuilder/commit/c6f948a6e892f82f32e85b0f53ad7dfb8ecad929) buildpacks: update heroku-buildpack-go to v46
 
 
 ### Slugrunner v2.2.0 -> v2.2.1
 
 #### Refactors
 
-- [`6b0c90d`](https://github.com/deisthree/slugrunner/commit/6b0c90df8593dc903c42a59faa20f83287d507a3) init: remove sdutil, which is no longer used (#51)
+- [`6b0c90d`](https://github.com/deis/slugrunner/commit/6b0c90df8593dc903c42a59faa20f83287d507a3) init: remove sdutil, which is no longer used (#51)
 
 #### Fixes
 
-- [`166bddd`](https://github.com/deisthree/slugrunner/commit/166bddd90fdf08501db5191baa6074f43a9de65e) init: check for valid YAML before accessing hash (#50)
-- [`2d86e6c`](https://github.com/deisthree/slugrunner/commit/2d86e6ccb98e0db60dc123ebcf3c50f2c180447b) Makefile: ensure to use "latest" build of cedar:14
+- [`166bddd`](https://github.com/deis/slugrunner/commit/166bddd90fdf08501db5191baa6074f43a9de65e) init: check for valid YAML before accessing hash (#50)
+- [`2d86e6c`](https://github.com/deis/slugrunner/commit/2d86e6ccb98e0db60dc123ebcf3c50f2c180447b) Makefile: ensure to use "latest" build of cedar:14
 
 #### Documentation
 
-- [`d87b04e`](https://github.com/deisthree/slugrunner/commit/d87b04e4c3762230979b23d76d279cdb1928003f) CONTRIBUTING: update contributing doc (#53)
+- [`d87b04e`](https://github.com/deis/slugrunner/commit/d87b04e4c3762230979b23d76d279cdb1928003f) CONTRIBUTING: update contributing doc (#53)
 
 
 ### Workflow CLI v2.4.0 -> v2.5.1
 
 #### Features
 
-- [`78118eb`](https://github.com/deisthree/workflow-cli/commit/78118ebf1076609511cf7e6b1037c6ed8fbae847) CI: refactor CI to build and then pass around a test image (#181)
-- [`aded419`](https://github.com/deisthree/workflow-cli/commit/aded419ac57ab03f833fd74551b422b87efb7d57) CI: upload CLI to seperate buckets (#190)
-- [`3cb4ad3`](https://github.com/deisthree/workflow-cli/commit/3cb4ad3f5a768f17301e61381e36c05df3a697d2) whitelist: Add support for ip whitlising for app
-- [`ec466d7`](https://github.com/deisthree/workflow-cli/commit/ec466d7ab27cf4640feafb39de6f979964d328bf) autoscale: add the ability to define autoscale rules per process type on an app (#208)
-- [`84de668`](https://github.com/deisthree/workflow-cli/commit/84de6687e797b0fb54e4838d42255f19abbabe5f) cmd: add `deis tls`
-- [`eefb125`](https://github.com/deisthree/workflow-cli/commit/eefb125151128e6122f94d2ee09c7b81db88d392) Makefile: build using dockefile and slim image size (#215)
-- [`a4dea17`](https://github.com/deisthree/workflow-cli/commit/a4dea1734cb63b1a65992e2d6b9ce300d13c6f2f) Makefile: add build-stable target
-- [`618939c`](https://github.com/deisthree/workflow-cli/commit/618939c99273edc8ccfe97e60ac5ae9c959975eb) users: show admins when listing users (#205)
-- [`01ca8f8`](https://github.com/deisthree/workflow-cli/commit/01ca8f8ba16f0eebb9a5bd42bad8115c8b6a4272) version: add deis version --all (#217)
+- [`78118eb`](https://github.com/deis/workflow-cli/commit/78118ebf1076609511cf7e6b1037c6ed8fbae847) CI: refactor CI to build and then pass around a test image (#181)
+- [`aded419`](https://github.com/deis/workflow-cli/commit/aded419ac57ab03f833fd74551b422b87efb7d57) CI: upload CLI to seperate buckets (#190)
+- [`3cb4ad3`](https://github.com/deis/workflow-cli/commit/3cb4ad3f5a768f17301e61381e36c05df3a697d2) whitelist: Add support for ip whitlising for app
+- [`ec466d7`](https://github.com/deis/workflow-cli/commit/ec466d7ab27cf4640feafb39de6f979964d328bf) autoscale: add the ability to define autoscale rules per process type on an app (#208)
+- [`84de668`](https://github.com/deis/workflow-cli/commit/84de6687e797b0fb54e4838d42255f19abbabe5f) cmd: add `deis tls`
+- [`eefb125`](https://github.com/deis/workflow-cli/commit/eefb125151128e6122f94d2ee09c7b81db88d392) Makefile: build using dockefile and slim image size (#215)
+- [`a4dea17`](https://github.com/deis/workflow-cli/commit/a4dea1734cb63b1a65992e2d6b9ce300d13c6f2f) Makefile: add build-stable target
+- [`618939c`](https://github.com/deis/workflow-cli/commit/618939c99273edc8ccfe97e60ac5ae9c959975eb) users: show admins when listing users (#205)
+- [`01ca8f8`](https://github.com/deis/workflow-cli/commit/01ca8f8ba16f0eebb9a5bd42bad8115c8b6a4272) version: add deis version --all (#217)
 
 #### Refactors
 
-- [`912ad85`](https://github.com/deisthree/workflow-cli/commit/912ad8521c6dbbca57483749fbd55f74f30afc5b) Jenkinsfile: remove shell output hack
+- [`912ad85`](https://github.com/deis/workflow-cli/commit/912ad8521c6dbbca57483749fbd55f74f30afc5b) Jenkinsfile: remove shell output hack
 
 #### Fixes
 
-- [`8653f92`](https://github.com/deisthree/workflow-cli/commit/8653f929475eee798aacb88da31612bd1a67a57f) whitelist: format the deis whitelist properly
-- [`82b6368`](https://github.com/deisthree/workflow-cli/commit/82b63684db9be3a3fcaae58d8c35285098d5e108) settings: remove duplicated 'v' in user agent (#188)
-- [`d5a004c`](https://github.com/deisthree/workflow-cli/commit/d5a004cedb4123ec5ee2f77e84520c73233d0189) tests: start adding unit tests (#183)
-- [`272b1cd`](https://github.com/deisthree/workflow-cli/commit/272b1cd91ea4020baf8c00c4cf6f9603e7d9f8c0) routing, maintenance: check for existence of pointer before reading it. (#195)
-- [`db38964`](https://github.com/deisthree/workflow-cli/commit/db389646b76bef387898579a99f5c0d9d1f058c8) git: properly log errors from git (#199)
-- [`09ca839`](https://github.com/deisthree/workflow-cli/commit/09ca8391d64e29d9adf65219cdd5375c06c96505) CI: don't upload to old bucket and declare varaibles locally (#211)
-- [`f9d85a0`](https://github.com/deisthree/workflow-cli/commit/f9d85a0ac77c6c32d50dae664fe7bc80bc8fca1b) ps: use new sdk for sorted processes (#210)
-- [`d49acf0`](https://github.com/deisthree/workflow-cli/commit/d49acf04d6b366f2fd882a1dd410ca21860b2e12) CI: define more variables locally (#212)
-- [`9b3980a`](https://github.com/deisthree/workflow-cli/commit/9b3980a4f2790a71a572a6d6a50bde90d3ac10a3) limits: remove short cpu flag (#216)
-- [`e10caf6`](https://github.com/deisthree/workflow-cli/commit/e10caf6f2a8decfccf98ce4f809ba421e6988c2b) cmd: fix help string when git remote already exists
+- [`8653f92`](https://github.com/deis/workflow-cli/commit/8653f929475eee798aacb88da31612bd1a67a57f) whitelist: format the deis whitelist properly
+- [`82b6368`](https://github.com/deis/workflow-cli/commit/82b63684db9be3a3fcaae58d8c35285098d5e108) settings: remove duplicated 'v' in user agent (#188)
+- [`d5a004c`](https://github.com/deis/workflow-cli/commit/d5a004cedb4123ec5ee2f77e84520c73233d0189) tests: start adding unit tests (#183)
+- [`272b1cd`](https://github.com/deis/workflow-cli/commit/272b1cd91ea4020baf8c00c4cf6f9603e7d9f8c0) routing, maintenance: check for existence of pointer before reading it. (#195)
+- [`db38964`](https://github.com/deis/workflow-cli/commit/db389646b76bef387898579a99f5c0d9d1f058c8) git: properly log errors from git (#199)
+- [`09ca839`](https://github.com/deis/workflow-cli/commit/09ca8391d64e29d9adf65219cdd5375c06c96505) CI: don't upload to old bucket and declare varaibles locally (#211)
+- [`f9d85a0`](https://github.com/deis/workflow-cli/commit/f9d85a0ac77c6c32d50dae664fe7bc80bc8fca1b) ps: use new sdk for sorted processes (#210)
+- [`d49acf0`](https://github.com/deis/workflow-cli/commit/d49acf04d6b366f2fd882a1dd410ca21860b2e12) CI: define more variables locally (#212)
+- [`9b3980a`](https://github.com/deis/workflow-cli/commit/9b3980a4f2790a71a572a6d6a50bde90d3ac10a3) limits: remove short cpu flag (#216)
+- [`e10caf6`](https://github.com/deis/workflow-cli/commit/e10caf6f2a8decfccf98ce4f809ba421e6988c2b) cmd: fix help string when git remote already exists
 
 #### Documentation
 
-- [`260d826`](https://github.com/deisthree/workflow-cli/commit/260d82694e8e851b53d02a4f7dd27b60e9381268) CONTRIBUTING: link contributing documentation to website (#185)
+- [`260d826`](https://github.com/deis/workflow-cli/commit/260d82694e8e851b53d02a4f7dd27b60e9381268) CONTRIBUTING: link contributing documentation to website (#185)
 
 #### Maintenance
 
-- [`850ee9c`](https://github.com/deisthree/workflow-cli/commit/850ee9c346e803f354d42920cf941ab6fce662a9) glide: update Controller SDK (#220)
+- [`850ee9c`](https://github.com/deis/workflow-cli/commit/850ee9c346e803f354d42920cf941ab6fce662a9) glide: update Controller SDK (#220)
 
 
 ### Workflow Documentation v2.4.1 -> v2.5.0
 
 #### Features
 
-- [`2e92c77`](https://github.com/deisthree/workflow/commit/2e92c778c32945d28f0a86d669af0153d72a8d08) contributing: add more details to issue reporting (#472)
-- [`a27f00f`](https://github.com/deisthree/workflow/commit/a27f00fce8bb40b275b0dd2ee49101837d8a3049) whitelist: Add docs for specifying application whitelist using deis client
-- [`b8b3eed`](https://github.com/deisthree/workflow/commit/b8b3eed07537800a2feaf01b3328d885b86111ee) autoscale: add documentation for the autoscale functionality (#483)
+- [`2e92c77`](https://github.com/deis/workflow/commit/2e92c778c32945d28f0a86d669af0153d72a8d08) contributing: add more details to issue reporting (#472)
+- [`a27f00f`](https://github.com/deis/workflow/commit/a27f00fce8bb40b275b0dd2ee49101837d8a3049) whitelist: Add docs for specifying application whitelist using deis client
+- [`b8b3eed`](https://github.com/deis/workflow/commit/b8b3eed07537800a2feaf01b3328d885b86111ee) autoscale: add documentation for the autoscale functionality (#483)
 
 #### Fixes
 
-- [`e066502`](https://github.com/deisthree/workflow/commit/e06650201eef71e2e5e490fdc2f5a827126742ce) quickstart: remove references to downgrade
-- [`6f2639a`](https://github.com/deisthree/workflow/commit/6f2639ad56c5dbb8f187b2c210fa44ce8a5a6e6a) quickstart: specify how to get hostname (#469)
-- [`219179f`](https://github.com/deisthree/workflow/commit/219179f02263afd34fcad6efba5c7b071a74b04c) managing-workflow: fix broken link
-- [`0a1c57d`](https://github.com/deisthree/workflow/commit/0a1c57d9fa875ab0b80beb6c580ab8d3ecf1ea7d) apps: KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS is now also per app (#486)
+- [`e066502`](https://github.com/deis/workflow/commit/e06650201eef71e2e5e490fdc2f5a827126742ce) quickstart: remove references to downgrade
+- [`6f2639a`](https://github.com/deis/workflow/commit/6f2639ad56c5dbb8f187b2c210fa44ce8a5a6e6a) quickstart: specify how to get hostname (#469)
+- [`219179f`](https://github.com/deis/workflow/commit/219179f02263afd34fcad6efba5c7b071a74b04c) managing-workflow: fix broken link
+- [`0a1c57d`](https://github.com/deis/workflow/commit/0a1c57d9fa875ab0b80beb6c580ab8d3ecf1ea7d) apps: KUBERNETES_POD_TERMINATION_GRACE_PERIOD_SECONDS is now also per app (#486)
 
 #### Documentation
 
-- [`d7db3d4`](https://github.com/deisthree/workflow/commit/d7db3d402016af534ffa4967cc7c681ebe950cf0) triaging-issues: describe new priority labels
-- [`2c753c2`](https://github.com/deisthree/workflow/commit/2c753c27dbb64f480d00a693caddb28229f1ad54) using-docker-images: use example-dockerfile-http as sample dockerfile application instead of helloworld. (#482)
-- [`6c1f4fd`](https://github.com/deisthree/workflow/commit/6c1f4fdeeace0d290e82666b676d8ca88e316fee) ssl-certificates: add docs on deis tls:enable
-- [`5e055f0`](https://github.com/deisthree/workflow/commit/5e055f07e8444daa63f1ebf241c73ad8af29c2db) fix: add --namespace=deis to Controlling Registration Modes
-- [`c112a46`](https://github.com/deisthree/workflow/commit/c112a4643c5133625d6fec292e51a57142548996) update: using-docker-images.md
-- [`5f46769`](https://github.com/deisthree/workflow/commit/5f467693e07c2cd3b0fff15f9286e3e50318446c) src/roadmap/releases.md: add step for releasing cli stable
-- [`1e79b46`](https://github.com/deisthree/workflow/commit/1e79b461d32f021cefd1b24caf742f8e699dc1bd) upgrading-workflow.md: remove errant/redundant command
-- [`b721180`](https://github.com/deisthree/workflow/commit/b721180f40a736c2a76f516e85c89eedad2be7e2) styles: docs(styles) sticky footer to avoid overlap with sidebar
-- [`c54c2ec`](https://github.com/deisthree/workflow/commit/c54c2ec8a4e52a8b62aa9f8b87dbee425f177682) styles: docs(styles) fix mobile menu scroll issues
+- [`d7db3d4`](https://github.com/deis/workflow/commit/d7db3d402016af534ffa4967cc7c681ebe950cf0) triaging-issues: describe new priority labels
+- [`2c753c2`](https://github.com/deis/workflow/commit/2c753c27dbb64f480d00a693caddb28229f1ad54) using-docker-images: use example-dockerfile-http as sample dockerfile application instead of helloworld. (#482)
+- [`6c1f4fd`](https://github.com/deis/workflow/commit/6c1f4fdeeace0d290e82666b676d8ca88e316fee) ssl-certificates: add docs on deis tls:enable
+- [`5e055f0`](https://github.com/deis/workflow/commit/5e055f07e8444daa63f1ebf241c73ad8af29c2db) fix: add --namespace=deis to Controlling Registration Modes
+- [`c112a46`](https://github.com/deis/workflow/commit/c112a4643c5133625d6fec292e51a57142548996) update: using-docker-images.md
+- [`5f46769`](https://github.com/deis/workflow/commit/5f467693e07c2cd3b0fff15f9286e3e50318446c) src/roadmap/releases.md: add step for releasing cli stable
+- [`1e79b46`](https://github.com/deis/workflow/commit/1e79b461d32f021cefd1b24caf742f8e699dc1bd) upgrading-workflow.md: remove errant/redundant command
+- [`b721180`](https://github.com/deis/workflow/commit/b721180f40a736c2a76f516e85c89eedad2be7e2) styles: docs(styles) sticky footer to avoid overlap with sidebar
+- [`c54c2ec`](https://github.com/deis/workflow/commit/c54c2ec8a4e52a8b62aa9f8b87dbee425f177682) styles: docs(styles) fix mobile menu scroll issues
 
 #### Maintenance
 
-- [`bd306d4`](https://github.com/deisthree/workflow/commit/bd306d457549a465399a476ec1ae25d472093c8e) release: Workflow 2.4.1 (#463)
-- [`4afda70`](https://github.com/deisthree/workflow/commit/4afda702f435cd4a4b308a7001d02c3f734f5ac6) release: Workflow 2.4.2
-- [`4694454`](https://github.com/deisthree/workflow/commit/469445425d16f0a498e0d613d39b278c54014372) changelogs: add top-level for changelogs
-- [`f383c43`](https://github.com/deisthree/workflow/commit/f383c432d4abfe16aecaaec2d020b58bb4ef8241) changelogs: add v2.0.0 changelog
-- [`176d080`](https://github.com/deisthree/workflow/commit/176d0807002957566365633ebf6964ead131a8fb) changelog: add v2.1.0 changelog
-- [`9ab4ba8`](https://github.com/deisthree/workflow/commit/9ab4ba81d59de17d6524885f01484d8adb9de647) changelog: add v2.2.0 changelog
-- [`ebac67f`](https://github.com/deisthree/workflow/commit/ebac67feb134b86634f327e23dee04c0baa81b12) changelog: add v2.3.0 changelog
-- [`1da032d`](https://github.com/deisthree/workflow/commit/1da032d6ed99484b8fb0a2e73295e118db017c70) changelog: add v2.4.0 changelog
-- [`db9bb8d`](https://github.com/deisthree/workflow/commit/db9bb8deb01bc3b6b945703a08f99183f7a7c01d) changelog: add v2.4.2 changelog
-- [`0d43482`](https://github.com/deisthree/workflow/commit/0d434820458c8d6f2ca75da0e18170b755d2128c) changelog: add headings for clarity
-- [`d18dec4`](https://github.com/deisthree/workflow/commit/d18dec47556f9d00e00972319ef7ab8a2738d408) changelog: update release process for new changelog page
-- [`a2d58aa`](https://github.com/deisthree/workflow/commit/a2d58aa89fc25e02ee20ac6f6f89e09c08bb5463) changelogs: add v2.4.1 changelog
-- [`bd4db54`](https://github.com/deisthree/workflow/commit/bd4db54186e61e2a4a743cbd78989329fe9ded1b) api-docs: add v2.3 API docs (#485)
+- [`bd306d4`](https://github.com/deis/workflow/commit/bd306d457549a465399a476ec1ae25d472093c8e) release: Workflow 2.4.1 (#463)
+- [`4afda70`](https://github.com/deis/workflow/commit/4afda702f435cd4a4b308a7001d02c3f734f5ac6) release: Workflow 2.4.2
+- [`4694454`](https://github.com/deis/workflow/commit/469445425d16f0a498e0d613d39b278c54014372) changelogs: add top-level for changelogs
+- [`f383c43`](https://github.com/deis/workflow/commit/f383c432d4abfe16aecaaec2d020b58bb4ef8241) changelogs: add v2.0.0 changelog
+- [`176d080`](https://github.com/deis/workflow/commit/176d0807002957566365633ebf6964ead131a8fb) changelog: add v2.1.0 changelog
+- [`9ab4ba8`](https://github.com/deis/workflow/commit/9ab4ba81d59de17d6524885f01484d8adb9de647) changelog: add v2.2.0 changelog
+- [`ebac67f`](https://github.com/deis/workflow/commit/ebac67feb134b86634f327e23dee04c0baa81b12) changelog: add v2.3.0 changelog
+- [`1da032d`](https://github.com/deis/workflow/commit/1da032d6ed99484b8fb0a2e73295e118db017c70) changelog: add v2.4.0 changelog
+- [`db9bb8d`](https://github.com/deis/workflow/commit/db9bb8deb01bc3b6b945703a08f99183f7a7c01d) changelog: add v2.4.2 changelog
+- [`0d43482`](https://github.com/deis/workflow/commit/0d434820458c8d6f2ca75da0e18170b755d2128c) changelog: add headings for clarity
+- [`d18dec4`](https://github.com/deis/workflow/commit/d18dec47556f9d00e00972319ef7ab8a2738d408) changelog: update release process for new changelog page
+- [`a2d58aa`](https://github.com/deis/workflow/commit/a2d58aa89fc25e02ee20ac6f6f89e09c08bb5463) changelogs: add v2.4.1 changelog
+- [`bd4db54`](https://github.com/deis/workflow/commit/bd4db54186e61e2a4a743cbd78989329fe9ded1b) api-docs: add v2.3 API docs (#485)
 
 
 ### Workflow E2E Tests v2.4.0 -> v2.5.2
 
 #### Features
 
-- [`a2ed8b2`](https://github.com/deisthree/workflow-e2e/commit/a2ed8b2237880e4be7a10942dc2f796bce297c4b) docker: add DEBUG option to hang build (#312)
-- [`30c8fd3`](https://github.com/deisthree/workflow-e2e/commit/30c8fd343c480b266542ab602cebe04401f4030d) procfile: unskip builds procfile test
-- [`95f4eb9`](https://github.com/deisthree/workflow-e2e/commit/95f4eb9cb630e1d2d0b149c08655e21b7fbf136f) docker-test-integration.sh: try curling cli from multiple buckets
-- [`9c294e3`](https://github.com/deisthree/workflow-e2e/commit/9c294e3fb3635c86a7444f9c026eeda3810c6f5d) maintenance: Add test for maintenance mode
-- [`013709e`](https://github.com/deisthree/workflow-e2e/commit/013709e7f2e08728bee9dc97209d12f41098c776) whitelist: Add tests for deis whitelist
-- [`5bc8cb0`](https://github.com/deisthree/workflow-e2e/commit/5bc8cb0f487bc09887e50da7ee2409e22debd134) tests: add deis tls tests (#316)
-- [`0f2df78`](https://github.com/deisthree/workflow-e2e/commit/0f2df7835cce1bda9bf863d5a0d70b2b5f967545) docker-test-integration.sh: check if 'stable'
+- [`a2ed8b2`](https://github.com/deis/workflow-e2e/commit/a2ed8b2237880e4be7a10942dc2f796bce297c4b) docker: add DEBUG option to hang build (#312)
+- [`30c8fd3`](https://github.com/deis/workflow-e2e/commit/30c8fd343c480b266542ab602cebe04401f4030d) procfile: unskip builds procfile test
+- [`95f4eb9`](https://github.com/deis/workflow-e2e/commit/95f4eb9cb630e1d2d0b149c08655e21b7fbf136f) docker-test-integration.sh: try curling cli from multiple buckets
+- [`9c294e3`](https://github.com/deis/workflow-e2e/commit/9c294e3fb3635c86a7444f9c026eeda3810c6f5d) maintenance: Add test for maintenance mode
+- [`013709e`](https://github.com/deis/workflow-e2e/commit/013709e7f2e08728bee9dc97209d12f41098c776) whitelist: Add tests for deis whitelist
+- [`5bc8cb0`](https://github.com/deis/workflow-e2e/commit/5bc8cb0f487bc09887e50da7ee2409e22debd134) tests: add deis tls tests (#316)
+- [`0f2df78`](https://github.com/deis/workflow-e2e/commit/0f2df7835cce1bda9bf863d5a0d70b2b5f967545) docker-test-integration.sh: check if 'stable'
 
 #### Refactors
 
-- [`2da83d9`](https://github.com/deisthree/workflow-e2e/commit/2da83d98c31f991ae7b8bf6b548104f7af3cb19b) Dockerfile: don't use alpine, it has known DNS issues (#313)
+- [`2da83d9`](https://github.com/deis/workflow-e2e/commit/2da83d98c31f991ae7b8bf6b548104f7af3cb19b) Dockerfile: don't use alpine, it has known DNS issues (#313)
 
 #### Fixes
 
-- [`8a2d858`](https://github.com/deisthree/workflow-e2e/commit/8a2d858b74a779d3543786d519cccb96cffdc80a) healthcheck: use correct port the image exposes
+- [`8a2d858`](https://github.com/deis/workflow-e2e/commit/8a2d858b74a779d3543786d519cccb96cffdc80a) healthcheck: use correct port the image exposes
 
 #### Maintenance
 
-- [`424f625`](https://github.com/deisthree/workflow-e2e/commit/424f6256b28a872e1f633ff5041348576d972aed) Makefile: update docker-go-dev to 0.17.0
-- [`88ad38f`](https://github.com/deisthree/workflow-e2e/commit/88ad38f1fd6718b325824e1cc5a30ebaae05e3f3) glide.lock: update ginkgo, gomega, controller-sdk-go
+- [`424f625`](https://github.com/deis/workflow-e2e/commit/424f6256b28a872e1f633ff5041348576d972aed) Makefile: update docker-go-dev to 0.17.0
+- [`88ad38f`](https://github.com/deis/workflow-e2e/commit/88ad38f1fd6718b325824e1cc5a30ebaae05e3f3) glide.lock: update ginkgo, gomega, controller-sdk-go
 
 
 ### Workflow Manager v2.4.0 -> v2.4.1
 
 #### Documentation
 
-- [`25f5b32`](https://github.com/deisthree/workflow-manager/commit/25f5b3279f1df73e2010261509f16b85c7fc6017) README.md: add codecov.io badge
+- [`25f5b32`](https://github.com/deis/workflow-manager/commit/25f5b3279f1df73e2010261509f16b85c7fc6017) README.md: add codecov.io badge
 
 #### Maintenance
 
-- [`940ced5`](https://github.com/deisthree/workflow-manager/commit/940ced5216ab300d9c62e5c2d0aa6d3a7086b172) Makefile: update to go-dev 0.17.0
-- [`d9b0326`](https://github.com/deisthree/workflow-manager/commit/d9b03265826bda8ed4b42aba1528f963f8cd20c8) rootfs/Dockerfile: update to latest base image
+- [`940ced5`](https://github.com/deis/workflow-manager/commit/940ced5216ab300d9c62e5c2d0aa6d3a7086b172) Makefile: update to go-dev 0.17.0
+- [`d9b0326`](https://github.com/deis/workflow-manager/commit/d9b03265826bda8ed4b42aba1528f963f8cd20c8) rootfs/Dockerfile: update to latest base image

--- a/src/changelogs/v2.6.0.md
+++ b/src/changelogs/v2.6.0.md
@@ -5,314 +5,314 @@
 
 #### Fixes
 
-- [`392ef7d`](https://github.com/deisthree/builder/commit/392ef7dd5c9def3e63605fac24a824ad072d08f0) Makefile: update deploy target to use deployments (#424)
-- [`933c124`](https://github.com/deisthree/builder/commit/933c1247161bab9c41d0894bff01acf87bfe8c98) conf: strip newlines from builder key (#425)
+- [`392ef7d`](https://github.com/deis/builder/commit/392ef7dd5c9def3e63605fac24a824ad072d08f0) Makefile: update deploy target to use deployments (#424)
+- [`933c124`](https://github.com/deis/builder/commit/933c1247161bab9c41d0894bff01acf87bfe8c98) conf: strip newlines from builder key (#425)
 
 #### Maintenance
 
-- [`b1a0ef6`](https://github.com/deisthree/builder/commit/b1a0ef674660cbe27e66f4884e0463b50f98d5c4) Dockerfile: update base image to v0.3.4
-- [`ac829c0`](https://github.com/deisthree/builder/commit/ac829c02864eb1e922f8b473ea72c9aefabece82) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#434)
+- [`b1a0ef6`](https://github.com/deis/builder/commit/b1a0ef674660cbe27e66f4884e0463b50f98d5c4) Dockerfile: update base image to v0.3.4
+- [`ac829c0`](https://github.com/deis/builder/commit/ac829c02864eb1e922f8b473ea72c9aefabece82) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#434)
 
 
 ### Controller v2.5.2 -> v2.6.0
 
 #### Features
 
-- [`f5d1454`](https://github.com/deisthree/controller/commit/f5d14548472b074ee0641e550a3cf92a194f353a) api: inject release metadata into application (#1080)
+- [`f5d1454`](https://github.com/deis/controller/commit/f5d14548472b074ee0641e550a3cf92a194f353a) api: inject release metadata into application (#1080)
 
 #### Refactors
 
-- [`13de6e6`](https://github.com/deisthree/controller/commit/13de6e6ceb5bf853cdc8f36a971284336ee8feef) Dockerfile: ditch the pip cache for a slightly smaller image (#1051)
-- [`3e1f9d6`](https://github.com/deisthree/controller/commit/3e1f9d67bac0767718a46a226a92ac2024cbec0e) scheduler: add HTTP functions in KubeHTTPClient (#1019)
-- [`8d287b9`](https://github.com/deisthree/controller/commit/8d287b94fd0a475c75041906a20b9430f8da7c5b) scheduler: move image pull policy settings from scheduler to App model and remove SLUG_RUNNER_IMAGE_PULL_POLICY (#1053)
-- [`02718a3`](https://github.com/deisthree/controller/commit/02718a303891db4a6fb75d1789a2353e4f08afb5) app: centralise all application configuration handling in App model to be used by run, deploy and scale (#1061)
-- [`22f96eb`](https://github.com/deisthree/controller/commit/22f96ebfbfc9aa623a1505b179311ed3fe0442d5) scheduler: add more Pod tests in scheduler and add create() to Pod resource (#1079)
-- [`13c1711`](https://github.com/deisthree/controller/commit/13c1711f8843c8633d93abccdabc727093e1f89e) Dockerfile: use base 0.3.2, smaller packages and better cleanup (#1088)
+- [`13de6e6`](https://github.com/deis/controller/commit/13de6e6ceb5bf853cdc8f36a971284336ee8feef) Dockerfile: ditch the pip cache for a slightly smaller image (#1051)
+- [`3e1f9d6`](https://github.com/deis/controller/commit/3e1f9d67bac0767718a46a226a92ac2024cbec0e) scheduler: add HTTP functions in KubeHTTPClient (#1019)
+- [`8d287b9`](https://github.com/deis/controller/commit/8d287b94fd0a475c75041906a20b9430f8da7c5b) scheduler: move image pull policy settings from scheduler to App model and remove SLUG_RUNNER_IMAGE_PULL_POLICY (#1053)
+- [`02718a3`](https://github.com/deis/controller/commit/02718a303891db4a6fb75d1789a2353e4f08afb5) app: centralise all application configuration handling in App model to be used by run, deploy and scale (#1061)
+- [`22f96eb`](https://github.com/deis/controller/commit/22f96ebfbfc9aa623a1505b179311ed3fe0442d5) scheduler: add more Pod tests in scheduler and add create() to Pod resource (#1079)
+- [`13c1711`](https://github.com/deis/controller/commit/13c1711f8843c8633d93abccdabc727093e1f89e) Dockerfile: use base 0.3.2, smaller packages and better cleanup (#1088)
 
 #### Fixes
 
-- [`4f5f944`](https://github.com/deisthree/controller/commit/4f5f944a4ce1639f82ae276372f28fd9fb2c9bd6) views: make sure domain is set it in cert attach operation (#1046)
-- [`29d51d9`](https://github.com/deisthree/controller/commit/29d51d99c4ed4eb47cfd7a9cd1900c670dd6ffa8) scheduler: show more information when there is a HTTP error in Kubernetes (#1041)
-- [`3d3676b`](https://github.com/deisthree/controller/commit/3d3676bf3a8a3bde97e8c5581dc2b4c2e16eace5) release: call proper RC scale instead of a missing (old) method (#1055)
-- [`60c6a5f`](https://github.com/deisthree/controller/commit/60c6a5ffe1c37e523fe48959a06d310aa3164c08) procfile: route the traffic to web proctype always if its present in procfile
-- [`d7e626c`](https://github.com/deisthree/controller/commit/d7e626cb2857c66817085b56e5743642fe645eb2) whitelist: remove the whitelist from annoations if its empty
-- [`b8aa206`](https://github.com/deisthree/controller/commit/b8aa206880033443364f8198f6d9c583c7c4b8e1) api: check if release.build is NoneType (#1078)
-- [`ad182b2`](https://github.com/deisthree/controller/commit/ad182b24d00f1fa5ee212dfa27a2157acac27524) api: cast DEPLOY_BATCHES and DEPLOY_TIMEOUT to int (#1076)
-- [`7aaee55`](https://github.com/deisthree/controller/commit/7aaee55caf9dc4cf867f8588dafb586968df00fc) Makefile: remove double usage of --noinput (#1083)
+- [`4f5f944`](https://github.com/deis/controller/commit/4f5f944a4ce1639f82ae276372f28fd9fb2c9bd6) views: make sure domain is set it in cert attach operation (#1046)
+- [`29d51d9`](https://github.com/deis/controller/commit/29d51d99c4ed4eb47cfd7a9cd1900c670dd6ffa8) scheduler: show more information when there is a HTTP error in Kubernetes (#1041)
+- [`3d3676b`](https://github.com/deis/controller/commit/3d3676bf3a8a3bde97e8c5581dc2b4c2e16eace5) release: call proper RC scale instead of a missing (old) method (#1055)
+- [`60c6a5f`](https://github.com/deis/controller/commit/60c6a5ffe1c37e523fe48959a06d310aa3164c08) procfile: route the traffic to web proctype always if its present in procfile
+- [`d7e626c`](https://github.com/deis/controller/commit/d7e626cb2857c66817085b56e5743642fe645eb2) whitelist: remove the whitelist from annoations if its empty
+- [`b8aa206`](https://github.com/deis/controller/commit/b8aa206880033443364f8198f6d9c583c7c4b8e1) api: check if release.build is NoneType (#1078)
+- [`ad182b2`](https://github.com/deis/controller/commit/ad182b24d00f1fa5ee212dfa27a2157acac27524) api: cast DEPLOY_BATCHES and DEPLOY_TIMEOUT to int (#1076)
+- [`7aaee55`](https://github.com/deis/controller/commit/7aaee55caf9dc4cf867f8588dafb586968df00fc) Makefile: remove double usage of --noinput (#1083)
 
 #### Maintenance
 
-- [`667ba1f`](https://github.com/deisthree/controller/commit/667ba1fb8ef160213a29c340eab2c4294995d480) requirements: update django-guardian to 1.4.6 (#1050)
-- [`640d220`](https://github.com/deisthree/controller/commit/640d2200168191555893ac6710bb41b6956b2874) requirements: chore(requirements) Update to docker-py 1.10.2 (#1056)
-- [`8559fb0`](https://github.com/deisthree/controller/commit/8559fb07108479f207450667af6f5e05390fc0c5) tests: port app logs test from deis/deis#5005 (#1064)
-- [`06c7695`](https://github.com/deisthree/controller/commit/06c7695f72cb301e41d742db6ee222890927b498) scheduler: move log lines to before a raise so DEBUG info is actually caught (#1067)
-- [`aaccdf7`](https://github.com/deisthree/controller/commit/aaccdf7a261e5b64202dfadfdd2b3d451aa322b6) tests: improve test coverage for HPA (#1081)
-- [`4d7591c`](https://github.com/deisthree/controller/commit/4d7591c8073031db0876fb0ff4a27d0b76540e28) requirements: update docker-py to 1.10.3 (#1086)
-- [`e9a9e7a`](https://github.com/deisthree/controller/commit/e9a9e7a9421a08f6171575e3d2f56f0e25eaf6cc) tests: improve Pod scheduler tests (#1085)
-- [`260b1e4`](https://github.com/deisthree/controller/commit/260b1e47f85b1a97d0afa492b87f03ab3dbf39dc) requirements: update DRF to 3.4.7 (#1087)
+- [`667ba1f`](https://github.com/deis/controller/commit/667ba1fb8ef160213a29c340eab2c4294995d480) requirements: update django-guardian to 1.4.6 (#1050)
+- [`640d220`](https://github.com/deis/controller/commit/640d2200168191555893ac6710bb41b6956b2874) requirements: chore(requirements) Update to docker-py 1.10.2 (#1056)
+- [`8559fb0`](https://github.com/deis/controller/commit/8559fb07108479f207450667af6f5e05390fc0c5) tests: port app logs test from deis/deis#5005 (#1064)
+- [`06c7695`](https://github.com/deis/controller/commit/06c7695f72cb301e41d742db6ee222890927b498) scheduler: move log lines to before a raise so DEBUG info is actually caught (#1067)
+- [`aaccdf7`](https://github.com/deis/controller/commit/aaccdf7a261e5b64202dfadfdd2b3d451aa322b6) tests: improve test coverage for HPA (#1081)
+- [`4d7591c`](https://github.com/deis/controller/commit/4d7591c8073031db0876fb0ff4a27d0b76540e28) requirements: update docker-py to 1.10.3 (#1086)
+- [`e9a9e7a`](https://github.com/deis/controller/commit/e9a9e7a9421a08f6171575e3d2f56f0e25eaf6cc) tests: improve Pod scheduler tests (#1085)
+- [`260b1e4`](https://github.com/deis/controller/commit/260b1e47f85b1a97d0afa492b87f03ab3dbf39dc) requirements: update DRF to 3.4.7 (#1087)
 
 
 ### Dockerbuilder v2.3.2 -> v2.3.3
 
 #### Maintenance
 
-- [`1bd4727`](https://github.com/deisthree/dockerbuilder/commit/1bd47277008bcaaf9c3ac64c48ebc29d36d2db9f) requirements: chore(requirements) Update to docker-py 1.10.2
-- [`28c31d4`](https://github.com/deisthree/dockerbuilder/commit/28c31d45a17a97473e83c451b0d2e743678620c0) requirements: update docker-py to 1.10.3 (#94)
-- [`f013504`](https://github.com/deisthree/dockerbuilder/commit/f0135046b32e707ab414ab428beae4c7ec276af4) Dockerfile: update base image to v0.3.4
-- [`070d5cb`](https://github.com/deisthree/dockerbuilder/commit/070d5cbbe2540cf5348c45437980ee6348e9f69c) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#96)
+- [`1bd4727`](https://github.com/deis/dockerbuilder/commit/1bd47277008bcaaf9c3ac64c48ebc29d36d2db9f) requirements: chore(requirements) Update to docker-py 1.10.2
+- [`28c31d4`](https://github.com/deis/dockerbuilder/commit/28c31d45a17a97473e83c451b0d2e743678620c0) requirements: update docker-py to 1.10.3 (#94)
+- [`f013504`](https://github.com/deis/dockerbuilder/commit/f0135046b32e707ab414ab428beae4c7ec276af4) Dockerfile: update base image to v0.3.4
+- [`070d5cb`](https://github.com/deis/dockerbuilder/commit/070d5cbbe2540cf5348c45437980ee6348e9f69c) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#96)
 
 
 ### Fluentd v2.2.0 -> v2.4.1
 
 #### Features
 
-- [`900a31b`](https://github.com/deisthree/fluentd/commit/900a31b9a5423d0413fd2ae0c49f678810c17471) Dockerfile: upgrade fluentd and pin versions
-- [`1529614`](https://github.com/deisthree/fluentd/commit/15296143a24daa08f5b4521e676add13d3be74f2) config: Allows for building custom plugins
-- [`c9a3d8f`](https://github.com/deisthree/fluentd/commit/c9a3d8f7ee61b232a374abdd5df2615737e35161) Allow configuring custom plugins/stores/filters for fluentd
+- [`900a31b`](https://github.com/deis/fluentd/commit/900a31b9a5423d0413fd2ae0c49f678810c17471) Dockerfile: upgrade fluentd and pin versions
+- [`1529614`](https://github.com/deis/fluentd/commit/15296143a24daa08f5b4521e676add13d3be74f2) config: Allows for building custom plugins
+- [`c9a3d8f`](https://github.com/deis/fluentd/commit/c9a3d8f7ee61b232a374abdd5df2615737e35161) Allow configuring custom plugins/stores/filters for fluentd
 
 #### Fixes
 
-- [`eeda904`](https://github.com/deisthree/fluentd/commit/eeda904095f4e2acef1d078a331950b9d3672ce1) conf: Remove time_format from sources
-- [`d5b8580`](https://github.com/deisthree/fluentd/commit/d5b85800f60ed3d040f1d21f9b5c4cff80c3d567) sources: allow users to specify what logs they want to capture
-- [`56f4d67`](https://github.com/deisthree/fluentd/commit/56f4d670c859a4a8b2c883db0c3d53ea2bd9897f) boot: fix missing container symlinks
-- [`eeda904`](https://github.com/deisthree/fluentd/commit/eeda904095f4e2acef1d078a331950b9d3672ce1) conf: Remove time_format from sources
-- [`d5b8580`](https://github.com/deisthree/fluentd/commit/d5b85800f60ed3d040f1d21f9b5c4cff80c3d567) sources: allow users to specify what logs they want to capture
-- [`56f4d67`](https://github.com/deisthree/fluentd/commit/56f4d670c859a4a8b2c883db0c3d53ea2bd9897f) boot: fix missing container symlinks
+- [`eeda904`](https://github.com/deis/fluentd/commit/eeda904095f4e2acef1d078a331950b9d3672ce1) conf: Remove time_format from sources
+- [`d5b8580`](https://github.com/deis/fluentd/commit/d5b85800f60ed3d040f1d21f9b5c4cff80c3d567) sources: allow users to specify what logs they want to capture
+- [`56f4d67`](https://github.com/deis/fluentd/commit/56f4d670c859a4a8b2c883db0c3d53ea2bd9897f) boot: fix missing container symlinks
+- [`eeda904`](https://github.com/deis/fluentd/commit/eeda904095f4e2acef1d078a331950b9d3672ce1) conf: Remove time_format from sources
+- [`d5b8580`](https://github.com/deis/fluentd/commit/d5b85800f60ed3d040f1d21f9b5c4cff80c3d567) sources: allow users to specify what logs they want to capture
+- [`56f4d67`](https://github.com/deis/fluentd/commit/56f4d670c859a4a8b2c883db0c3d53ea2bd9897f) boot: fix missing container symlinks
 
 #### Maintenance
 
-- [`bf242e2`](https://github.com/deisthree/fluentd/commit/bf242e209ec9b74d3ed14c414e965a53658a447d) deis: Allow users to disable the deis output plugin
-- [`30911be`](https://github.com/deisthree/fluentd/commit/30911be8eed235bf0cf77e7715877b679cae8ebd) Dockerfile: update base image to v0.3.4
-- [`36f90ae`](https://github.com/deisthree/fluentd/commit/36f90ae2cfea338d9603c85e3c537fa3238f43df) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#54)
-- [`bf242e2`](https://github.com/deisthree/fluentd/commit/bf242e209ec9b74d3ed14c414e965a53658a447d) deis: Allow users to disable the deis output plugin
+- [`bf242e2`](https://github.com/deis/fluentd/commit/bf242e209ec9b74d3ed14c414e965a53658a447d) deis: Allow users to disable the deis output plugin
+- [`30911be`](https://github.com/deis/fluentd/commit/30911be8eed235bf0cf77e7715877b679cae8ebd) Dockerfile: update base image to v0.3.4
+- [`36f90ae`](https://github.com/deis/fluentd/commit/36f90ae2cfea338d9603c85e3c537fa3238f43df) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#54)
+- [`bf242e2`](https://github.com/deis/fluentd/commit/bf242e209ec9b74d3ed14c414e965a53658a447d) deis: Allow users to disable the deis output plugin
 
 #### Documentation
 
-- [`49d8d29`](https://github.com/deisthree/fluentd/commit/49d8d29a7657d71bfa5d1f30f9d55bb43f0fc478) Document custom plugin environment variables.
+- [`49d8d29`](https://github.com/deis/fluentd/commit/49d8d29a7657d71bfa5d1f30f9d55bb43f0fc478) Document custom plugin environment variables.
 
 
 ### Logger v2.3.0 -> v2.3.1
 
 #### Fixes
 
-- [`9bd19a3`](https://github.com/deisthree/logger/commit/9bd19a3eb52117efbfc17ee46acefb5ee1f6ca07) weblog: fix up CPU issues
+- [`9bd19a3`](https://github.com/deis/logger/commit/9bd19a3eb52117efbfc17ee46acefb5ee1f6ca07) weblog: fix up CPU issues
 
 #### Documentation
 
-- [`9eb022d`](https://github.com/deisthree/logger/commit/9eb022dae0296f953c1b7b74997cfe5b7de40624) README: docs(README) update docs
+- [`9eb022d`](https://github.com/deis/logger/commit/9eb022dae0296f953c1b7b74997cfe5b7de40624) README: docs(README) update docs
 
 #### Maintenance
 
-- [`6a865ee`](https://github.com/deisthree/logger/commit/6a865eea6c847bd3af8632e9a0cbf4da3e545a8a) Dockerfile: update base image to v0.3.4
+- [`6a865ee`](https://github.com/deis/logger/commit/6a865eea6c847bd3af8632e9a0cbf4da3e545a8a) Dockerfile: update base image to v0.3.4
 
 
 ### Minio v2.2.1 -> v2.3.0
 
 #### Features
 
-- [`430d6d2`](https://github.com/deisthree/minio/commit/430d6d278f3bfaaac33d68811dc6a07e307f0e80) pkg: update the pkg to latest and get ip using downward api
+- [`430d6d2`](https://github.com/deis/minio/commit/430d6d278f3bfaaac33d68811dc6a07e307f0e80) pkg: update the pkg to latest and get ip using downward api
 
 #### Maintenance
 
-- [`ac80262`](https://github.com/deisthree/minio/commit/ac8026299344ac98db31119382669fdf44baa6bb) Dockerfile: update base image to v0.3.4
+- [`ac80262`](https://github.com/deis/minio/commit/ac8026299344ac98db31119382669fdf44baa6bb) Dockerfile: update base image to v0.3.4
 
 
 ### Monitoring v2.4.0 -> v2.5.1
 
 #### Features
 
-- [`ab1d467`](https://github.com/deisthree/monitor/commit/ab1d4675e1f7ceba17f6943fa2f95ab11a28a975) influxdb: upgrade influxdb and telegraph to 1.0
+- [`ab1d467`](https://github.com/deis/monitor/commit/ab1d4675e1f7ceba17f6943fa2f95ab11a28a975) influxdb: upgrade influxdb and telegraph to 1.0
 
 #### Maintenance
 
-- [`1a10082`](https://github.com/deisthree/monitor/commit/1a1008284829d1adb7f3b2957df2dc1ea95a3162) telegraf,grafana,influx: Update to 0.3.4 base
-- [`d596b08`](https://github.com/deisthree/monitor/commit/d596b08506cc4271b8507e15af362f232ba344e6) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#144)
-- [`3aea2a7`](https://github.com/deisthree/monitor/commit/3aea2a7754322a58e3457c0d554bf4b3c3e2ca1e) config: Remove calls to quote
+- [`1a10082`](https://github.com/deis/monitor/commit/1a1008284829d1adb7f3b2957df2dc1ea95a3162) telegraf,grafana,influx: Update to 0.3.4 base
+- [`d596b08`](https://github.com/deis/monitor/commit/d596b08506cc4271b8507e15af362f232ba344e6) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#144)
+- [`3aea2a7`](https://github.com/deis/monitor/commit/3aea2a7754322a58e3457c0d554bf4b3c3e2ca1e) config: Remove calls to quote
 
 
 ### NSQ v2.2.0 -> v2.2.2
 
 #### Fixes
 
-- [`8e1e208`](https://github.com/deisthree/nsq/commit/8e1e20887a5d614cd622f510b39c517cd5fffb76) Adding set -eo pipefail to start up script
+- [`8e1e208`](https://github.com/deis/nsq/commit/8e1e20887a5d614cd622f510b39c517cd5fffb76) Adding set -eo pipefail to start up script
 
 #### Maintenance
 
-- [`ef2bb5d`](https://github.com/deisthree/nsq/commit/ef2bb5dd54c89329aa9d2dd9394bd2d8ffffbed7) Dockerfile: update base image to v0.3.4
+- [`ef2bb5d`](https://github.com/deis/nsq/commit/ef2bb5dd54c89329aa9d2dd9394bd2d8ffffbed7) Dockerfile: update base image to v0.3.4
 
 
 ### Redis v2.2.0 -> v2.2.2
 
 #### Fixes
 
-- [`3659efb`](https://github.com/deisthree/redis/commit/3659efb0955fecf45f1f19172b07faa3062da361) Dockerfile: missing && in Dockerfile makes apt not so happy (#5)
+- [`3659efb`](https://github.com/deis/redis/commit/3659efb0955fecf45f1f19172b07faa3062da361) Dockerfile: missing && in Dockerfile makes apt not so happy (#5)
 
 #### Refactors
 
-- [`7e62f08`](https://github.com/deisthree/redis/commit/7e62f0863ea0889a1afa92488fad0d39043da764) Makefile: remove obsolete "docker tag -f" flag
+- [`7e62f08`](https://github.com/deis/redis/commit/7e62f0863ea0889a1afa92488fad0d39043da764) Makefile: remove obsolete "docker tag -f" flag
 
 #### Maintenance
 
-- [`545c46b`](https://github.com/deisthree/redis/commit/545c46bd545f4e1ebc4504c87eada1e0707bfaa1) Dockerfile: update base image to v0.3.4
-- [`21c376d`](https://github.com/deisthree/redis/commit/21c376dda137d219e8e9842150021cd75ebeb0f8) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#4)
+- [`545c46b`](https://github.com/deis/redis/commit/545c46bd545f4e1ebc4504c87eada1e0707bfaa1) Dockerfile: update base image to v0.3.4
+- [`21c376d`](https://github.com/deis/redis/commit/21c376dda137d219e8e9842150021cd75ebeb0f8) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#4)
 
 
 ### Registry v2.2.1 -> v2.2.2
 
 #### Maintenance
 
-- [`c9150b9`](https://github.com/deisthree/registry/commit/c9150b9ae338b63ab5d4cb2455286b80cebec551) Dockerfile: update base image to v0.3.4
-- [`32a7400`](https://github.com/deisthree/registry/commit/32a740033fd6ff5a96179607c9b4a68c88c3bbdd) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#67)
+- [`c9150b9`](https://github.com/deis/registry/commit/c9150b9ae338b63ab5d4cb2455286b80cebec551) Dockerfile: update base image to v0.3.4
+- [`32a7400`](https://github.com/deis/registry/commit/32a740033fd6ff5a96179607c9b4a68c88c3bbdd) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#67)
 
 
 ### Registry Proxy v1.0.0 -> v1.1.0
 
 #### Fixes
 
-- [`5f69fe0`](https://github.com/deisthree/registry-proxy/commit/5f69fe069945abf79c2566728a103b994382658d) nginx: set worker_processes to auto
+- [`5f69fe0`](https://github.com/deis/registry-proxy/commit/5f69fe069945abf79c2566728a103b994382658d) nginx: set worker_processes to auto
 
 #### Maintenance
 
-- [`89687b0`](https://github.com/deisthree/registry-proxy/commit/89687b02a3883e877b1b3288ebfd5a43c01e7305) rootfs: bump version to v1.1.0-dev
-- [`70a8a8b`](https://github.com/deisthree/registry-proxy/commit/70a8a8ba5127b6373ed6b4cf33ea78dfafa5f79c) rootfs: bump version to v1.1.0
+- [`89687b0`](https://github.com/deis/registry-proxy/commit/89687b02a3883e877b1b3288ebfd5a43c01e7305) rootfs: bump version to v1.1.0-dev
+- [`70a8a8b`](https://github.com/deis/registry-proxy/commit/70a8a8ba5127b6373ed6b4cf33ea78dfafa5f79c) rootfs: bump version to v1.1.0
 
 
 ### Router v2.5.0 -> v2.6.2
 
 #### Features
 
-- [`151916e`](https://github.com/deisthree/router/commit/151916ee562507c7c9c7b2e566ad6c60141e1bd0) nginx: Allow sending nginx X-Request-Id and X-Correlation-Id headers.
+- [`151916e`](https://github.com/deis/router/commit/151916ee562507c7c9c7b2e566ad6c60141e1bd0) nginx: Allow sending nginx X-Request-Id and X-Correlation-Id headers.
 
 #### Refactors
 
-- [`b33c18c`](https://github.com/deisthree/router/commit/b33c18c768a6adebc0a41a5444852391d2bf4407) glide: use the official kubernetes client (#259)
+- [`b33c18c`](https://github.com/deis/router/commit/b33c18c768a6adebc0a41a5444852391d2bf4407) glide: use the official kubernetes client (#259)
 
 #### Fixes
 
-- [`a729799`](https://github.com/deisthree/router/commit/a72979956e4f324837203d8d34102a5fe4e407d5) nginx: Enable builder PROXY PROTOCOL support
-- [`0d9b119`](https://github.com/deisthree/router/commit/0d9b11928b6619d1eb376eaf1fd0714ef2da9e7a) ngnix: handle X-Forwarded-Port and X-Forwarded-Proto properly
+- [`a729799`](https://github.com/deis/router/commit/a72979956e4f324837203d8d34102a5fe4e407d5) nginx: Enable builder PROXY PROTOCOL support
+- [`0d9b119`](https://github.com/deis/router/commit/0d9b11928b6619d1eb376eaf1fd0714ef2da9e7a) ngnix: handle X-Forwarded-Port and X-Forwarded-Proto properly
 
 #### Documentation
 
-- [`b20eba0`](https://github.com/deisthree/router/commit/b20eba00c2f7bb1ef9de6b3065e446f22aaaa223) README: Correct errant references to RC in annotations table
+- [`b20eba0`](https://github.com/deis/router/commit/b20eba00c2f7bb1ef9de6b3065e446f22aaaa223) README: Correct errant references to RC in annotations table
 
 #### Maintenance
 
-- [`4afbcc6`](https://github.com/deisthree/router/commit/4afbcc6f243a413aa040eef5be9a7201fd603351) Dockerfile: update base image to v0.3.4
-- [`5a6b004`](https://github.com/deisthree/router/commit/5a6b004e6b3ee1ed1f0408117f79f95bba426372) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#262)
-- [`e38a69b`](https://github.com/deisthree/router/commit/e38a69b72a873d87b3c46e98201f1f1caa71adbd) nginx: update nginx to 1.11.4 (#252)
-- [`246bdc5`](https://github.com/deisthree/router/commit/246bdc5b4f785da5da49139922d1455200c21e73) Dockerfile: bump deis/base to v0.3.2
+- [`4afbcc6`](https://github.com/deis/router/commit/4afbcc6f243a413aa040eef5be9a7201fd603351) Dockerfile: update base image to v0.3.4
+- [`5a6b004`](https://github.com/deis/router/commit/5a6b004e6b3ee1ed1f0408117f79f95bba426372) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#262)
+- [`e38a69b`](https://github.com/deis/router/commit/e38a69b72a873d87b3c46e98201f1f1caa71adbd) nginx: update nginx to 1.11.4 (#252)
+- [`246bdc5`](https://github.com/deis/router/commit/246bdc5b4f785da5da49139922d1455200c21e73) Dockerfile: bump deis/base to v0.3.2
 
 
 ### Slugbuilder v2.4.1 -> v2.4.3
 
 #### Refactors
 
-- [`24e0ce9`](https://github.com/deisthree/slugbuilder/commit/24e0ce984dbfd27f7ccbcac8fcac9af53222cf16) Dockerfile: simplify chown commands
+- [`24e0ce9`](https://github.com/deis/slugbuilder/commit/24e0ce984dbfd27f7ccbcac8fcac9af53222cf16) Dockerfile: simplify chown commands
 
 #### Fixes
 
-- [`37c5109`](https://github.com/deisthree/slugbuilder/commit/37c5109557a3005e3f0afd5f224781c609a8f6b4) build.sh: switch to build_root before running hooks
+- [`37c5109`](https://github.com/deis/slugbuilder/commit/37c5109557a3005e3f0afd5f224781c609a8f6b4) build.sh: switch to build_root before running hooks
 
 #### Maintenance
 
-- [`2a7769d`](https://github.com/deisthree/slugbuilder/commit/2a7769d328ffd9ceb2ca13288f8608fdf2f7562b) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#113)
-- [`0ff387f`](https://github.com/deisthree/slugbuilder/commit/0ff387fe24cfafc4100db9cca666ac00fd30d0d8) buildpacks: update heroku-buildpack-go to v48
-- [`4eada8d`](https://github.com/deisthree/slugbuilder/commit/4eada8d5a9ce385e5418898537dca85390eda55a) buildpacks: update heroku-buildpack-php to v110
-- [`fcb645b`](https://github.com/deisthree/slugbuilder/commit/fcb645b6d09f8ec5ab95877d26c8ca215dc9a095) buildpacks: update heroku-buildpack-python to v82
-- [`69abae5`](https://github.com/deisthree/slugbuilder/commit/69abae5c6f560ff2ec7baf8d2d4be4cdf15393e5) buildpacks: update heroku-buildpack-gradle to v18
-- [`d6445a6`](https://github.com/deisthree/slugbuilder/commit/d6445a62331fc0d7d518123de361c54d72f8f4d4) buildpacks: update heroku-buildpack-java to v46
-- [`30ce52f`](https://github.com/deisthree/slugbuilder/commit/30ce52fc93ab25d537958d9524c0e0f880f9f78b) buildpacks: update heroku-buildpack-go to v49
-- [`7e4e9cc`](https://github.com/deisthree/slugbuilder/commit/7e4e9ccec99bd5b8bf19e608494093e7dfab16d0) buildpacks: update heroku-buildpack-php to v112
+- [`2a7769d`](https://github.com/deis/slugbuilder/commit/2a7769d328ffd9ceb2ca13288f8608fdf2f7562b) Dockerfile: cleanup after installation a bit more than before and keep copyright / license files (#113)
+- [`0ff387f`](https://github.com/deis/slugbuilder/commit/0ff387fe24cfafc4100db9cca666ac00fd30d0d8) buildpacks: update heroku-buildpack-go to v48
+- [`4eada8d`](https://github.com/deis/slugbuilder/commit/4eada8d5a9ce385e5418898537dca85390eda55a) buildpacks: update heroku-buildpack-php to v110
+- [`fcb645b`](https://github.com/deis/slugbuilder/commit/fcb645b6d09f8ec5ab95877d26c8ca215dc9a095) buildpacks: update heroku-buildpack-python to v82
+- [`69abae5`](https://github.com/deis/slugbuilder/commit/69abae5c6f560ff2ec7baf8d2d4be4cdf15393e5) buildpacks: update heroku-buildpack-gradle to v18
+- [`d6445a6`](https://github.com/deis/slugbuilder/commit/d6445a62331fc0d7d518123de361c54d72f8f4d4) buildpacks: update heroku-buildpack-java to v46
+- [`30ce52f`](https://github.com/deis/slugbuilder/commit/30ce52fc93ab25d537958d9524c0e0f880f9f78b) buildpacks: update heroku-buildpack-go to v49
+- [`7e4e9cc`](https://github.com/deis/slugbuilder/commit/7e4e9ccec99bd5b8bf19e608494093e7dfab16d0) buildpacks: update heroku-buildpack-php to v112
 
 
 ### Slugbuilder v2.2.1 -> v2.2.2
 
 #### Maintenance
 
-- [`098d05a`](https://github.com/deisthree/slugrunner/commit/098d05a927f8201d16f82ff0ef18e7ada02a6593) Dockerfile: consolidate a few chmod and chown into one layer (#54)
+- [`098d05a`](https://github.com/deis/slugrunner/commit/098d05a927f8201d16f82ff0ef18e7ada02a6593) Dockerfile: consolidate a few chmod and chown into one layer (#54)
 
 
 ### Workflow CLI v2.5.1 -> v2.6.0
 
 #### Features
 
-- [`c760eb1`](https://github.com/deisthree/workflow-cli/commit/c760eb13cd3cb4fe098f700b0ae33e4258312275) cmd: only print version mismatch warning once (#223)
-- [`a330059`](https://github.com/deisthree/workflow-cli/commit/a3300599ba7a247934b3e6483ef2ff65a92e05af) git: clean up git package and write tests (#227)
+- [`c760eb1`](https://github.com/deis/workflow-cli/commit/c760eb13cd3cb4fe098f700b0ae33e4258312275) cmd: only print version mismatch warning once (#223)
+- [`a330059`](https://github.com/deis/workflow-cli/commit/a3300599ba7a247934b3e6483ef2ff65a92e05af) git: clean up git package and write tests (#227)
 
 #### Refactors
 
-- [`85f2df2`](https://github.com/deisthree/workflow-cli/commit/85f2df23f90dcd82002d9b0d5cb1a3e25ebfaf1b) Dockerfile: remove deprecated --strip-vcs flag
+- [`85f2df2`](https://github.com/deis/workflow-cli/commit/85f2df23f90dcd82002d9b0d5cb1a3e25ebfaf1b) Dockerfile: remove deprecated --strip-vcs flag
 
 #### Fixes
 
-- [`6b13756`](https://github.com/deisthree/workflow-cli/commit/6b13756587ed58c7af667da097f7130db658f601) CI: explicitly set codecov git SHA (#221)
-- [`2bb4cde`](https://github.com/deisthree/workflow-cli/commit/2bb4cdea48ce739921aa489f81c9c204c74dafe6) Jenkinsfile: un-parallelize lint and test tasks
+- [`6b13756`](https://github.com/deis/workflow-cli/commit/6b13756587ed58c7af667da097f7130db658f601) CI: explicitly set codecov git SHA (#221)
+- [`2bb4cde`](https://github.com/deis/workflow-cli/commit/2bb4cdea48ce739921aa489f81c9c204c74dafe6) Jenkinsfile: un-parallelize lint and test tasks
 
 #### Documentation
 
-- [`c04610d`](https://github.com/deisthree/workflow-cli/commit/c04610de61a56450578dae863e8515342fffc313) README.md: update bucket location
-- [`8745328`](https://github.com/deisthree/workflow-cli/commit/8745328563dc3632229343bf120e0e64a0d1e0f7) readme: adding codecov badge (#249)
+- [`c04610d`](https://github.com/deis/workflow-cli/commit/c04610de61a56450578dae863e8515342fffc313) README.md: update bucket location
+- [`8745328`](https://github.com/deis/workflow-cli/commit/8745328563dc3632229343bf120e0e64a0d1e0f7) readme: adding codecov badge (#249)
 
 #### Maintenance
 
-- [`1041d9e`](https://github.com/deisthree/workflow-cli/commit/1041d9ea6bf97a88075e45849bed5911933b13aa) Dockerfile: update go-dev and go toolchain
+- [`1041d9e`](https://github.com/deis/workflow-cli/commit/1041d9ea6bf97a88075e45849bed5911933b13aa) Dockerfile: update go-dev and go toolchain
 
 
 ### Workflow Documentation v2.5.0 -> v2.6.0
 
 #### Features
 
-- [`a3a25c0`](https://github.com/deisthree/workflow/commit/a3a25c0aea39d5e7e721aa3b9ef8dd9c54306742) scripts: build every tagged version of workflow docs
-- [`9ae8f9c`](https://github.com/deisthree/workflow/commit/9ae8f9c378521d30ff8178d04176095b1d2564d7) apps: add information about IMAGE_PULL_POLICY globally and per app (#504)
+- [`a3a25c0`](https://github.com/deis/workflow/commit/a3a25c0aea39d5e7e721aa3b9ef8dd9c54306742) scripts: build every tagged version of workflow docs
+- [`9ae8f9c`](https://github.com/deis/workflow/commit/9ae8f9c378521d30ff8178d04176095b1d2564d7) apps: add information about IMAGE_PULL_POLICY globally and per app (#504)
 
 #### Refactors
 
-- [`495e1a1`](https://github.com/deisthree/workflow/commit/495e1a17900b2d3304e6e7918abb8edc12faf2e1) configuring-registry: clarify ECR registry variables
+- [`495e1a1`](https://github.com/deis/workflow/commit/495e1a17900b2d3304e6e7918abb8edc12faf2e1) configuring-registry: clarify ECR registry variables
 
 #### Fixes
 
-- [`fb5d378`](https://github.com/deisthree/workflow/commit/fb5d378a084b70810d3a13c3388cc596fa5fecd5) releases: deisrel no longer requires $OLD_SHA and $OLD_RELEASE
-- [`cb23b43`](https://github.com/deisthree/workflow/commit/cb23b43ec310888c53d8b55f08cbe166c9fb17c3) components: link to architecture, not itself (#499)
-- [`c95c24b`](https://github.com/deisthree/workflow/commit/c95c24bb760e13ff1012159bdbe43dcc478e8d05) configuring-registry: add missing IAM link
-- [`6509c41`](https://github.com/deisthree/workflow/commit/6509c41fab97c4bdfbd00006352827cf9a5fe622) docs: add documentation on resetting a password using the cli. (#507)
-- [`7b88723`](https://github.com/deisthree/workflow/commit/7b8872332e6cd11b26683536d96f25f5e707b44d) docs: change the references from RC's to deploments
-- [`54df10a`](https://github.com/deisthree/workflow/commit/54df10af0707865a270281d487b3a27fc372932b) deisrel: update the deisrel command to generate changelog
-- [`0e56d8a`](https://github.com/deisthree/workflow/commit/0e56d8ab4194cfc9d29748c303bf357b10bac2ac) gutenbuild: do not build any pre-release tags
-- [`80f0551`](https://github.com/deisthree/workflow/commit/80f0551716bc146b52300a7b6a7e8326bca8f315) gutenbuild: ensure we are on master before building
-- [`1e87307`](https://github.com/deisthree/workflow/commit/1e8730733f5d695f01058236bd4f276d9d9ff577) gutenbuild: prepend grep string with --
-- [`26d8a40`](https://github.com/deisthree/workflow/commit/26d8a405733d3f92c9b909aef68c564a4bea98df) gutenbuild: use dev_build_dest for second build
+- [`fb5d378`](https://github.com/deis/workflow/commit/fb5d378a084b70810d3a13c3388cc596fa5fecd5) releases: deisrel no longer requires $OLD_SHA and $OLD_RELEASE
+- [`cb23b43`](https://github.com/deis/workflow/commit/cb23b43ec310888c53d8b55f08cbe166c9fb17c3) components: link to architecture, not itself (#499)
+- [`c95c24b`](https://github.com/deis/workflow/commit/c95c24bb760e13ff1012159bdbe43dcc478e8d05) configuring-registry: add missing IAM link
+- [`6509c41`](https://github.com/deis/workflow/commit/6509c41fab97c4bdfbd00006352827cf9a5fe622) docs: add documentation on resetting a password using the cli. (#507)
+- [`7b88723`](https://github.com/deis/workflow/commit/7b8872332e6cd11b26683536d96f25f5e707b44d) docs: change the references from RC's to deploments
+- [`54df10a`](https://github.com/deis/workflow/commit/54df10af0707865a270281d487b3a27fc372932b) deisrel: update the deisrel command to generate changelog
+- [`0e56d8a`](https://github.com/deis/workflow/commit/0e56d8ab4194cfc9d29748c303bf357b10bac2ac) gutenbuild: do not build any pre-release tags
+- [`80f0551`](https://github.com/deis/workflow/commit/80f0551716bc146b52300a7b6a7e8326bca8f315) gutenbuild: ensure we are on master before building
+- [`1e87307`](https://github.com/deis/workflow/commit/1e8730733f5d695f01058236bd4f276d9d9ff577) gutenbuild: prepend grep string with --
+- [`26d8a40`](https://github.com/deis/workflow/commit/26d8a405733d3f92c9b909aef68c564a4bea98df) gutenbuild: use dev_build_dest for second build
 
 #### Documentation
 
-- [`8b542a1`](https://github.com/deisthree/workflow/commit/8b542a13e47c057a396c0adff0174d035ccad278) upgrade: reminder to upgrade deis client
-- [`0ef84bc`](https://github.com/deisthree/workflow/commit/0ef84bcc360f0660d26f834fe18d7b75c5b8115c) slugbuilder-cache: add CACHE_PATH variable
-- [`a349d20`](https://github.com/deisthree/workflow/commit/a349d2025f5d2243b653b746cb162768bb9be8ff) slugbuilder-cache: add usage documentation
-- [`1f09a8c`](https://github.com/deisthree/workflow/commit/1f09a8ce818e82fe205beeb799b883c19ab5858e) slugbuilder-cache: add application tuning variable
-- [`ec42f7b`](https://github.com/deisthree/workflow/commit/ec42f7bb8bdd5051def6de6d1e79750e75aa1d1a) src/roadmap/releases.md: remove publish component release step
-- [`a971a25`](https://github.com/deisthree/workflow/commit/a971a25c047f9a7e25650757d8391814f42b41f5) CONTRIBUTING: update contributing documentation (#498)
-- [`d0a43b5`](https://github.com/deisthree/workflow/commit/d0a43b5ca27972b9ed4145690a4cd169e96a9537) tuning: update storage default for logger
-- [`5720dce`](https://github.com/deisthree/workflow/commit/5720dcedb855c8f0d409eb1f4a34f8ca045e085a) src/managing-workflow/upgrading-workflow.md: document nodes >= 2 for upgrade
-- [`5705489`](https://github.com/deisthree/workflow/commit/5705489307424ff8c65565ddc33f867d04268c91) src/roadmap/releases.md: link to pipeline flow diagrams
-- [`0da5297`](https://github.com/deisthree/workflow/commit/0da52979a42f575bde50b806c595561ce3868340) managing-workflow: Document PROXY protocol configuration
-- [`b5f2d99`](https://github.com/deisthree/workflow/commit/b5f2d99308c12ed02490d01893af51bb43510347) releases: add missing details and reword CI flow reference
+- [`8b542a1`](https://github.com/deis/workflow/commit/8b542a13e47c057a396c0adff0174d035ccad278) upgrade: reminder to upgrade deis client
+- [`0ef84bc`](https://github.com/deis/workflow/commit/0ef84bcc360f0660d26f834fe18d7b75c5b8115c) slugbuilder-cache: add CACHE_PATH variable
+- [`a349d20`](https://github.com/deis/workflow/commit/a349d2025f5d2243b653b746cb162768bb9be8ff) slugbuilder-cache: add usage documentation
+- [`1f09a8c`](https://github.com/deis/workflow/commit/1f09a8ce818e82fe205beeb799b883c19ab5858e) slugbuilder-cache: add application tuning variable
+- [`ec42f7b`](https://github.com/deis/workflow/commit/ec42f7bb8bdd5051def6de6d1e79750e75aa1d1a) src/roadmap/releases.md: remove publish component release step
+- [`a971a25`](https://github.com/deis/workflow/commit/a971a25c047f9a7e25650757d8391814f42b41f5) CONTRIBUTING: update contributing documentation (#498)
+- [`d0a43b5`](https://github.com/deis/workflow/commit/d0a43b5ca27972b9ed4145690a4cd169e96a9537) tuning: update storage default for logger
+- [`5720dce`](https://github.com/deis/workflow/commit/5720dcedb855c8f0d409eb1f4a34f8ca045e085a) src/managing-workflow/upgrading-workflow.md: document nodes >= 2 for upgrade
+- [`5705489`](https://github.com/deis/workflow/commit/5705489307424ff8c65565ddc33f867d04268c91) src/roadmap/releases.md: link to pipeline flow diagrams
+- [`0da5297`](https://github.com/deis/workflow/commit/0da52979a42f575bde50b806c595561ce3868340) managing-workflow: Document PROXY protocol configuration
+- [`b5f2d99`](https://github.com/deis/workflow/commit/b5f2d99308c12ed02490d01893af51bb43510347) releases: add missing details and reword CI flow reference
 
 #### Maintenance
 
-- [`7faaaa7`](https://github.com/deisthree/workflow/commit/7faaaa7fa6ecd20306a2a91111076b615ec22d43) release: update roadmap for 2.5
-- [`e8c5d3f`](https://github.com/deisthree/workflow/commit/e8c5d3f9bc27127c94bed5acff9749b199dbc1b8) src/roadmap/releases.md: update jenkins-jobs var name
-- [`2655c90`](https://github.com/deisthree/workflow/commit/2655c9040b4187e8c0a1bc4d0805f86620700c1a) scripts: remove old release tools and CHANGELOG
+- [`7faaaa7`](https://github.com/deis/workflow/commit/7faaaa7fa6ecd20306a2a91111076b615ec22d43) release: update roadmap for 2.5
+- [`e8c5d3f`](https://github.com/deis/workflow/commit/e8c5d3f9bc27127c94bed5acff9749b199dbc1b8) src/roadmap/releases.md: update jenkins-jobs var name
+- [`2655c90`](https://github.com/deis/workflow/commit/2655c9040b4187e8c0a1bc4d0805f86620700c1a) scripts: remove old release tools and CHANGELOG
 
 
 ### Workflow E2E Tests v2.5.2 -> v2.5.3
 
 #### Fixes
 
-- [`4f00c8b`](https://github.com/deisthree/workflow-e2e/commit/4f00c8bb9e4b876e68b4abc4db1995cec5d28f6e) tests: re-enable tls tests (#326)
+- [`4f00c8b`](https://github.com/deis/workflow-e2e/commit/4f00c8bb9e4b876e68b4abc4db1995cec5d28f6e) tests: re-enable tls tests (#326)
 
 
 ### Worklfow Manager v2.4.1 -> v2.4.2
 
 #### Maintenance
 
-- [`350f7c3`](https://github.com/deisthree/workflow-manager/commit/350f7c36c3a2432c8ddba7ce7f8d2cc03a26d054) Dockerfile: update base image to v0.3.4
+- [`350f7c3`](https://github.com/deis/workflow-manager/commit/350f7c36c3a2432c8ddba7ce7f8d2cc03a26d054) Dockerfile: update base image to v0.3.4

--- a/src/changelogs/v2.7.0.md
+++ b/src/changelogs/v2.7.0.md
@@ -5,191 +5,191 @@
 
 #### Refactors
 
-- [`3a6c891`](https://github.com/deisthree/builder/commit/3a6c891d4372d26e89d6ed1e9ac26c7a1f75322c) controller: use the env config instead of directly getting from environment
+- [`3a6c891`](https://github.com/deis/builder/commit/3a6c891d4372d26e89d6ed1e9ac26c7a1f75322c) controller: use the env config instead of directly getting from environment
 
 #### Fixes
 
-- [`dd4f1b0`](https://github.com/deisthree/builder/commit/dd4f1b00e694b4893f6339492facf0e45a124709) travis: remove vendor dir from cache
-- [`4a4044e`](https://github.com/deisthree/builder/commit/4a4044ebadade52c0e394a9b1943af3fc980ddf1) sshd: Typo in the timeout message.
+- [`dd4f1b0`](https://github.com/deis/builder/commit/dd4f1b00e694b4893f6339492facf0e45a124709) travis: remove vendor dir from cache
+- [`4a4044e`](https://github.com/deis/builder/commit/4a4044ebadade52c0e394a9b1943af3fc980ddf1) sshd: Typo in the timeout message.
 
 #### Maintenance
 
-- [`1196719`](https://github.com/deisthree/builder/commit/11967199b0ae86e401886b92c7222c38857ad0e1) CHANGELOG: remove changelog
+- [`1196719`](https://github.com/deis/builder/commit/11967199b0ae86e401886b92c7222c38857ad0e1) CHANGELOG: remove changelog
 
 
 ### Controller v2.6.0 -> v2.7.0
 
 #### Features
 
-- [`d63fe7f`](https://github.com/deisthree/controller/commit/d63fe7f2fa44897235eb1b017d8b6cbf80136bae) errors: give more context on what model is involved when 404 Not Found is involved (#1096)
+- [`d63fe7f`](https://github.com/deis/controller/commit/d63fe7f2fa44897235eb1b017d8b6cbf80136bae) errors: give more context on what model is involved when 404 Not Found is involved (#1096)
 
 #### Refactors
 
-- [`9baa3d3`](https://github.com/deisthree/controller/commit/9baa3d3220cf18f5251716913ccb38099e5a1734) registry: remove simpleflock and depend on Docker 1.9 minimum (#1090)
+- [`9baa3d3`](https://github.com/deis/controller/commit/9baa3d3220cf18f5251716913ccb38099e5a1734) registry: remove simpleflock and depend on Docker 1.9 minimum (#1090)
 
 #### Fixes
 
-- [`12b5bfd`](https://github.com/deisthree/controller/commit/12b5bfd1b1a73c70ec3669ac6296f18d58153edb) key: ssh key name has to be unique now - migration included that appends a number (#1098)
-- [`8f943d9`](https://github.com/deisthree/controller/commit/8f943d906d0defd73c7428b408852f445aaac4fd) version: Use a different version number for each release
-- [`451622b`](https://github.com/deisthree/controller/commit/451622b5075cb2a67a02f0089f92a6ab5d298ced) app: an app can now be removed from the database even if the namespace for it was already deleted (#1101)
-- [`9f6cb94`](https://github.com/deisthree/controller/commit/9f6cb94de0bf1fa6817302dd041ea173a76d08d0) urls: terminate url regex with $ so that there is no cascading attempts at URLs (#1103)
-- [`aa6e0f3`](https://github.com/deisthree/controller/commit/aa6e0f3d2e0291103c59bdfd2a020ede79e4d109) secret: create objectstore  secret before calling scheduler deploy
-- [`53e118e`](https://github.com/deisthree/controller/commit/53e118ead55539a2c8e9660137d2cedf5c9e483b) procfile: validate the proctypes during build itself
+- [`12b5bfd`](https://github.com/deis/controller/commit/12b5bfd1b1a73c70ec3669ac6296f18d58153edb) key: ssh key name has to be unique now - migration included that appends a number (#1098)
+- [`8f943d9`](https://github.com/deis/controller/commit/8f943d906d0defd73c7428b408852f445aaac4fd) version: Use a different version number for each release
+- [`451622b`](https://github.com/deis/controller/commit/451622b5075cb2a67a02f0089f92a6ab5d298ced) app: an app can now be removed from the database even if the namespace for it was already deleted (#1101)
+- [`9f6cb94`](https://github.com/deis/controller/commit/9f6cb94de0bf1fa6817302dd041ea173a76d08d0) urls: terminate url regex with $ so that there is no cascading attempts at URLs (#1103)
+- [`aa6e0f3`](https://github.com/deis/controller/commit/aa6e0f3d2e0291103c59bdfd2a020ede79e4d109) secret: create objectstore  secret before calling scheduler deploy
+- [`53e118e`](https://github.com/deis/controller/commit/53e118ead55539a2c8e9660137d2cedf5c9e483b) procfile: validate the proctypes during build itself
 
 #### Maintenance
 
-- [`67c5471`](https://github.com/deisthree/controller/commit/67c547124681357fd8c86a5fd8d4b2de98e03d6b) scheduler: move lower level deploy helpers into their respective resources (#1092)
-- [`7ba556b`](https://github.com/deisthree/controller/commit/7ba556b4219ce7e7251b055883be6bcfd3dd496d) CHANGELOG: remove changelog (#1091)
-- [`f724afe`](https://github.com/deisthree/controller/commit/f724afe5fd612515b36d85ac3214ed6a233a269d) requirements: update Django to 1.10.2
-- [`9582496`](https://github.com/deisthree/controller/commit/95824969268c4536b5517e527c24959661832b1c) requirements: update pytz to 2016.7 (#1102)
+- [`67c5471`](https://github.com/deis/controller/commit/67c547124681357fd8c86a5fd8d4b2de98e03d6b) scheduler: move lower level deploy helpers into their respective resources (#1092)
+- [`7ba556b`](https://github.com/deis/controller/commit/7ba556b4219ce7e7251b055883be6bcfd3dd496d) CHANGELOG: remove changelog (#1091)
+- [`f724afe`](https://github.com/deis/controller/commit/f724afe5fd612515b36d85ac3214ed6a233a269d) requirements: update Django to 1.10.2
+- [`9582496`](https://github.com/deis/controller/commit/95824969268c4536b5517e527c24959661832b1c) requirements: update pytz to 2016.7 (#1102)
 
 
 ### Dockerbuilder v2.3.3 -> v2.4.0
 
 #### Features
 
-- [`e8763ba`](https://github.com/deisthree/dockerbuilder/commit/e8763ba4e6f9feedacccfc69afd79c58013c2d0f) registry: Allow FROM to refer to the off-cluster docker registry.
+- [`e8763ba`](https://github.com/deis/dockerbuilder/commit/e8763ba4e6f9feedacccfc69afd79c58013c2d0f) registry: Allow FROM to refer to the off-cluster docker registry.
 
 #### Refactors
 
-- [`aa183bf`](https://github.com/deisthree/dockerbuilder/commit/aa183bf116528e9d94fb258b3945595eb4cf1f9a) Dockerfile: remove musl and musl-dev
+- [`aa183bf`](https://github.com/deis/dockerbuilder/commit/aa183bf116528e9d94fb258b3945595eb4cf1f9a) Dockerfile: remove musl and musl-dev
 
 #### Maintenance
 
-- [`b980335`](https://github.com/deisthree/dockerbuilder/commit/b9803354133aaae03f72c1fb4fc4b3ab516b9604) CHANGELOG: remove changelog
+- [`b980335`](https://github.com/deis/dockerbuilder/commit/b9803354133aaae03f72c1fb4fc4b3ab516b9604) CHANGELOG: remove changelog
 
 
 ### Minio v2.3.0 -> v2.3.1
 
 #### Refactors
 
-- [`56e25fb`](https://github.com/deisthree/minio/commit/56e25fb8a9f4711bdf41e0a1bcb6b1d254d38ecf) boot: remove unused template and POD_IP references
+- [`56e25fb`](https://github.com/deis/minio/commit/56e25fb8a9f4711bdf41e0a1bcb6b1d254d38ecf) boot: remove unused template and POD_IP references
 
 #### Maintenance
 
-- [`b233465`](https://github.com/deisthree/minio/commit/b2334656c5bd7a6083d2359458995b5459da6df7) CHANGELOG: remove CHANGELOG
+- [`b233465`](https://github.com/deis/minio/commit/b2334656c5bd7a6083d2359458995b5459da6df7) CHANGELOG: remove CHANGELOG
 
 
 ## Monitoring v2.5.1 -> v2.6.0
 
 ### Maintenance
 
-- [`08e8bae`](https://github.com/deisthree/monitor/commit/08e8bae631d195bb96866b973fcd00e633f06dcb) CHANGELOG: remove CHANGELOG
-- [`31f9a9e`](https://github.com/deisthree/monitor/commit/31f9a9e3e8a68d60c6c7f5015aa65d9028b62bd0) telegraf: Use the new kubernetes input plugin
+- [`08e8bae`](https://github.com/deis/monitor/commit/08e8bae631d195bb96866b973fcd00e633f06dcb) CHANGELOG: remove CHANGELOG
+- [`31f9a9e`](https://github.com/deis/monitor/commit/31f9a9e3e8a68d60c6c7f5015aa65d9028b62bd0) telegraf: Use the new kubernetes input plugin
 
 
 ### NSQ v2.2.2 -> v2.2.3
 
 #### Fixes
 
-- [`f675e23`](https://github.com/deisthree/nsq/commit/f675e23913bd70f5fdda2780319869ca9200ec2f) Removing unneeded node address information.
+- [`f675e23`](https://github.com/deis/nsq/commit/f675e23913bd70f5fdda2780319869ca9200ec2f) Removing unneeded node address information.
 
 
 ### Router v2.6.2 -> v2.6.3
 
 #### Fixes
 
-- [`e77deec`](https://github.com/deisthree/router/commit/e77deec6e6852fb71da73eb3b1b5dc46ea4ee38a) nginx: allow setting ErrorLogLevel to 'debug'
-- [`85d4a96`](https://github.com/deisthree/router/commit/85d4a965280c93e0ec780bf6eb952564d5416b6e) docs: correct annotation key for maxWorkerConnections
-- [`5efc248`](https://github.com/deisthree/router/commit/5efc2480608b7ef1c6ac59a3d37bc5e774aa9d7a) nginx: known model shouldn't be refreshed if Nginx reload failed.
-- [`7c1f99d`](https://github.com/deisthree/router/commit/7c1f99d32ef18ae040faaed195ecb844dd7741db) model: check if CertMapping exists
+- [`e77deec`](https://github.com/deis/router/commit/e77deec6e6852fb71da73eb3b1b5dc46ea4ee38a) nginx: allow setting ErrorLogLevel to 'debug'
+- [`85d4a96`](https://github.com/deis/router/commit/85d4a965280c93e0ec780bf6eb952564d5416b6e) docs: correct annotation key for maxWorkerConnections
+- [`5efc248`](https://github.com/deis/router/commit/5efc2480608b7ef1c6ac59a3d37bc5e774aa9d7a) nginx: known model shouldn't be refreshed if Nginx reload failed.
+- [`7c1f99d`](https://github.com/deis/router/commit/7c1f99d32ef18ae040faaed195ecb844dd7741db) model: check if CertMapping exists
 
 #### Documentation
 
-- [`60bf8c1`](https://github.com/deisthree/router/commit/60bf8c108592bc3d7c7ce0f7c5fdbfa52cfc1b89) readme: remove reference to `make dev-registry`
+- [`60bf8c1`](https://github.com/deis/router/commit/60bf8c108592bc3d7c7ce0f7c5fdbfa52cfc1b89) readme: remove reference to `make dev-registry`
 
 #### Maintenance
 
-- [`2fc5d77`](https://github.com/deisthree/router/commit/2fc5d772286b091709d62272fa9e4c3dfe8dee61) CHANGELOG: remove CHANGELOG
+- [`2fc5d77`](https://github.com/deis/router/commit/2fc5d772286b091709d62272fa9e4c3dfe8dee61) CHANGELOG: remove CHANGELOG
 
 
 ### Slugbuilder v2.4.3 -> v2.4.4
 
 #### Maintenance
 
-- [`6186982`](https://github.com/deisthree/slugbuilder/commit/6186982486ec8b76b05ae0513253d33888c3a885) CHANGELOG: remove CHANGELOG
-- [`4ef1326`](https://github.com/deisthree/slugbuilder/commit/4ef13265d4d155356641d0437ffc819ba77bed5b) buildpacks: update heroku-buildpack-go to v50
+- [`6186982`](https://github.com/deis/slugbuilder/commit/6186982486ec8b76b05ae0513253d33888c3a885) CHANGELOG: remove CHANGELOG
+- [`4ef1326`](https://github.com/deis/slugbuilder/commit/4ef13265d4d155356641d0437ffc819ba77bed5b) buildpacks: update heroku-buildpack-go to v50
 
 
 ### Workflow Charts v2.6.0 -> v2.7.0
 
 #### Features
 
-- [`00ec320`](https://github.com/deisthree/charts/commit/00ec320ee81a03f9ae11d12b6089f3794aba6585) scripts: automate some of workflow release
-- [`37de884`](https://github.com/deisthree/charts/commit/37de884cd1e18092b45e2785fc4087491a948beb) telegraf: Use kubernetes telegraf plugin
+- [`00ec320`](https://github.com/deis/charts/commit/00ec320ee81a03f9ae11d12b6089f3794aba6585) scripts: automate some of workflow release
+- [`37de884`](https://github.com/deis/charts/commit/37de884cd1e18092b45e2785fc4087491a948beb) telegraf: Use kubernetes telegraf plugin
 
 #### Fixes
 
-- [`e22104e`](https://github.com/deisthree/charts/commit/e22104ee329a50f2cda5f079e66fff8e5c946fde) router,e2e: normalize strings for automation
-- [`9225708`](https://github.com/deisthree/charts/commit/92257082bc50b2b55c6d8579186d82f3e45b0209) charts: make grafana creds configurable and remove unused minio POD_IP env
-- [`16784ef`](https://github.com/deisthree/charts/commit/16784ef2c79830ac4f6147fc8de24ebb37ba574f) workflow-dev: bump router's livenessProbe initial delay
-- [`1cac30b`](https://github.com/deisthree/charts/commit/1cac30bf782f385667fcff7f0096a34395df1241) helm-keep: Add helm-keep annotations to all the services
+- [`e22104e`](https://github.com/deis/charts/commit/e22104ee329a50f2cda5f079e66fff8e5c946fde) router,e2e: normalize strings for automation
+- [`9225708`](https://github.com/deis/charts/commit/92257082bc50b2b55c6d8579186d82f3e45b0209) charts: make grafana creds configurable and remove unused minio POD_IP env
+- [`16784ef`](https://github.com/deis/charts/commit/16784ef2c79830ac4f6147fc8de24ebb37ba574f) workflow-dev: bump router's livenessProbe initial delay
+- [`1cac30b`](https://github.com/deis/charts/commit/1cac30bf782f385667fcff7f0096a34395df1241) helm-keep: Add helm-keep annotations to all the services
 
 #### Maintenance
 
-- [`091edb4`](https://github.com/deisthree/charts/commit/091edb4f2a5bf6add7c5ec1b980ea6a0a2d8509f) CHANGELOG: remove CHANGELOG
-- [`9581bd6`](https://github.com/deisthree/charts/commit/9581bd6bf5c2def583baca73765524fdd71ad77c) workflow-v2.6.0: releasing workflow-v2.6.0(-e2e)
-- [`19e5e35`](https://github.com/deisthree/charts/commit/19e5e35c159e54b57426b83a90d8e2ebb8b45316) workflow-v2.7.0: releasing workflow-v2.7.0(-e2e)
+- [`091edb4`](https://github.com/deis/charts/commit/091edb4f2a5bf6add7c5ec1b980ea6a0a2d8509f) CHANGELOG: remove CHANGELOG
+- [`9581bd6`](https://github.com/deis/charts/commit/9581bd6bf5c2def583baca73765524fdd71ad77c) workflow-v2.6.0: releasing workflow-v2.6.0(-e2e)
+- [`19e5e35`](https://github.com/deis/charts/commit/19e5e35c159e54b57426b83a90d8e2ebb8b45316) workflow-v2.7.0: releasing workflow-v2.7.0(-e2e)
 
 
 ### Workflow CLI v2.6.1 -> v2.7.0
 
 #### Features
 
-- [`0391c6c`](https://github.com/deisthree/workflow-cli/commit/0391c6c2d9971c13cf7ebc933c25476942dbc200) keys: add an optional name support for keys:add (#257)
+- [`0391c6c`](https://github.com/deis/workflow-cli/commit/0391c6c2d9971c13cf7ebc933c25476942dbc200) keys: add an optional name support for keys:add (#257)
 
 #### Fixes
 
-- [`1622cf6`](https://github.com/deisthree/workflow-cli/commit/1622cf6ede6f7972ef42d351b9f7f479cb06e546) deis.go: do not add top level command to cmdArgs
-- [`4aa36eb`](https://github.com/deisthree/workflow-cli/commit/4aa36eb9468b686d1f438dc3d007935b09f54bf2) healthcheck: show all the healthchecks set when no proctype is specified
-- [`785a6b6`](https://github.com/deisthree/workflow-cli/commit/785a6b60c77b0f42c00d24bd946ee3dbf4f532a1) ssh: support ed25519 SSH keys
-- [`9c73132`](https://github.com/deisthree/workflow-cli/commit/9c73132ae0a30166fc01227926bb7dfd01a19857) ssh: please the gofmt gods
+- [`1622cf6`](https://github.com/deis/workflow-cli/commit/1622cf6ede6f7972ef42d351b9f7f479cb06e546) deis.go: do not add top level command to cmdArgs
+- [`4aa36eb`](https://github.com/deis/workflow-cli/commit/4aa36eb9468b686d1f438dc3d007935b09f54bf2) healthcheck: show all the healthchecks set when no proctype is specified
+- [`785a6b6`](https://github.com/deis/workflow-cli/commit/785a6b60c77b0f42c00d24bd946ee3dbf4f532a1) ssh: support ed25519 SSH keys
+- [`9c73132`](https://github.com/deis/workflow-cli/commit/9c73132ae0a30166fc01227926bb7dfd01a19857) ssh: please the gofmt gods
 
 #### Documentation
 
-- [`dcdddaf`](https://github.com/deisthree/workflow-cli/commit/dcdddaf737c469ecb08121bf830be234657dbb1d) readme: use just `make` for building binary on unix / darwin
+- [`dcdddaf`](https://github.com/deis/workflow-cli/commit/dcdddaf737c469ecb08121bf830be234657dbb1d) readme: use just `make` for building binary on unix / darwin
 
 #### Maintenance
 
-- [`427f8ee`](https://github.com/deisthree/workflow-cli/commit/427f8ee41bda4107aa12abe6dcd9ffdab3628529) CHANGELOG: remove CHANGELOG
+- [`427f8ee`](https://github.com/deis/workflow-cli/commit/427f8ee41bda4107aa12abe6dcd9ffdab3628529) CHANGELOG: remove CHANGELOG
 
 
 ### Workflow Documentation v2.6.0 -> v2.7.0
 
 #### Features
 
-- [`e5bc58d`](https://github.com/deisthree/workflow/commit/e5bc58d6f72b79e5499551e38564efd4d3bdd382) reference-guide: add Deis v1 Migration Guide
+- [`e5bc58d`](https://github.com/deis/workflow/commit/e5bc58d6f72b79e5499551e38564efd4d3bdd382) reference-guide: add Deis v1 Migration Guide
 
 #### Fixes
 
-- [`53f5134`](https://github.com/deisthree/workflow/commit/53f51346effdf5e093a8ef948f6956f60da0e58d) docs: correct docs for limits:set --cpu flag (#537)
-- [`3ad28eb`](https://github.com/deisthree/workflow/commit/3ad28eb42899f5ad8d43cdd8de0d8503e003671b) docs: update gke screenshot and text. (#540)
-- [`468f277`](https://github.com/deisthree/workflow/commit/468f2774d1a52bc0ae97eb9acc5e76f699600db6) docs: minor spelling corrections (#543)
-- [`1ce3489`](https://github.com/deisthree/workflow/commit/1ce3489da785e82347c7d21392500a3c2555055e) docs: minor spelling corrections (#541)
-- [`7259932`](https://github.com/deisthree/workflow/commit/72599326278c0cd2bcff01f539e59e9582f9e694) docs: minor spelling correction (#542)
-- [`c362ecc`](https://github.com/deisthree/workflow/commit/c362ecc7012217534e61bd05f77f261595ce380b) docs: minor spelling corrections (#544)
+- [`53f5134`](https://github.com/deis/workflow/commit/53f51346effdf5e093a8ef948f6956f60da0e58d) docs: correct docs for limits:set --cpu flag (#537)
+- [`3ad28eb`](https://github.com/deis/workflow/commit/3ad28eb42899f5ad8d43cdd8de0d8503e003671b) docs: update gke screenshot and text. (#540)
+- [`468f277`](https://github.com/deis/workflow/commit/468f2774d1a52bc0ae97eb9acc5e76f699600db6) docs: minor spelling corrections (#543)
+- [`1ce3489`](https://github.com/deis/workflow/commit/1ce3489da785e82347c7d21392500a3c2555055e) docs: minor spelling corrections (#541)
+- [`7259932`](https://github.com/deis/workflow/commit/72599326278c0cd2bcff01f539e59e9582f9e694) docs: minor spelling correction (#542)
+- [`c362ecc`](https://github.com/deis/workflow/commit/c362ecc7012217534e61bd05f77f261595ce380b) docs: minor spelling corrections (#544)
 
 #### Documentation
 
-- [`5553649`](https://github.com/deisthree/workflow/commit/55536493f19d4cbfb02033867de872dccf431121) src/roadmap/releases.md: add registry-token-refresher to deisrel .json
-- [`5d87e32`](https://github.com/deisthree/workflow/commit/5d87e32b0ddf05ce06d1981f22558aa0b1fd0958) relases: simplify Workflow release step 4
-- [`3139333`](https://github.com/deisthree/workflow/commit/3139333a19524feb6b1416393fe4e69720b65c66) installing-workflow: add followup link to register a user
+- [`5553649`](https://github.com/deis/workflow/commit/55536493f19d4cbfb02033867de872dccf431121) src/roadmap/releases.md: add registry-token-refresher to deisrel .json
+- [`5d87e32`](https://github.com/deis/workflow/commit/5d87e32b0ddf05ce06d1981f22558aa0b1fd0958) relases: simplify Workflow release step 4
+- [`3139333`](https://github.com/deis/workflow/commit/3139333a19524feb6b1416393fe4e69720b65c66) installing-workflow: add followup link to register a user
 
 
 ### Workflow E2E Tests v2.5.3 -> v2.6.0
 
 #### Features
 
-- [`b0f0e69`](https://github.com/deisthree/workflow-e2e/commit/b0f0e69d4fbdaa63a8a273b63dda5851243b8f3d) tests(config): add tests for config push/pull with LF and CRLF line endings. (#328)
+- [`b0f0e69`](https://github.com/deis/workflow-e2e/commit/b0f0e69d4fbdaa63a8a273b63dda5851243b8f3d) tests(config): add tests for config push/pull with LF and CRLF line endings. (#328)
 
 #### Fixes
 
-- [`0722699`](https://github.com/deisthree/workflow-e2e/commit/0722699cba91567959ced114e9d0af37fc593d72) tests/git_push_test.go: bump deis run timeout
+- [`0722699`](https://github.com/deis/workflow-e2e/commit/0722699cba91567959ced114e9d0af37fc593d72) tests/git_push_test.go: bump deis run timeout
 
 #### Documentation
 
-- [`723cbae`](https://github.com/deisthree/workflow-e2e/commit/723cbaea8cd95015d66e85706c5118c9113f62dd) README: update e2e chart name/installation
+- [`723cbae`](https://github.com/deis/workflow-e2e/commit/723cbaea8cd95015d66e85706c5118c9113f62dd) README: update e2e chart name/installation
 
 #### Maintenance
 
-- [`0183165`](https://github.com/deisthree/workflow-e2e/commit/0183165b53309ba6c8479615828f17dd32580f45) CHANGELOG: remove CHANGELOG (#327)
+- [`0183165`](https://github.com/deis/workflow-e2e/commit/0183165b53309ba6c8479615828f17dd32580f45) CHANGELOG: remove CHANGELOG (#327)

--- a/src/changelogs/v2.8.0.md
+++ b/src/changelogs/v2.8.0.md
@@ -4,225 +4,225 @@
 
 #### Fixes
 
-- [`4745179`](https://github.com/deisthree/builder/commit/4745179d9487ced5607cd7398a55c5488fabf5c9) charts: Use the common storage secret
+- [`4745179`](https://github.com/deis/builder/commit/4745179d9487ced5607cd7398a55c5488fabf5c9) charts: Use the common storage secret
 
 ### Controller v2.7.1 -> v2.8.1
 
 
 #### Fixes
 
-- [`0d83024`](https://github.com/deisthree/controller/commit/0d830247b3635c097bd8605dddc745fa957ece35) deploy: add a global / per-app setting called PROCFILE_REMOVE_PROCS_ON_DEPLOY to allow turning off / on removal of processes on deploys (#1099)
-- [`1c0350a`](https://github.com/deisthree/controller/commit/1c0350aea77e160afdf3c194b3e03c892b284079) registration: allow admin user registration when the mode is admin_only
-- [`172d91b`](https://github.com/deisthree/controller/commit/172d91b8b9f5fd3b4ec72d1be229e509474b4a0a) registration: Add support to change the default regsitration mode
-- [`eb2104a`](https://github.com/deisthree/controller/commit/eb2104aba2183121ef7b1f12a097218f80da9127) release: Don't rollback if there is no build
+- [`0d83024`](https://github.com/deis/controller/commit/0d830247b3635c097bd8605dddc745fa957ece35) deploy: add a global / per-app setting called PROCFILE_REMOVE_PROCS_ON_DEPLOY to allow turning off / on removal of processes on deploys (#1099)
+- [`1c0350a`](https://github.com/deis/controller/commit/1c0350aea77e160afdf3c194b3e03c892b284079) registration: allow admin user registration when the mode is admin_only
+- [`172d91b`](https://github.com/deis/controller/commit/172d91b8b9f5fd3b4ec72d1be229e509474b4a0a) registration: Add support to change the default regsitration mode
+- [`eb2104a`](https://github.com/deis/controller/commit/eb2104aba2183121ef7b1f12a097218f80da9127) release: Don't rollback if there is no build
 
 #### Documentation
 
-- [`a230913`](https://github.com/deisthree/controller/commit/a230913870e48cfecf977993f2044648cc2afe43) readme: fix links to virtualenv docs
-- [`946de66`](https://github.com/deisthree/controller/commit/946de66a6d2c9ba47920366c54e307e1b915fdcc) readme: fix links to virtualenv docs
-- [`40e8be1`](https://github.com/deisthree/controller/commit/40e8be13b0c3f1d212c67777b1dfd9b3d7925e92) README: docs(README) Refer to postgres setup in Makefile
-- [`f0fea19`](https://github.com/deisthree/controller/commit/f0fea19dd7ab399d91c0a5dfb42ab25d930b5b8f) README: Recommend installing python via pyenv
+- [`a230913`](https://github.com/deis/controller/commit/a230913870e48cfecf977993f2044648cc2afe43) readme: fix links to virtualenv docs
+- [`946de66`](https://github.com/deis/controller/commit/946de66a6d2c9ba47920366c54e307e1b915fdcc) readme: fix links to virtualenv docs
+- [`40e8be1`](https://github.com/deis/controller/commit/40e8be13b0c3f1d212c67777b1dfd9b3d7925e92) README: docs(README) Refer to postgres setup in Makefile
+- [`f0fea19`](https://github.com/deis/controller/commit/f0fea19dd7ab399d91c0a5dfb42ab25d930b5b8f) README: Recommend installing python via pyenv
 
 #### Maintenance
 
-- [`70a6853`](https://github.com/deisthree/controller/commit/70a68532609687f23883f0f3092a454bbdc5bb6b) tests: add test for ed25519 SSH keys
-- [`d2ff507`](https://github.com/deisthree/controller/commit/d2ff5070e21b0db217c6f8c545551f329cb061ba) tests: add hook tests for ECDSA and ED25519 SSH keys
-- [`796668a`](https://github.com/deisthree/controller/commit/796668a373a0d04b60c379855fea00da4de3cc1c) requirements: update PyOpenSSL to 16.2.0 (#1114)
-- [`58d5ae7`](https://github.com/deisthree/controller/commit/58d5ae72a72dcb2c2a2ed59376ad2a55e6301cef) requirements: update docker-py to 1.10.4 (#1115)
-- [`1dd4093`](https://github.com/deisthree/controller/commit/1dd4093d8a77930e720ced15f4427e4006c51089) requirements: update to DRF 3.5.1 (#1120)
+- [`70a6853`](https://github.com/deis/controller/commit/70a68532609687f23883f0f3092a454bbdc5bb6b) tests: add test for ed25519 SSH keys
+- [`d2ff507`](https://github.com/deis/controller/commit/d2ff5070e21b0db217c6f8c545551f329cb061ba) tests: add hook tests for ECDSA and ED25519 SSH keys
+- [`796668a`](https://github.com/deis/controller/commit/796668a373a0d04b60c379855fea00da4de3cc1c) requirements: update PyOpenSSL to 16.2.0 (#1114)
+- [`58d5ae7`](https://github.com/deis/controller/commit/58d5ae72a72dcb2c2a2ed59376ad2a55e6301cef) requirements: update docker-py to 1.10.4 (#1115)
+- [`1dd4093`](https://github.com/deis/controller/commit/1dd4093d8a77930e720ced15f4427e4006c51089) requirements: update to DRF 3.5.1 (#1120)
 
 ### Dockerbuilder v2.4.1 -> v2.5.0
 
 #### Features
 
-- [`1df9223`](https://github.com/deisthree/dockerbuilder/commit/1df9223e2ebed7c592f419ff786faf75d001ab87) deploy.py: add pull option
+- [`1df9223`](https://github.com/deis/dockerbuilder/commit/1df9223e2ebed7c592f419ff786faf75d001ab87) deploy.py: add pull option
 
 ### Fluentd v2.4.2 -> v2.4.3
 
 #### Features
 
-- [`ceaa347`](https://github.com/deisthree/fluentd/commit/ceaa3473ede5e99b3d677a482dab9f8c2414e3e0) elasticsearch: Add support for dropping fluentd's own logs to stop an infinite death spiral
+- [`ceaa347`](https://github.com/deis/fluentd/commit/ceaa3473ede5e99b3d677a482dab9f8c2414e3e0) elasticsearch: Add support for dropping fluentd's own logs to stop an infinite death spiral
 
 #### Fixes
 
-- [`d3523b3`](https://github.com/deisthree/fluentd/commit/d3523b3482c0824981332d22cf7e6af2a60c0d16) boot/deis: Fix conditional for disabling deis output
+- [`d3523b3`](https://github.com/deis/fluentd/commit/d3523b3482c0824981332d22cf7e6af2a60c0d16) boot/deis: Fix conditional for disabling deis output
 
 
 ### Logging v2.3.1 -> v2.3.2
 
 #### Features
 
-- [`9bf8520`](https://github.com/deisthree/logger/commit/9bf8520e23621a4c6ac07b9012e0968f794c6f23) charts: Add helm charts for logger
+- [`9bf8520`](https://github.com/deis/logger/commit/9bf8520e23621a4c6ac07b9012e0968f794c6f23) charts: Add helm charts for logger
 
 #### Fixes
 
-- [`2c838b3`](https://github.com/deisthree/logger/commit/2c838b3906c85d4b1e4fc796aa139814dbf5a8aa) server_test: skip TestServerClose
+- [`2c838b3`](https://github.com/deis/logger/commit/2c838b3906c85d4b1e4fc796aa139814dbf5a8aa) server_test: skip TestServerClose
 
 #### Maintenance
 
-- [`e36fe0f`](https://github.com/deisthree/logger/commit/e36fe0f4e0dcafa7376a3fb6c35e597c3c0b3e43) CHANGELOG: remove CHANGELOG
+- [`e36fe0f`](https://github.com/deis/logger/commit/e36fe0f4e0dcafa7376a3fb6c35e597c3c0b3e43) CHANGELOG: remove CHANGELOG
 
 ### Logger-Redis v2.2.2 -> v2.2.3
 
 #### Features
 
-- [`bf58552`](https://github.com/deisthree/redis/commit/bf585524e8c96184bb7d7a855a08242af6601755) charts: Add helm charts for redis
+- [`bf58552`](https://github.com/deis/redis/commit/bf585524e8c96184bb7d7a855a08242af6601755) charts: Add helm charts for redis
 
 
 ### Minio v2.3.1 -> v2.3.3
 
 #### Features
 
-- [`1f63beb`](https://github.com/deisthree/minio/commit/1f63beb0c51153388a73654952a3076183a1c589) charts: Add helm charts for minio
+- [`1f63beb`](https://github.com/deis/minio/commit/1f63beb0c51153388a73654952a3076183a1c589) charts: Add helm charts for minio
 
 #### Fixes
 
-- [`7b1db94`](https://github.com/deisthree/minio/commit/7b1db94884b2177c1bbbe54544e01f445cbcb22f) docs: fix link location to deis documentation (#121)
+- [`7b1db94`](https://github.com/deis/minio/commit/7b1db94884b2177c1bbbe54544e01f445cbcb22f) docs: fix link location to deis documentation (#121)
 
 ### Monitoring v2.6.1 -> v2.6.2
 
 #### Features
 
-- [`adedd69`](https://github.com/deisthree/monitor/commit/adedd69bff3960e9496a062ef6e4b0fc39de05d4) monitor: Allow for off cluster influxdb
+- [`adedd69`](https://github.com/deis/monitor/commit/adedd69bff3960e9496a062ef6e4b0fc39de05d4) monitor: Allow for off cluster influxdb
 
 #### Fixes
 
-- [`c177c70`](https://github.com/deisthree/monitor/commit/c177c70501afe86a5775d6af83b616d682b1e46a) grafana,telegraf: make curl fail on unsuccessful HTTP codes
+- [`c177c70`](https://github.com/deis/monitor/commit/c177c70501afe86a5775d6af83b616d682b1e46a) grafana,telegraf: make curl fail on unsuccessful HTTP codes
 
 #### Maintenance
 
-- [`e008741`](https://github.com/deisthree/monitor/commit/e00874199741fdf9f9e638179b66833c5b63e11a) grafana: Update dashboards for new telegraf
+- [`e008741`](https://github.com/deis/monitor/commit/e00874199741fdf9f9e638179b66833c5b63e11a) grafana: Update dashboards for new telegraf
 
 
 ### NSQ v2.2.3 -> v2.2.4
 
 #### Features
 
-- [`6d01e7e`](https://github.com/deisthree/nsq/commit/6d01e7edd823a7d9f6971ada81a11139fba33d11) charts: Add helm charts for nsq
+- [`6d01e7e`](https://github.com/deis/nsq/commit/6d01e7edd823a7d9f6971ada81a11139fba33d11) charts: Add helm charts for nsq
 
 
 ### Postgres v2.2.5 -> v2.2.6
 
 #### Fixes
 
-- [`4bb00a1`](https://github.com/deisthree/postgres/commit/4bb00a1c4662a4cc003742997084aaecf84ee5d3) charts: Use the common storage secret
+- [`4bb00a1`](https://github.com/deis/postgres/commit/4bb00a1c4662a4cc003742997084aaecf84ee5d3) charts: Use the common storage secret
 
 
 ### Registry v2.2.2 -> v2.2.4
 
 #### Features
 
-- [`5614cf7`](https://github.com/deisthree/registry/commit/5614cf7832cd15a40e67f39a3c1a4f14e4924c29) charts: Add helm charts for registry
+- [`5614cf7`](https://github.com/deis/registry/commit/5614cf7832cd15a40e67f39a3c1a4f14e4924c29) charts: Add helm charts for registry
 
 #### Fixes
 
-- [`e4bbb57`](https://github.com/deisthree/registry/commit/e4bbb573051ee0ee0de734f0262c5ecc70bcfd74) charts: Use the common storage secret
+- [`e4bbb57`](https://github.com/deis/registry/commit/e4bbb573051ee0ee0de734f0262c5ecc70bcfd74) charts: Use the common storage secret
 
 #### Maintenance
 
-- [`a46404c`](https://github.com/deisthree/registry/commit/a46404c23db49d0310dc2709d92d21663953b3c8) CHANGELOG: remove CHANGELOG
+- [`a46404c`](https://github.com/deis/registry/commit/a46404c23db49d0310dc2709d92d21663953b3c8) CHANGELOG: remove CHANGELOG
 
 
 ### Registry Proxy v1.1.0 -> v1.1.1
 
 #### Features
 
-- [`a9e1d48`](https://github.com/deisthree/registry-proxy/commit/a9e1d48d78edb18a6c6275b80e5dcba16342b899) charts: Add helm charts for registry proxy
+- [`a9e1d48`](https://github.com/deis/registry-proxy/commit/a9e1d48d78edb18a6c6275b80e5dcba16342b899) charts: Add helm charts for registry proxy
 
 #### Maintenance
 
-- [`62ad655`](https://github.com/deisthree/registry-proxy/commit/62ad655f21c985245506ba84cc26842a554c9535) rootfs: bump version to v1.2.0-dev
+- [`62ad655`](https://github.com/deis/registry-proxy/commit/62ad655f21c985245506ba84cc26842a554c9535) rootfs: bump version to v1.2.0-dev
 
 
 ### Registry Token Refresher v1.0.2 -> v1.0.3
 
 #### Features
 
-- [`ec09ac2`](https://github.com/deisthree/registry-token-refresher/commit/ec09ac2b4eef9983828f3613afc99996901ea263) charts: Add helm charts for registry token refresher
+- [`ec09ac2`](https://github.com/deis/registry-token-refresher/commit/ec09ac2b4eef9983828f3613afc99996901ea263) charts: Add helm charts for registry token refresher
 
 
 ### Router v2.6.3 -> v2.6.5
 
 #### Features
 
-- [`0241013`](https://github.com/deisthree/router/commit/024101377aa6ea8c5e1d08774007b93d3f8a6652) charts: Add helm charts for the router
+- [`0241013`](https://github.com/deis/router/commit/024101377aa6ea8c5e1d08774007b93d3f8a6652) charts: Add helm charts for the router
 
 #### Fixes
 
-- [`646b1c6`](https://github.com/deisthree/router/commit/646b1c69faf9b8493687af2da53fc723a92be8e8) charts: bump router's livenessProbe initial delay
+- [`646b1c6`](https://github.com/deis/router/commit/646b1c69faf9b8493687af2da53fc723a92be8e8) charts: bump router's livenessProbe initial delay
 
 #### Maintenance
 
-- [`fbdc2c6`](https://github.com/deisthree/router/commit/fbdc2c6cf6f5d3e37c38c660ebaa499dfe0c3aaf) nginx: update nginx to 1.11.5
+- [`fbdc2c6`](https://github.com/deis/router/commit/fbdc2c6cf6f5d3e37c38c660ebaa499dfe0c3aaf) nginx: update nginx to 1.11.5
 
 
 ### Slugbuilder v2.4.4 -> v2.4.5
 
 #### Features
 
-- [`844021a`](https://github.com/deisthree/slugbuilder/commit/844021a2e4a749c1199e2462f7218a30b9f906f4) charts: Add helm charts for slugbuilder
+- [`844021a`](https://github.com/deis/slugbuilder/commit/844021a2e4a749c1199e2462f7218a30b9f906f4) charts: Add helm charts for slugbuilder
 
 
 ### Slugrunner v2.2.2 -> v2.2.3
 
 #### Features
 
-- [`e4dc4ae`](https://github.com/deisthree/slugrunner/commit/e4dc4aeadac2544fb75153085e8b4a5610e518ef) charts: Add helm charts for slugrunner
+- [`e4dc4ae`](https://github.com/deis/slugrunner/commit/e4dc4aeadac2544fb75153085e8b4a5610e518ef) charts: Add helm charts for slugrunner
 
 #### Maintenance
 
-- [`d45accb`](https://github.com/deisthree/slugrunner/commit/d45accbab82db122cf291ad36c6852149e1fdf12) CHANGELOG: remove CHANGELOG
+- [`d45accb`](https://github.com/deis/slugrunner/commit/d45accbab82db122cf291ad36c6852149e1fdf12) CHANGELOG: remove CHANGELOG
 
 
 ### Workflow Documentation v2.7.0 -> v2.8.0
 
 #### Features
 
-- [`4196ca3`](https://github.com/deisthree/workflow/commit/4196ca3d20e4abf90949f56645faac900decedc6) deploys: Add new configuration options to Controller introduced in controller/#1099 (#551)
-- [`659116d`](https://github.com/deisthree/workflow/commit/659116de8778572437af6744ca738941caf58b42) charts: Add helm charts for workflow
-- [`bef1728`](https://github.com/deisthree/workflow/commit/bef172805705e8a5ec24e4c1368b9a2f9a2857e9) helm: Add instruction to install workflow using the new helm
-- [`d793606`](https://github.com/deisthree/workflow/commit/d7936068a7159b085e537d96121b85d62ded8166) charts: Add support for external influxdb and changing registration mode
+- [`4196ca3`](https://github.com/deis/workflow/commit/4196ca3d20e4abf90949f56645faac900decedc6) deploys: Add new configuration options to Controller introduced in controller/#1099 (#551)
+- [`659116d`](https://github.com/deis/workflow/commit/659116de8778572437af6744ca738941caf58b42) charts: Add helm charts for workflow
+- [`bef1728`](https://github.com/deis/workflow/commit/bef172805705e8a5ec24e4c1368b9a2f9a2857e9) helm: Add instruction to install workflow using the new helm
+- [`d793606`](https://github.com/deis/workflow/commit/d7936068a7159b085e537d96121b85d62ded8166) charts: Add support for external influxdb and changing registration mode
 
 #### Fixes
 
-- [`330945d`](https://github.com/deisthree/workflow/commit/330945d0ed020fbe0fcd2d3b48b8cc15b864bfe4) troubleshooting: remove reference to Workflow version
-- [`34d96c5`](https://github.com/deisthree/workflow/commit/34d96c5c4e5acc5921f3772874e64446a74affa5) charts: Add workflow manager production urls for the release charts
+- [`330945d`](https://github.com/deis/workflow/commit/330945d0ed020fbe0fcd2d3b48b8cc15b864bfe4) troubleshooting: remove reference to Workflow version
+- [`34d96c5`](https://github.com/deis/workflow/commit/34d96c5c4e5acc5921f3772874e64446a74affa5) charts: Add workflow manager production urls for the release charts
 
 #### Documentation
 
-- [`8c48e28`](https://github.com/deisthree/workflow/commit/8c48e28bb7c5a76f47d1dc8cf129c71ec286a3b0) object-storage: document the required STORAGE_TYPE env var (#547)
-- [`df70784`](https://github.com/deisthree/workflow/commit/df70784a346fc94f60a130eb7cae1ec3c5c62dd3) readme: adding workflow-manager to list of components (#549)
-- [`43ff1b6`](https://github.com/deisthree/workflow/commit/43ff1b6b6a6bd1612548a1a9ca0792ef08724d5a) installing/platform-logging: Update docs for off-cluster installs
-- [`e1b6b0b`](https://github.com/deisthree/workflow/commit/e1b6b0be3095d599258481f64efe7e78eb1ca8dc) Documentation changes, suggestions, fixes (#548)
-- [`8d8b7ec`](https://github.com/deisthree/workflow/commit/8d8b7ec6ef7719b2fb3fadc21c6d4c66d7489019) readme: add nsq to list of deis components (#550)
-- [`297307c`](https://github.com/deisthree/workflow/commit/297307c40c0466288eecf9bd1879e520559bf416) upgrading-workflow: Add instructions to preserve platform SSL credentials (#561)
-- [`f8841b7`](https://github.com/deisthree/workflow/commit/f8841b7413349e6ac347b3b727a8655023a32fb9) Update boot.md
-- [`3c57d88`](https://github.com/deisthree/workflow/commit/3c57d8816f017e386603134639a42cc66d857bc2) Fix minor typo (#572)
+- [`8c48e28`](https://github.com/deis/workflow/commit/8c48e28bb7c5a76f47d1dc8cf129c71ec286a3b0) object-storage: document the required STORAGE_TYPE env var (#547)
+- [`df70784`](https://github.com/deis/workflow/commit/df70784a346fc94f60a130eb7cae1ec3c5c62dd3) readme: adding workflow-manager to list of components (#549)
+- [`43ff1b6`](https://github.com/deis/workflow/commit/43ff1b6b6a6bd1612548a1a9ca0792ef08724d5a) installing/platform-logging: Update docs for off-cluster installs
+- [`e1b6b0b`](https://github.com/deis/workflow/commit/e1b6b0be3095d599258481f64efe7e78eb1ca8dc) Documentation changes, suggestions, fixes (#548)
+- [`8d8b7ec`](https://github.com/deis/workflow/commit/8d8b7ec6ef7719b2fb3fadc21c6d4c66d7489019) readme: add nsq to list of deis components (#550)
+- [`297307c`](https://github.com/deis/workflow/commit/297307c40c0466288eecf9bd1879e520559bf416) upgrading-workflow: Add instructions to preserve platform SSL credentials (#561)
+- [`f8841b7`](https://github.com/deis/workflow/commit/f8841b7413349e6ac347b3b727a8655023a32fb9) Update boot.md
+- [`3c57d88`](https://github.com/deis/workflow/commit/3c57d8816f017e386603134639a42cc66d857bc2) Fix minor typo (#572)
 
 ### Workflow CLI v2.7.0 -> v2.7.1
 
 #### Features
 
-- [`950e1ad`](https://github.com/deisthree/workflow-cli/commit/950e1adcd307938b3e31a2f12f9dc949a201f3f1) Jenkinsfile: send slack channel to downstream test job
+- [`950e1ad`](https://github.com/deis/workflow-cli/commit/950e1adcd307938b3e31a2f12f9dc949a201f3f1) Jenkinsfile: send slack channel to downstream test job
 
 #### Tests
 
-- [`6c9c935`](https://github.com/deisthree/workflow-cli/commit/6c9c9352cc402ca99882fbd2d9080c297e4193fc) auth: add test for whoami --all (#261)
+- [`6c9c935`](https://github.com/deis/workflow-cli/commit/6c9c9352cc402ca99882fbd2d9080c297e4193fc) auth: add test for whoami --all (#261)
 
 
 ### Workflow E2E Tests v2.6.0 -> v2.6.1
 
 #### Features
 
-- [`bf3a560`](https://github.com/deisthree/workflow-e2e/commit/bf3a5604dea20bed5597636daa899ec0d9443b01) charts: Add helm charts for workflow-e2e
+- [`bf3a560`](https://github.com/deis/workflow-e2e/commit/bf3a5604dea20bed5597636daa899ec0d9443b01) charts: Add helm charts for workflow-e2e
 
 
 ### Workflow Manager v2.4.2 -> v2.4.3
 
 #### Features
 
-- [`80af9c3`](https://github.com/deisthree/workflow-manager/commit/80af9c388e6a2ac1d2ba8be998ed84611d587fd7) charts: Add helm charts for workflow-manager
+- [`80af9c3`](https://github.com/deis/workflow-manager/commit/80af9c388e6a2ac1d2ba8be998ed84611d587fd7) charts: Add helm charts for workflow-manager
 
 #### Maintenance
 
-- [`43f1251`](https://github.com/deisthree/workflow-manager/commit/43f12514e95e4c9254587770b54d74d9c1760bbf) CHANGELOG: remove CHANGELOG
+- [`43f1251`](https://github.com/deis/workflow-manager/commit/43f12514e95e4c9254587770b54d74d9c1760bbf) CHANGELOG: remove CHANGELOG

--- a/src/changelogs/v2.9.0.md
+++ b/src/changelogs/v2.9.0.md
@@ -24,127 +24,127 @@
 
 #### Features
 
-- [`ea9e648`](https://github.com/deisthree/charts/commit/ea9e648bf535cc8def497256597c464ce962ea1f) (charts) - workflow-dev: add preStop hook to postgres
-- [`26c78ee`](https://github.com/deisthree/controller/commit/26c78eecef7d753016fdd38851f741d4e3832530) (controller) - limits-cmd: accept new limits:set value type
-- [`bc4f452`](https://github.com/deisthree/controller/commit/bc4f452a08fb1e6c556ec257db55de445b1c89d9) (controller) - label-cmd: support new label cmd
-- [`a01c455`](https://github.com/deisthree/fluentd/commit/a01c4558625b93d56e1cc3178f6aa352817dd3e7) (fluentd) - deis_out: Add time to record when publishing to nsq
-- [`7498fe5`](https://github.com/deisthree/logger/commit/7498fe5802ed197bae89e6e54e5f127d84fd2f1e) (logger) - model/message_handler: Add time to log message output
-- [`c105495`](https://github.com/deisthree/minio/commit/c1054953ba3e45b6d43e8e53d0c8560e175eb1f8) (minio) - travis: add codecov
-- [`444838e`](https://github.com/deisthree/postgres/commit/444838e2ce23328e6c3320cc285f63966c9eb33c) (postgres) - charts: add backup to preStop hook
-- [`19466c5`](https://github.com/deisthree/router/commit/19466c579f59d64bba9ffd533db653b14a20d361) (router) - charts: Add support to add annotations during install
-- [`07747dd`](https://github.com/deisthree/workflow-cli/commit/07747dd4c889676942be5e4f94c586dd38b5b103) (workflow-cli) - cmd: allow config:set FOO=""
-- [`029f39e`](https://github.com/deisthree/workflow-cli/commit/029f39e09562b041159a8ba18894cf7cc77b9aa4) (workflow-cli) - label-cmd: add Label cmd
-- [`8ab113f`](https://github.com/deisthree/workflow-cli/commit/8ab113f34185b0b64eeb8747d8a49d0b0d0c39b1) (workflow-cli) - label-cmd: update controller-sdk-go dependency
-- [`8955e7e`](https://github.com/deisthree/workflow-cli/commit/8955e7ed47c2a152a01c292c3facdd7f4e5078b9) (workflow-cli) - cmd/labels.go: sort labels when listing
-- [`874c9e0`](https://github.com/deisthree/workflow-e2e/commit/874c9e056765bf46dd960c39523558bc67b350a0) (workflow-e2e) - label-cmd: add Label cmd
+- [`ea9e648`](https://github.com/deis/charts/commit/ea9e648bf535cc8def497256597c464ce962ea1f) (charts) - workflow-dev: add preStop hook to postgres
+- [`26c78ee`](https://github.com/deis/controller/commit/26c78eecef7d753016fdd38851f741d4e3832530) (controller) - limits-cmd: accept new limits:set value type
+- [`bc4f452`](https://github.com/deis/controller/commit/bc4f452a08fb1e6c556ec257db55de445b1c89d9) (controller) - label-cmd: support new label cmd
+- [`a01c455`](https://github.com/deis/fluentd/commit/a01c4558625b93d56e1cc3178f6aa352817dd3e7) (fluentd) - deis_out: Add time to record when publishing to nsq
+- [`7498fe5`](https://github.com/deis/logger/commit/7498fe5802ed197bae89e6e54e5f127d84fd2f1e) (logger) - model/message_handler: Add time to log message output
+- [`c105495`](https://github.com/deis/minio/commit/c1054953ba3e45b6d43e8e53d0c8560e175eb1f8) (minio) - travis: add codecov
+- [`444838e`](https://github.com/deis/postgres/commit/444838e2ce23328e6c3320cc285f63966c9eb33c) (postgres) - charts: add backup to preStop hook
+- [`19466c5`](https://github.com/deis/router/commit/19466c579f59d64bba9ffd533db653b14a20d361) (router) - charts: Add support to add annotations during install
+- [`07747dd`](https://github.com/deis/workflow-cli/commit/07747dd4c889676942be5e4f94c586dd38b5b103) (workflow-cli) - cmd: allow config:set FOO=""
+- [`029f39e`](https://github.com/deis/workflow-cli/commit/029f39e09562b041159a8ba18894cf7cc77b9aa4) (workflow-cli) - label-cmd: add Label cmd
+- [`8ab113f`](https://github.com/deis/workflow-cli/commit/8ab113f34185b0b64eeb8747d8a49d0b0d0c39b1) (workflow-cli) - label-cmd: update controller-sdk-go dependency
+- [`8955e7e`](https://github.com/deis/workflow-cli/commit/8955e7ed47c2a152a01c292c3facdd7f4e5078b9) (workflow-cli) - cmd/labels.go: sort labels when listing
+- [`874c9e0`](https://github.com/deis/workflow-e2e/commit/874c9e056765bf46dd960c39523558bc67b350a0) (workflow-e2e) - label-cmd: add Label cmd
 
 #### Refactors
 
-- [`67c0a3f`](https://github.com/deisthree/charts/commit/67c0a3f0c45e5b3b8a833751f1ab12fa1a01d294) (charts) - workflow-dev: make PGCTLTIMEOUT tunable
-- [`a026223`](https://github.com/deisthree/postgres/commit/a026223ec3852579311e6c3f3e0fa3402e3b9107) (postgres) - rootfs: remove timeout to pg_ctl start
-- [`fe9364e`](https://github.com/deisthree/postgres/commit/fe9364e728478d5a2eab964dd9781e029935c8c1) (postgres) - backup: bump default base backup interval to 4h
-- [`3af1129`](https://github.com/deisthree/registry/commit/3af11290c99b1b113934e5efa251bc8538947c2c) (registry) - Dockerfile: use upstream registry image
+- [`67c0a3f`](https://github.com/deis/charts/commit/67c0a3f0c45e5b3b8a833751f1ab12fa1a01d294) (charts) - workflow-dev: make PGCTLTIMEOUT tunable
+- [`a026223`](https://github.com/deis/postgres/commit/a026223ec3852579311e6c3f3e0fa3402e3b9107) (postgres) - rootfs: remove timeout to pg_ctl start
+- [`fe9364e`](https://github.com/deis/postgres/commit/fe9364e728478d5a2eab964dd9781e029935c8c1) (postgres) - backup: bump default base backup interval to 4h
+- [`3af1129`](https://github.com/deis/registry/commit/3af11290c99b1b113934e5efa251bc8538947c2c) (registry) - Dockerfile: use upstream registry image
 
 #### Fixes
 
-- [`4745179`](https://github.com/deisthree/builder/commit/4745179d9487ced5607cd7398a55c5488fabf5c9) (builder) - charts: Use the common storage secret
-- [`5460be8`](https://github.com/deisthree/builder/commit/5460be8cdb844841c711cce4fe4640f3f3c9d208) (builder) - slugbuilder: Dont expose the conifg as env vars during build
-- [`c960478`](https://github.com/deisthree/builder/commit/c960478826dbf6f32554599bde9121883f17f66a) (builder) - gitreceive: clarify the error message when release failed
-- [`fcd7edd`](https://github.com/deisthree/builder/commit/fcd7edd815fdd46f8fbc8eba71f33c64b1aa313e) (builder) - charts: Don't use caps in the configmap keys
-- [`92f7751`](https://github.com/deisthree/charts/commit/92f775103fe6fc1f664a5f3636ecffd54277bf07) (charts) - workflow-dev/tpl/deis-database-deployment.yaml: rename env var
-- [`5bc0305`](https://github.com/deisthree/charts/commit/5bc030565c7ed762c69aab3808fececec6fd9b4f) (charts) - workflow-dev: rewrite to avoid whitespace errors
-- [`615b834`](https://github.com/deisthree/controller/commit/615b834f39cb68a854cc1f1e2f0f82d862ea2731) (controller) - boot: Ensure DEIS_DEBUG==true for debug output
-- [`f3daff7`](https://github.com/deisthree/controller/commit/f3daff74471249baae1f17e0faf159046ffb87ff) (controller) - proctype: Change the regex used for validating proctypes
-- [`828c13b`](https://github.com/deisthree/controller/commit/828c13bca15e94ffd8fced28f032f6623c7bf9d7) (controller) - port: Port can be made optional for non-routable apps
-- [`4dd1a6c`](https://github.com/deisthree/controller/commit/4dd1a6c37a4496a1a1adae8ef1b2c353ed2a71fc) (controller) - timeout-debug-msg: unresolved variable (#1148)
-- [`ffeb14a`](https://github.com/deisthree/controller/commit/ffeb14a184727efa94af4d62c1f10003bb803a88) (controller) - api: ensure a 409 is raised when cancelling a user with downstream objects (#1147)
-- [`06211a2`](https://github.com/deisthree/controller/commit/06211a27f78c0bfdf0c9d5eee421d0bb3bc277a0) (controller) - api: transfer all downstream resources along with app (#1146)
-- [`87ef21d`](https://github.com/deisthree/dockerbuilder/commit/87ef21d9280a8cae5c60cca3a67e2eec698d14dd) (dockerbuilder) - charts: Don't use caps in the configmap keys
-- [`0b6d8a9`](https://github.com/deisthree/dockerbuilder/commit/0b6d8a96e5bbd565a80f049accaf55af0d80d9cc) (dockerbuilder) - move to python3
-- [`f113aac`](https://github.com/deisthree/fluentd/commit/f113aac7c4a942262dd6b8b4f7c8c4bfc7259cd6) (fluentd) - elastic search: Allow the elastic search plugin to index via namespace
-- [`4c72d59`](https://github.com/deisthree/minio/commit/4c72d5911f941f6ff3b620df923ebcb05fe8c244) (minio) - codecov: add test-cover target
-- [`4bb00a1`](https://github.com/deisthree/postgres/commit/4bb00a1c4662a4cc003742997084aaecf84ee5d3) (postgres) - charts: Use the common storage secret
-- [`414c534`](https://github.com/deisthree/postgres/commit/414c5344df413bbd8f6a943ec02d3c92bd55349f) (postgres) - test-swift: remove reliance on local swift client
-- [`b63909a`](https://github.com/deisthree/postgres/commit/b63909a96e5e43f64de193aad557aeb3a7d7565e) (postgres) - test-minio: change DNS entry to minio
-- [`b7a2d5b`](https://github.com/deisthree/postgres/commit/b7a2d5b6a03036d210ac41d21de1c488c92b3a3b) (postgres) - setup_envdir: remove AWS_REGION from WALE_S3_ENDPOINT
-- [`d1744d5`](https://github.com/deisthree/postgres/commit/d1744d5813942cc440b56c8330b29cc2f84942f0) (postgres) - setup_envdir: do not set AWS_ACCESS_KEY_ID if empty
-- [`3984d62`](https://github.com/deisthree/postgres/commit/3984d62270ebe6a1747209497f8d958bb5571106) (postgres) - gcs: Use correct env variable for the gcs service account file path
-- [`7458672`](https://github.com/deisthree/postgres/commit/7458672dbb76b90c2442d065238c25a97ec4cb0f) (postgres) - charts: fix typo and stanza location
-- [`388c593`](https://github.com/deisthree/postgres/commit/388c593dd182755fad2218ef2c1f24d39bc29948) (postgres) - boto: specify the region while getting s3 connection
-- [`758632d`](https://github.com/deisthree/postgres/commit/758632dae206685916fd2edeeb1113b9b455b86a) (postgres) - setup-envdir: convert AWS_REGION to WALE_S3_ENDPOINT
-- [`bc77951`](https://github.com/deisthree/postgres/commit/bc7795100a1e7c0d535c5d519ec9f925f71fd4e5) (postgres) - create_bucket: try default s3 region on create error
-- [`8bf4c52`](https://github.com/deisthree/postgres/commit/8bf4c52fbc4bd2c54166f7d072578be11c4d90c7) (postgres) - create_bucket: propagate us-east-1 to wal-e
-- [`76bf6d8`](https://github.com/deisthree/redis/commit/76bf6d8cb88131aa6b14a65acc33e0f9a2b60f3e) (redis) - charts: Use proper values for offcluster redis
-- [`e4bbb57`](https://github.com/deisthree/registry/commit/e4bbb573051ee0ee0de734f0262c5ecc70bcfd74) (registry) - charts: Use the common storage secret
-- [`6e27041`](https://github.com/deisthree/registry/commit/6e27041194d694857ffcd4056e52288f9393c994) (registry) - boto: specify the region while getting s3 connection
-- [`384bf31`](https://github.com/deisthree/slugbuilder/commit/384bf313d62d2d5d895354b991b5be6123952b57) (slugbuilder) - charts: Don't use caps in the configmap keys
-- [`5b053c8`](https://github.com/deisthree/workflow-cli/commit/5b053c801b8a1767f44f0168ef3af1aa5d79c3d6) (workflow-cli) - login: User should login by default when he registers
-- [`5b06f6b`](https://github.com/deisthree/workflow-e2e/commit/5b06f6b7a0cd2f9a36c8df97ab3760553e9af17f) (workflow-e2e) - tests/labels_test.go: adjust spacing
+- [`4745179`](https://github.com/deis/builder/commit/4745179d9487ced5607cd7398a55c5488fabf5c9) (builder) - charts: Use the common storage secret
+- [`5460be8`](https://github.com/deis/builder/commit/5460be8cdb844841c711cce4fe4640f3f3c9d208) (builder) - slugbuilder: Dont expose the conifg as env vars during build
+- [`c960478`](https://github.com/deis/builder/commit/c960478826dbf6f32554599bde9121883f17f66a) (builder) - gitreceive: clarify the error message when release failed
+- [`fcd7edd`](https://github.com/deis/builder/commit/fcd7edd815fdd46f8fbc8eba71f33c64b1aa313e) (builder) - charts: Don't use caps in the configmap keys
+- [`92f7751`](https://github.com/deis/charts/commit/92f775103fe6fc1f664a5f3636ecffd54277bf07) (charts) - workflow-dev/tpl/deis-database-deployment.yaml: rename env var
+- [`5bc0305`](https://github.com/deis/charts/commit/5bc030565c7ed762c69aab3808fececec6fd9b4f) (charts) - workflow-dev: rewrite to avoid whitespace errors
+- [`615b834`](https://github.com/deis/controller/commit/615b834f39cb68a854cc1f1e2f0f82d862ea2731) (controller) - boot: Ensure DEIS_DEBUG==true for debug output
+- [`f3daff7`](https://github.com/deis/controller/commit/f3daff74471249baae1f17e0faf159046ffb87ff) (controller) - proctype: Change the regex used for validating proctypes
+- [`828c13b`](https://github.com/deis/controller/commit/828c13bca15e94ffd8fced28f032f6623c7bf9d7) (controller) - port: Port can be made optional for non-routable apps
+- [`4dd1a6c`](https://github.com/deis/controller/commit/4dd1a6c37a4496a1a1adae8ef1b2c353ed2a71fc) (controller) - timeout-debug-msg: unresolved variable (#1148)
+- [`ffeb14a`](https://github.com/deis/controller/commit/ffeb14a184727efa94af4d62c1f10003bb803a88) (controller) - api: ensure a 409 is raised when cancelling a user with downstream objects (#1147)
+- [`06211a2`](https://github.com/deis/controller/commit/06211a27f78c0bfdf0c9d5eee421d0bb3bc277a0) (controller) - api: transfer all downstream resources along with app (#1146)
+- [`87ef21d`](https://github.com/deis/dockerbuilder/commit/87ef21d9280a8cae5c60cca3a67e2eec698d14dd) (dockerbuilder) - charts: Don't use caps in the configmap keys
+- [`0b6d8a9`](https://github.com/deis/dockerbuilder/commit/0b6d8a96e5bbd565a80f049accaf55af0d80d9cc) (dockerbuilder) - move to python3
+- [`f113aac`](https://github.com/deis/fluentd/commit/f113aac7c4a942262dd6b8b4f7c8c4bfc7259cd6) (fluentd) - elastic search: Allow the elastic search plugin to index via namespace
+- [`4c72d59`](https://github.com/deis/minio/commit/4c72d5911f941f6ff3b620df923ebcb05fe8c244) (minio) - codecov: add test-cover target
+- [`4bb00a1`](https://github.com/deis/postgres/commit/4bb00a1c4662a4cc003742997084aaecf84ee5d3) (postgres) - charts: Use the common storage secret
+- [`414c534`](https://github.com/deis/postgres/commit/414c5344df413bbd8f6a943ec02d3c92bd55349f) (postgres) - test-swift: remove reliance on local swift client
+- [`b63909a`](https://github.com/deis/postgres/commit/b63909a96e5e43f64de193aad557aeb3a7d7565e) (postgres) - test-minio: change DNS entry to minio
+- [`b7a2d5b`](https://github.com/deis/postgres/commit/b7a2d5b6a03036d210ac41d21de1c488c92b3a3b) (postgres) - setup_envdir: remove AWS_REGION from WALE_S3_ENDPOINT
+- [`d1744d5`](https://github.com/deis/postgres/commit/d1744d5813942cc440b56c8330b29cc2f84942f0) (postgres) - setup_envdir: do not set AWS_ACCESS_KEY_ID if empty
+- [`3984d62`](https://github.com/deis/postgres/commit/3984d62270ebe6a1747209497f8d958bb5571106) (postgres) - gcs: Use correct env variable for the gcs service account file path
+- [`7458672`](https://github.com/deis/postgres/commit/7458672dbb76b90c2442d065238c25a97ec4cb0f) (postgres) - charts: fix typo and stanza location
+- [`388c593`](https://github.com/deis/postgres/commit/388c593dd182755fad2218ef2c1f24d39bc29948) (postgres) - boto: specify the region while getting s3 connection
+- [`758632d`](https://github.com/deis/postgres/commit/758632dae206685916fd2edeeb1113b9b455b86a) (postgres) - setup-envdir: convert AWS_REGION to WALE_S3_ENDPOINT
+- [`bc77951`](https://github.com/deis/postgres/commit/bc7795100a1e7c0d535c5d519ec9f925f71fd4e5) (postgres) - create_bucket: try default s3 region on create error
+- [`8bf4c52`](https://github.com/deis/postgres/commit/8bf4c52fbc4bd2c54166f7d072578be11c4d90c7) (postgres) - create_bucket: propagate us-east-1 to wal-e
+- [`76bf6d8`](https://github.com/deis/redis/commit/76bf6d8cb88131aa6b14a65acc33e0f9a2b60f3e) (redis) - charts: Use proper values for offcluster redis
+- [`e4bbb57`](https://github.com/deis/registry/commit/e4bbb573051ee0ee0de734f0262c5ecc70bcfd74) (registry) - charts: Use the common storage secret
+- [`6e27041`](https://github.com/deis/registry/commit/6e27041194d694857ffcd4056e52288f9393c994) (registry) - boto: specify the region while getting s3 connection
+- [`384bf31`](https://github.com/deis/slugbuilder/commit/384bf313d62d2d5d895354b991b5be6123952b57) (slugbuilder) - charts: Don't use caps in the configmap keys
+- [`5b053c8`](https://github.com/deis/workflow-cli/commit/5b053c801b8a1767f44f0168ef3af1aa5d79c3d6) (workflow-cli) - login: User should login by default when he registers
+- [`5b06f6b`](https://github.com/deis/workflow-e2e/commit/5b06f6b7a0cd2f9a36c8df97ab3760553e9af17f) (workflow-e2e) - tests/labels_test.go: adjust spacing
 
 #### Documentation
 
-- [`bd1a6f1`](https://github.com/deisthree/charts/commit/bd1a6f181ca35b33ae7e5a70676a66d3cf849e53) (charts) - README: remove dead Travis CI badge
-- [`de94939`](https://github.com/deisthree/charts/commit/de949394811acab8bd7960f27493531795c98c68) (charts) - add note about Helm classic deprecation
-- [`1f60736`](https://github.com/deisthree/workflow-e2e/commit/1f6073696baf766a7b7c83ac8483fc9e1b1a2239) (workflow-e2e) - README: swap out helmc for helm installation instructions
+- [`bd1a6f1`](https://github.com/deis/charts/commit/bd1a6f181ca35b33ae7e5a70676a66d3cf849e53) (charts) - README: remove dead Travis CI badge
+- [`de94939`](https://github.com/deis/charts/commit/de949394811acab8bd7960f27493531795c98c68) (charts) - add note about Helm classic deprecation
+- [`1f60736`](https://github.com/deis/workflow-e2e/commit/1f6073696baf766a7b7c83ac8483fc9e1b1a2239) (workflow-e2e) - README: swap out helmc for helm installation instructions
 
 #### Tests
 
-- [`a5666f1`](https://github.com/deisthree/controller/commit/a5666f1225901f211350e33a378438f461186cfb) (controller) - scheduler: confirm "network unreachable" raises KubeHTTPException (#1142)
-- [`92a0f8e`](https://github.com/deisthree/controller/commit/92a0f8e1d16e1c51dae4999e23c57d0321c2fe0b) (controller) - label-cmd: add new label cmd test
-- [`d2ab260`](https://github.com/deisthree/workflow-cli/commit/d2ab26062035c89e317b22bdf21b430568a231d2) (workflow-cli) - label-cmd: add Label cmd test
+- [`a5666f1`](https://github.com/deis/controller/commit/a5666f1225901f211350e33a378438f461186cfb) (controller) - scheduler: confirm "network unreachable" raises KubeHTTPException (#1142)
+- [`92a0f8e`](https://github.com/deis/controller/commit/92a0f8e1d16e1c51dae4999e23c57d0321c2fe0b) (controller) - label-cmd: add new label cmd test
+- [`d2ab260`](https://github.com/deis/workflow-cli/commit/d2ab26062035c89e317b22bdf21b430568a231d2) (workflow-cli) - label-cmd: add Label cmd test
 
 #### Maintenance
 
-- [`d08070e`](https://github.com/deisthree/builder/commit/d08070e6b14ea4933110b0f0483de80fec0ab583) (builder) - Dockerfile: update deis/base to 0.3.5
-- [`3fb031a`](https://github.com/deisthree/builder/commit/3fb031a34f3b21a936e5996696d1642a0b20788b) (builder) - Makefile: update deis/go-dev to 0.20.0
-- [`a5d9525`](https://github.com/deisthree/builder/commit/a5d95259c57c2712d29bf6284ff2112da31d7063) (builder) - glide.yaml: update controller-sdk-go
-- [`0fbd407`](https://github.com/deisthree/charts/commit/0fbd407f7c44a291d687f201f02dd42a23248624) (charts) - workflow-v2.9.0: releasing workflow-v2.9.0(-e2e)
-- [`46c72dd`](https://github.com/deisthree/controller/commit/46c72dd87d8b7ffa9dad12aec316e17b4fde7d00) (controller) - requirements: update Django to 1.10.3
-- [`e81be7a`](https://github.com/deisthree/controller/commit/e81be7a0bbe7da13e629012818835ff52ed27473) (controller) - requirements: update docker-py to 1.10.6
-- [`e3d66aa`](https://github.com/deisthree/controller/commit/e3d66aabc5533bbad02e3155da790064a39cd530) (controller) - Dockerfile: update deis/base to 0.3.5
-- [`6cb0dd1`](https://github.com/deisthree/controller/commit/6cb0dd1ef65bea65a0050245eb3fe9df671057c8) (controller) - requirements: update DRF to 3.5.2
-- [`db9d44c`](https://github.com/deisthree/controller/commit/db9d44c0b639ed8c4154bee9874e8539fd60e374) (controller) - requirements: update DRF to 3.5.3
-- [`5921ff1`](https://github.com/deisthree/controller/commit/5921ff1e4eb145092162a041dc84110b2fc0d22e) (controller) - requirements: update requests lib to 2.12.1
-- [`11d0e4b`](https://github.com/deisthree/controller/commit/11d0e4b203b9654aa709df6504caa46a774b6f89) (controller) - requirements: update backoff library
-- [`2ba4e2e`](https://github.com/deisthree/dockerbuilder/commit/2ba4e2e44dce76df0d7fba868e6dab8fb6560955) (dockerbuilder) - Dockerfile: update docker-py to 1.10.6
-- [`04ad320`](https://github.com/deisthree/dockerbuilder/commit/04ad320a909c165a74dc3a6205266b3115458257) (dockerbuilder) - Dockerfile: update deis/base to 0.3.5
-- [`e5d8a25`](https://github.com/deisthree/fluentd/commit/e5d8a253c960c27e352bf69f183f1252dd9cc8ed) (fluentd) - Dockerfile: update deis/base to 0.3.5
-- [`a756744`](https://github.com/deisthree/logger/commit/a756744b3256410c77258c8832040845c6223c2c) (logger) - tests: Add more tests to increase coverage
-- [`bcf8bb4`](https://github.com/deisthree/logger/commit/bcf8bb489277090b58bd322d579df3321493cda0) (logger) - Dockerfile: update deis/base to 0.3.5
-- [`65c2d14`](https://github.com/deisthree/logger/commit/65c2d143cc6761ceb0ba561254bc14cd0c660c75) (logger) - Makefile: update deis/go-dev to 0.20.0
-- [`9d496b4`](https://github.com/deisthree/minio/commit/9d496b49ef72e910c99447740dc2cc17fa2f94c0) (minio) - Dockerfile: update deis/base to 0.3.5
-- [`d230c2b`](https://github.com/deisthree/minio/commit/d230c2bb336be9510e8529785c49ba5ca615ee20) (minio) - Makefile: update deis/go-dev to 0.20.0
-- [`0369d15`](https://github.com/deisthree/monitor/commit/0369d1585edd83d0a07dd4c2cc2c92dc8b234759) (monitor) - grafana: Add improved kubernetes health dashboard
-- [`8c44281`](https://github.com/deisthree/monitor/commit/8c442819ada08b70d3aa9e6c3b663f830fd0fc66) (monitor) - grafana: Update to 3.1.1
-- [`7a730d9`](https://github.com/deisthree/monitor/commit/7a730d91ccc665044f4b6268ad25b766ce436330) (monitor) - Dockerfiles: update deis/base to 0.3.5
-- [`a35ed28`](https://github.com/deisthree/nsq/commit/a35ed28b4a6d340855ee4eb18e24c36643c84d6c) (nsq) - Dockerfile: update deis/base to 0.3.5
-- [`42225fd`](https://github.com/deisthree/postgres/commit/42225fdd9b0b0babab53024a87ded21493f0bfd4) (postgres) - Dockerfile: bump to wal-e v1.0.1
-- [`99e5254`](https://github.com/deisthree/postgres/commit/99e52543b798ba79e71b73e9d25e4bf38a4e230d) (postgres) - Dockerfile: bump PG_VERSION to 9.4.10-1.pgdg16.04+1
-- [`c8f3d28`](https://github.com/deisthree/postgres/commit/c8f3d28d1b34ed502534d1a0ae0bdd98bec3e899) (postgres) - Dockerfile: bump boto to 2.43.0
-- [`3f80837`](https://github.com/deisthree/postgres/commit/3f80837b2f798741977a86f65e30d404382f3914) (postgres) - Dockerfile: update deis/base to 0.3.5
-- [`8c85530`](https://github.com/deisthree/postgres/commit/8c85530d47f6ccab97af47adad16fed8fa2067c5) (postgres) - Makefile: update deis/go-dev to 0.20.0
-- [`6d8f6b4`](https://github.com/deisthree/redis/commit/6d8f6b4c26ec57a231888d23fe69f7d39240afed) (redis) - Dockerfile: update deis/base to 0.3.5
-- [`9f3e88f`](https://github.com/deisthree/registry/commit/9f3e88fc92c8ed1ff94c3f28b0c449173a146984) (registry) - Dockerfile: update deis/base to v0.3.5
-- [`edb65d5`](https://github.com/deisthree/registry/commit/edb65d549313f75962bb4185bb9f9c5be85fc22a) (registry) - Makefile: update docker-go-dev to 0.20.0
-- [`5ef240b`](https://github.com/deisthree/registry-token-refresher/commit/5ef240b2e353aebff3cebf425a6ebcb0eb6279d9) (registry-token-refresher) - Dockerfile: update deis/base to v0.3.5
-- [`1380b20`](https://github.com/deisthree/registry-token-refresher/commit/1380b2093009e26b0c6327ba6150aa84d63773e0) (registry-token-refresher) - Makefile: update deis/docker-go-dev to 0.20.0
-- [`ee40fe5`](https://github.com/deisthree/router/commit/ee40fe5368c6b20b2e3d4773cb9bd39e29331266) (router) - Makefile: bump docker-go-dev to 0.20.0
-- [`fd563fe`](https://github.com/deisthree/router/commit/fd563febc3fa0dea6f3876eedf49c8e74c97851f) (router) - Dockerfile: update deis/base to v0.3.5
-- [`99316f6`](https://github.com/deisthree/router/commit/99316f65e0102d72b8ed545eab8bad1c04000f7b) (router) - nginx: update nginx to 1.11.6
-- [`7960638`](https://github.com/deisthree/slugbuilder/commit/79606385e578b225b37ebf84efb027bdbfd9f9dc) (slugbuilder) - buildpacks: update heroku-buildpack-php to v113
-- [`44f1194`](https://github.com/deisthree/slugbuilder/commit/44f11949ae6f4067512e634a7363cdf8174b14d8) (slugbuilder) - buildpacks: update heroku-buildpack-go to v52
-- [`f749395`](https://github.com/deisthree/slugbuilder/commit/f749395e9dff66d84e8d81395b10f8faa866e860) (slugbuilder) - Makefile: bump deis/docker-go-dev to 0.20.0
-- [`8a62e05`](https://github.com/deisthree/slugbuilder/commit/8a62e050c35e98920a7782e7f6cffd7b000b19f6) (slugbuilder) - buildpacks: update heroku-buildpack-python to v83
-- [`bf8cd6d`](https://github.com/deisthree/slugbuilder/commit/bf8cd6db2ea4d073f80b31ed455b118272309c54) (slugbuilder) - buildpacks: update heroku-buildpack-php to v114
-- [`aefdf03`](https://github.com/deisthree/slugbuilder/commit/aefdf0313fc2eb0d1a307db2cc3d5c74cf55178c) (slugbuilder) - buildpacks: update heroku-buildpack-python to v85
-- [`920815c`](https://github.com/deisthree/slugbuilder/commit/920815c532fc894ddb6046019b18ace75171d09f) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v148
-- [`2bed510`](https://github.com/deisthree/slugbuilder/commit/2bed510e485a6dd3fed335f48c62e5197b5d03a7) (slugbuilder) - buildpacks: update heroku-buildpack-java to v48
-- [`3d308c8`](https://github.com/deisthree/slugbuilder/commit/3d308c8490361aa8ada8cf9d6b164fa6bf39b87c) (slugbuilder) - buildpacks: update heroku-buildpack-grails to v21
-- [`ba9a77d`](https://github.com/deisthree/slugrunner/commit/ba9a77d7a2ed0111c977bceb2aa55e30c7dd39ab) (slugrunner) - Makefile: update deis/docker-go-dev to 0.20.0
-- [`f290693`](https://github.com/deisthree/workflow-cli/commit/f290693dde2e4bcb49e280ac6069ee1d183d582f) (workflow-cli) - glide: update controller-sdk-go package
-- [`5ed663b`](https://github.com/deisthree/workflow-e2e/commit/5ed663b6c78e77f3a4ab1ad20cb0ffb8877697ed) (workflow-e2e) - apps_test: Fix up logger tests for new log format
-- [`96c5779`](https://github.com/deisthree/workflow-e2e/commit/96c5779b1d6a038753ca8de7976acbdef3525acf) (workflow-e2e) - Dockerfile: bump deis/docker-go-dev to 0.19.0 (#336)
-- [`f9cbec4`](https://github.com/deisthree/workflow-e2e/commit/f9cbec43e8d362ae1b16c471ce2053ef95a60c53) (workflow-e2e) - Dockerfile: bump kubectl version
-- [`df3684f`](https://github.com/deisthree/workflow-manager/commit/df3684f117e7407a56cb14d5127e4d90653dce7c) (workflow-manager) - Dockerfile: bump deis/base to v0.3.5
-- [`e267d45`](https://github.com/deisthree/workflow-manager/commit/e267d45304de09cbfc7aef27f7c1662756394253) (workflow-manager) - Makefile: bump deis/docker-go-dev to 0.20.0
-- [`dea4480`](https://github.com/deisthree/workflow-manager/commit/dea44807a548c60500f7cb15bcf56d344b49d85a) (workflow-manager) - Makefile: update goswagger/swagger to 0.7.3
+- [`d08070e`](https://github.com/deis/builder/commit/d08070e6b14ea4933110b0f0483de80fec0ab583) (builder) - Dockerfile: update deis/base to 0.3.5
+- [`3fb031a`](https://github.com/deis/builder/commit/3fb031a34f3b21a936e5996696d1642a0b20788b) (builder) - Makefile: update deis/go-dev to 0.20.0
+- [`a5d9525`](https://github.com/deis/builder/commit/a5d95259c57c2712d29bf6284ff2112da31d7063) (builder) - glide.yaml: update controller-sdk-go
+- [`0fbd407`](https://github.com/deis/charts/commit/0fbd407f7c44a291d687f201f02dd42a23248624) (charts) - workflow-v2.9.0: releasing workflow-v2.9.0(-e2e)
+- [`46c72dd`](https://github.com/deis/controller/commit/46c72dd87d8b7ffa9dad12aec316e17b4fde7d00) (controller) - requirements: update Django to 1.10.3
+- [`e81be7a`](https://github.com/deis/controller/commit/e81be7a0bbe7da13e629012818835ff52ed27473) (controller) - requirements: update docker-py to 1.10.6
+- [`e3d66aa`](https://github.com/deis/controller/commit/e3d66aabc5533bbad02e3155da790064a39cd530) (controller) - Dockerfile: update deis/base to 0.3.5
+- [`6cb0dd1`](https://github.com/deis/controller/commit/6cb0dd1ef65bea65a0050245eb3fe9df671057c8) (controller) - requirements: update DRF to 3.5.2
+- [`db9d44c`](https://github.com/deis/controller/commit/db9d44c0b639ed8c4154bee9874e8539fd60e374) (controller) - requirements: update DRF to 3.5.3
+- [`5921ff1`](https://github.com/deis/controller/commit/5921ff1e4eb145092162a041dc84110b2fc0d22e) (controller) - requirements: update requests lib to 2.12.1
+- [`11d0e4b`](https://github.com/deis/controller/commit/11d0e4b203b9654aa709df6504caa46a774b6f89) (controller) - requirements: update backoff library
+- [`2ba4e2e`](https://github.com/deis/dockerbuilder/commit/2ba4e2e44dce76df0d7fba868e6dab8fb6560955) (dockerbuilder) - Dockerfile: update docker-py to 1.10.6
+- [`04ad320`](https://github.com/deis/dockerbuilder/commit/04ad320a909c165a74dc3a6205266b3115458257) (dockerbuilder) - Dockerfile: update deis/base to 0.3.5
+- [`e5d8a25`](https://github.com/deis/fluentd/commit/e5d8a253c960c27e352bf69f183f1252dd9cc8ed) (fluentd) - Dockerfile: update deis/base to 0.3.5
+- [`a756744`](https://github.com/deis/logger/commit/a756744b3256410c77258c8832040845c6223c2c) (logger) - tests: Add more tests to increase coverage
+- [`bcf8bb4`](https://github.com/deis/logger/commit/bcf8bb489277090b58bd322d579df3321493cda0) (logger) - Dockerfile: update deis/base to 0.3.5
+- [`65c2d14`](https://github.com/deis/logger/commit/65c2d143cc6761ceb0ba561254bc14cd0c660c75) (logger) - Makefile: update deis/go-dev to 0.20.0
+- [`9d496b4`](https://github.com/deis/minio/commit/9d496b49ef72e910c99447740dc2cc17fa2f94c0) (minio) - Dockerfile: update deis/base to 0.3.5
+- [`d230c2b`](https://github.com/deis/minio/commit/d230c2bb336be9510e8529785c49ba5ca615ee20) (minio) - Makefile: update deis/go-dev to 0.20.0
+- [`0369d15`](https://github.com/deis/monitor/commit/0369d1585edd83d0a07dd4c2cc2c92dc8b234759) (monitor) - grafana: Add improved kubernetes health dashboard
+- [`8c44281`](https://github.com/deis/monitor/commit/8c442819ada08b70d3aa9e6c3b663f830fd0fc66) (monitor) - grafana: Update to 3.1.1
+- [`7a730d9`](https://github.com/deis/monitor/commit/7a730d91ccc665044f4b6268ad25b766ce436330) (monitor) - Dockerfiles: update deis/base to 0.3.5
+- [`a35ed28`](https://github.com/deis/nsq/commit/a35ed28b4a6d340855ee4eb18e24c36643c84d6c) (nsq) - Dockerfile: update deis/base to 0.3.5
+- [`42225fd`](https://github.com/deis/postgres/commit/42225fdd9b0b0babab53024a87ded21493f0bfd4) (postgres) - Dockerfile: bump to wal-e v1.0.1
+- [`99e5254`](https://github.com/deis/postgres/commit/99e52543b798ba79e71b73e9d25e4bf38a4e230d) (postgres) - Dockerfile: bump PG_VERSION to 9.4.10-1.pgdg16.04+1
+- [`c8f3d28`](https://github.com/deis/postgres/commit/c8f3d28d1b34ed502534d1a0ae0bdd98bec3e899) (postgres) - Dockerfile: bump boto to 2.43.0
+- [`3f80837`](https://github.com/deis/postgres/commit/3f80837b2f798741977a86f65e30d404382f3914) (postgres) - Dockerfile: update deis/base to 0.3.5
+- [`8c85530`](https://github.com/deis/postgres/commit/8c85530d47f6ccab97af47adad16fed8fa2067c5) (postgres) - Makefile: update deis/go-dev to 0.20.0
+- [`6d8f6b4`](https://github.com/deis/redis/commit/6d8f6b4c26ec57a231888d23fe69f7d39240afed) (redis) - Dockerfile: update deis/base to 0.3.5
+- [`9f3e88f`](https://github.com/deis/registry/commit/9f3e88fc92c8ed1ff94c3f28b0c449173a146984) (registry) - Dockerfile: update deis/base to v0.3.5
+- [`edb65d5`](https://github.com/deis/registry/commit/edb65d549313f75962bb4185bb9f9c5be85fc22a) (registry) - Makefile: update docker-go-dev to 0.20.0
+- [`5ef240b`](https://github.com/deis/registry-token-refresher/commit/5ef240b2e353aebff3cebf425a6ebcb0eb6279d9) (registry-token-refresher) - Dockerfile: update deis/base to v0.3.5
+- [`1380b20`](https://github.com/deis/registry-token-refresher/commit/1380b2093009e26b0c6327ba6150aa84d63773e0) (registry-token-refresher) - Makefile: update deis/docker-go-dev to 0.20.0
+- [`ee40fe5`](https://github.com/deis/router/commit/ee40fe5368c6b20b2e3d4773cb9bd39e29331266) (router) - Makefile: bump docker-go-dev to 0.20.0
+- [`fd563fe`](https://github.com/deis/router/commit/fd563febc3fa0dea6f3876eedf49c8e74c97851f) (router) - Dockerfile: update deis/base to v0.3.5
+- [`99316f6`](https://github.com/deis/router/commit/99316f65e0102d72b8ed545eab8bad1c04000f7b) (router) - nginx: update nginx to 1.11.6
+- [`7960638`](https://github.com/deis/slugbuilder/commit/79606385e578b225b37ebf84efb027bdbfd9f9dc) (slugbuilder) - buildpacks: update heroku-buildpack-php to v113
+- [`44f1194`](https://github.com/deis/slugbuilder/commit/44f11949ae6f4067512e634a7363cdf8174b14d8) (slugbuilder) - buildpacks: update heroku-buildpack-go to v52
+- [`f749395`](https://github.com/deis/slugbuilder/commit/f749395e9dff66d84e8d81395b10f8faa866e860) (slugbuilder) - Makefile: bump deis/docker-go-dev to 0.20.0
+- [`8a62e05`](https://github.com/deis/slugbuilder/commit/8a62e050c35e98920a7782e7f6cffd7b000b19f6) (slugbuilder) - buildpacks: update heroku-buildpack-python to v83
+- [`bf8cd6d`](https://github.com/deis/slugbuilder/commit/bf8cd6db2ea4d073f80b31ed455b118272309c54) (slugbuilder) - buildpacks: update heroku-buildpack-php to v114
+- [`aefdf03`](https://github.com/deis/slugbuilder/commit/aefdf0313fc2eb0d1a307db2cc3d5c74cf55178c) (slugbuilder) - buildpacks: update heroku-buildpack-python to v85
+- [`920815c`](https://github.com/deis/slugbuilder/commit/920815c532fc894ddb6046019b18ace75171d09f) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v148
+- [`2bed510`](https://github.com/deis/slugbuilder/commit/2bed510e485a6dd3fed335f48c62e5197b5d03a7) (slugbuilder) - buildpacks: update heroku-buildpack-java to v48
+- [`3d308c8`](https://github.com/deis/slugbuilder/commit/3d308c8490361aa8ada8cf9d6b164fa6bf39b87c) (slugbuilder) - buildpacks: update heroku-buildpack-grails to v21
+- [`ba9a77d`](https://github.com/deis/slugrunner/commit/ba9a77d7a2ed0111c977bceb2aa55e30c7dd39ab) (slugrunner) - Makefile: update deis/docker-go-dev to 0.20.0
+- [`f290693`](https://github.com/deis/workflow-cli/commit/f290693dde2e4bcb49e280ac6069ee1d183d582f) (workflow-cli) - glide: update controller-sdk-go package
+- [`5ed663b`](https://github.com/deis/workflow-e2e/commit/5ed663b6c78e77f3a4ab1ad20cb0ffb8877697ed) (workflow-e2e) - apps_test: Fix up logger tests for new log format
+- [`96c5779`](https://github.com/deis/workflow-e2e/commit/96c5779b1d6a038753ca8de7976acbdef3525acf) (workflow-e2e) - Dockerfile: bump deis/docker-go-dev to 0.19.0 (#336)
+- [`f9cbec4`](https://github.com/deis/workflow-e2e/commit/f9cbec43e8d362ae1b16c471ce2053ef95a60c53) (workflow-e2e) - Dockerfile: bump kubectl version
+- [`df3684f`](https://github.com/deis/workflow-manager/commit/df3684f117e7407a56cb14d5127e4d90653dce7c) (workflow-manager) - Dockerfile: bump deis/base to v0.3.5
+- [`e267d45`](https://github.com/deis/workflow-manager/commit/e267d45304de09cbfc7aef27f7c1662756394253) (workflow-manager) - Makefile: bump deis/docker-go-dev to 0.20.0
+- [`dea4480`](https://github.com/deis/workflow-manager/commit/dea44807a548c60500f7cb15bcf56d344b49d85a) (workflow-manager) - Makefile: update goswagger/swagger to 0.7.3

--- a/src/changelogs/v2.9.1.md
+++ b/src/changelogs/v2.9.1.md
@@ -7,14 +7,14 @@
 
 #### Fixes
 
-- [`d723de6`](https://github.com/deisthree/controller/commit/d723de618d0a420cfba3c5be7e3d53c17aa9a404) (controller) - api: account for NoneType when resource is gone (#1178)
-- [`ebeb922`](https://github.com/deisthree/slugbuilder/commit/ebeb9223919a9725f570cc26534e525c6e2d0e13) (slugbuilder) - env_dir: Remove directories from the env dir passed to the compile
-- [`e058fa2`](https://github.com/deisthree/slugbuilder/commit/e058fa27b3f8c2e3bf9e20c06374ef4450f0a186) (slugbuilder) - ssh: read the ssh key from dir instead of environment
+- [`d723de6`](https://github.com/deis/controller/commit/d723de618d0a420cfba3c5be7e3d53c17aa9a404) (controller) - api: account for NoneType when resource is gone (#1178)
+- [`ebeb922`](https://github.com/deis/slugbuilder/commit/ebeb9223919a9725f570cc26534e525c6e2d0e13) (slugbuilder) - env_dir: Remove directories from the env dir passed to the compile
+- [`e058fa2`](https://github.com/deis/slugbuilder/commit/e058fa27b3f8c2e3bf9e20c06374ef4450f0a186) (slugbuilder) - ssh: read the ssh key from dir instead of environment
 
 #### Maintenance
 
-- [`673ce82`](https://github.com/deisthree/slugbuilder/commit/673ce822af983855a3a1565095838bfe0d5b4a08) (slugbuilder) - buildpacks: update heroku-buildpack-php to v115
-- [`998b7ce`](https://github.com/deisthree/slugbuilder/commit/998b7ce2b043c8dfd8787027a33b2e336d37d050) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v149
-- [`195c4f2`](https://github.com/deisthree/slugbuilder/commit/195c4f28c821048779e471a202f8d9d80d753ce7) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v19
-- [`03ab39a`](https://github.com/deisthree/slugbuilder/commit/03ab39af4f7e7da944cd46ae2c8da35c28954ae5) (slugbuilder) - buildpacks: update heroku-buildpack-php to v116
-- [`51514b1`](https://github.com/deisthree/slugbuilder/commit/51514b14259bfab0329b372213835bb8d6873451) (slugbuilder) - buildpacks: update heroku-buildpack-go to v54
+- [`673ce82`](https://github.com/deis/slugbuilder/commit/673ce822af983855a3a1565095838bfe0d5b4a08) (slugbuilder) - buildpacks: update heroku-buildpack-php to v115
+- [`998b7ce`](https://github.com/deis/slugbuilder/commit/998b7ce2b043c8dfd8787027a33b2e336d37d050) (slugbuilder) - buildpacks: update heroku-buildpack-ruby to v149
+- [`195c4f2`](https://github.com/deis/slugbuilder/commit/195c4f28c821048779e471a202f8d9d80d753ce7) (slugbuilder) - buildpacks: update heroku-buildpack-gradle to v19
+- [`03ab39a`](https://github.com/deis/slugbuilder/commit/03ab39af4f7e7da944cd46ae2c8da35c28954ae5) (slugbuilder) - buildpacks: update heroku-buildpack-php to v116
+- [`51514b1`](https://github.com/deis/slugbuilder/commit/51514b14259bfab0329b372213835bb8d6873451) (slugbuilder) - buildpacks: update heroku-buildpack-go to v54

--- a/src/contributing/development-environment.md
+++ b/src/contributing/development-environment.md
@@ -5,7 +5,7 @@ This document is for developers who are interested in working directly on the De
 We try to make it simple to hack on Deis components. However, there are necessarily several moving pieces and some setup required. We welcome any suggestions for automating or simplifying this process.
 
 !!! note
-    The Deis team is actively engaged in containerizing Go and Python based development environments tailored specifically for Deis development in order to minimize the setup required.  This work is ongoing.  Refer to the [deis/router][router] project for a working example of a fully containerized development environment.
+    The Deis team is actively engaged in containerizing Go and Python based development environments tailored specifically for Deis development in order to minimize the setup required.  This work is ongoing.  Refer to the [teamhephy/router][router] project for a working example of a fully containerized development environment.
 
 If you're just getting into the Deis codebase, look for GitHub issues with the label [easy-fix][]. These are more straightforward or low-risk issues and are a great way to become more familiar with Deis.
 
@@ -20,7 +20,7 @@ In order to successfully compile and test Deis binaries and build Docker images 
 - [shellcheck][shellcheck]
 - [Docker][docker] (in a non-Linux environment, you will additionally want [Docker Machine][machine])
 
-For [deis/controller][controller], in particular, you will also need:
+For [teamhephy/controller][controller], in particular, you will also need:
 
 - Python 2.7 or later (with `pip`)
 - virtualenv (`sudo pip install virtualenv`)
@@ -83,39 +83,39 @@ After following these steps, some Docker Machine users report a slight delay (30
 
 Once the prerequisites have been met, we can begin to work with Deis components.
 
-Begin at Github by forking whichever Deis project you would like to contribute to, then clone that fork locally.  Since Deis is predominantly written in Go, the best place to put it is under `$GOPATH/src/github.com/deis/`.
+Begin at Github by forking whichever Hephy project you would like to contribute to, then clone that fork locally.  Since Hephy is predominantly written in Go, the best place to put it is under `$GOPATH/src/github.com/teamhephy/`.
 
 ```
-$ mkdir -p  $GOPATH/src/github.com/deis
-$ cd $GOPATH/src/github.com/deis
+$ mkdir -p  $GOPATH/src/github.com/teamhephy
+$ cd $GOPATH/src/github.com/teamhephy
 $ git clone git@github.com:<username>/<component>.git
 $ cd <component>
 ```
 
 !!! note
-    By checking out the forked copy into the namespace `github.com/deis/<component>`, we are tricking the Go toolchain into seeing our fork as the "official" source tree.
+    By checking out the forked copy into the namespace `github.com/teamhephy/<component>`, we are tricking the Go toolchain into seeing our fork as the "official" source tree.
 
 If you are going to be issuing pull requests to the upstream repository from which you forked, we suggest configuring Git such that you can easily rebase your code to the upstream repository's master branch. There are various strategies for doing this, but the [most common](https://help.github.com/articles/fork-a-repo/) is to add an `upstream` remote:
 
 ```
-$ git remote add upstream https://github.com/deisthree/<component>.git
+$ git remote add upstream https://github.com/teamhephy/<component>.git
 ```
 
 For the sake of simplicity, you may want to point an environment variable to your Deis code - the directory containing one or more Deis components:
 
 ```
-$ export DEIS=$GOPATH/src/github.com/deis
+$ export DEIS=$GOPATH/src/github.com/teamhephy
 ```
 
 Throughout the rest of this document, `$DEIS` refers to that location.
 
 ### Alternative: Forking with a Pushurl
 
-A number of Deis contributors prefer to pull directly from `deis/<component>`, but push to `<username>/<component>`. If that workflow suits you better, you can set it up this way:
+A number of Deis contributors prefer to pull directly from `teamhephy/<component>`, but push to `<username>/<component>`. If that workflow suits you better, you can set it up this way:
 
 ```
-$ git clone git@github.com:deis/<component>.git
-$ cd deis
+$ git clone git@github.com:teamhephy/<component>.git
+$ cd teamhephy
 $ git config remote.origin.pushurl git@github.com:<username>/<component>.git
 ```
 
@@ -222,7 +222,7 @@ $ kubectl --namespace=deis logs -f <pod name>
 
 ### Django Shell
 
-Specific to [deis/controller][controller]
+Specific to [teamhephy/controller][controller]
 
 ```
 $ kubectl --namespace=deis exec -it <pod name> -- python manage.py shell
@@ -237,7 +237,7 @@ Satisfied with your changes?  Share them!
 Please read [Submitting a Pull Request](submitting-a-pull-request.md). It contains a checklist of
 things you should do when proposing a change to any Deis component.
 
-[router]: https://github.com/deisthree/router
+[router]: https://github.com/teamhephy/router
 [easy-fix]: https://github.com/issues?q=user%3Adeis+label%3Aeasy-fix+is%3Aopen
 [git]: https://git-scm.com/
 [glide]: https://github.com/Masterminds/glide
@@ -245,7 +245,7 @@ things you should do when proposing a change to any Deis component.
 [shellcheck]: https://github.com/koalaman/shellcheck
 [docker]: https://www.docker.com/
 [machine]: http://docs.docker.com/machine/install-machine/
-[controller]: https://github.com/deisthree/controller
+[controller]: https://github.com/teamhephy/controller
 [vbox]: https://www.virtualbox.org/
 [testing]: testing.md
 [k8s]: http://kubernetes.io/

--- a/src/contributing/overview.md
+++ b/src/contributing/overview.md
@@ -16,7 +16,7 @@ Before opening a new issue, it's helpful to search and see if anyone else has al
 
 ## Write Documentation
 
-We are always looking to improve and expand our documentation. Most docs reside in the [deis/workflow][workflow] repository. Simply fork the project, update docs and send us a pull request.
+We are always looking to improve and expand our documentation. Most docs reside in the [teamhephy/workflow][workflow] repository. Simply fork the project, update docs and send us a pull request.
 
 ## Contribute Code
 
@@ -34,11 +34,11 @@ If you don't have time to code, consider helping with triage. The community will
 
 Interact with the community on our user mailing list or live in our [Deis #community Slack channel](https://slack.deis.io), where you can chat with other Deis Workflow users any time of day.
 
-[workflow]: https://github.com/deisthree/workflow
+[workflow]: https://github.com/teamhephy/workflow
 [dd]: design-documents.md
 [dev-environment]: development-environment.md
 [easy fix]: https://github.com/pulls?utf8=%E2%9C%93&q=user%3Adeis+label%3A%22easy+fix%22+is%3Aopen
-[dco]: https://github.com/deisthree/workflow/blob/master/DCO
+[dco]: https://github.com/teamhephy/workflow/blob/master/DCO
 [help wanted]: https://github.com/pulls?utf8=%E2%9C%93&q=user%3Adeis+label%3A%22help+wanted%22+is%3Aopen
 [troubleshooting]: ../troubleshooting/index.md
 [issues]: https://github.com/pulls?utf8=%E2%9C%93&q=user%3Adeis+user%3Ahelm

--- a/src/contributing/submitting-a-pull-request.md
+++ b/src/contributing/submitting-a-pull-request.md
@@ -17,20 +17,20 @@ Most pull requests will reference a GitHub issue. In the PR description - not in
 
 ## Include Tests
 
-If you significantly alter or add functionality to a component that impacts the broader Deis Workflow PaaS, you should submit a complementary PR to modify or amend end-to-end integration tests.  These integration tests can be found in the [deis/workflow-e2e][workflow-e2e] repository.
+If you significantly alter or add functionality to a component that impacts the broader Deis Workflow PaaS, you should submit a complementary PR to modify or amend end-to-end integration tests.  These integration tests can be found in the [teamhephy/workflow-e2e][workflow-e2e] repository.
 
 See [testing](testing.md) for more information.
 
 
 ## Include Docs
 
-Changes to any Deis Workflow component that could affect a user's experience also require a change or addition to the relevant documentation. For most Deis components, this involves updating the component's _own_ documentation. In some cases where a component is tightly integrated into [deis/workflow][workflow], its documentation must also be updated.
+Changes to any Deis Workflow component that could affect a user's experience also require a change or addition to the relevant documentation. For most Deis components, this involves updating the component's _own_ documentation. In some cases where a component is tightly integrated into [teamhephy/workflow][workflow], its documentation must also be updated.
 
 ## Cross-repo commits
 
-If a pull request is part of a larger piece of work involving one or more additional commits in other Workflow repositories, these commits can be referenced in the last PR to be submitted.  The downstream [e2e test job](https://ci.deis.io/job/workflow-test-pr/) will then supply every referenced commit (derived from PR issue number supplied) to the test runner so it can source the necessary Docker images for inclusion in the generated Workflow chart to be tested.
+If a pull request is part of a larger piece of work involving one or more additional commits in other Workflow repositories, these commits can be referenced in the last PR to be submitted.  The downstream [e2e test job](https://ci.teamhephy.info/job/workflow-e2e-pr/) will then supply every referenced commit (derived from PR issue number supplied) to the test runner so it can source the necessary Docker images for inclusion in the generated Workflow chart to be tested.
 
-For example, consider paired commits in [deis/controller](https://github.com/deisthree/controller) and [deis/workflow-e2e](https://github.com/deisthree/workflow-e2e).  The commit body for the first PR in `deis/workflow-e2e` would look like:
+For example, consider paired commits in [teamhephy/controller](https://github.com/teamhephy/controller) and [teamhephy/workflow-e2e](https://github.com/teamhephy/workflow-e2e).  The commit body for the first PR in `teamhephy/workflow-e2e` would look like:
 
 ```
 feat(foo_test): add e2e test for feature foo
@@ -39,7 +39,7 @@ feat(foo_test): add e2e test for feature foo
 ```
 Adding `[skip e2e]` forgoes the e2e tests on this commit. This and any other required PRs aside from the final PR should be submitted first, so that their respective build and image push jobs run.
 
-Lastly, the final PR in `deis/controller` should be created with the required PR number(s) listed, in the form of `[Rr]equires <repoName>#<pullRequestNumber>`, for use by the downstream e2e run.
+Lastly, the final PR in `teamhephy/controller` should be created with the required PR number(s) listed, in the form of `[Rr]equires <repoName>#<pullRequestNumber>`, for use by the downstream e2e run.
 
 ```
 feat(foo): add feature foo
@@ -120,5 +120,5 @@ An exception to this is when an errant commit needs to be reverted urgently. If 
 [pep8]: http://www.python.org/dev/peps/pep-0008/
 [python]: http://www.python.org/
 [zen]: http://www.python.org/dev/peps/pep-0020/
-[workflow]: https://github.com/deisthree/workflow
-[workflow-e2e]: https://github.com/deisthree/workflow-e2e
+[workflow]: https://github.com/teamhephy/workflow
+[workflow-e2e]: https://github.com/teamhephy/workflow-e2e

--- a/src/contributing/testing.md
+++ b/src/contributing/testing.md
@@ -4,7 +4,7 @@ Each Deis component is one among an ecosystem of such components - many of which
 
 Each Deis component includes its own suite of style checks, [unit tests][], and black-box type [functional tests][].
 
-[Integration tests][] verify the behavior of the Deis components together as a system and are provided separately by the [deis/workflow-e2e][workflow-e2e] project.
+[Integration tests][] verify the behavior of the Deis components together as a system and are provided separately by the [teamhephy/workflow-e2e][workflow-e2e] project.
 
 GitHub pull requests for all Deis components are tested automatically by the [Travis CI][travis] [continuous integration][] system. Contributors should run the same tests locally before proposing any changes to the Deis codebase.
 
@@ -40,12 +40,12 @@ To execute style checks, unit tests, and functional tests all in one shot:
 $ make test
 ```
 
-To execute integration tests, refer to [deis/workflow-e2e][workflow-e2e] documentation.
+To execute integration tests, refer to [teamhephy/workflow-e2e][workflow-e2e] documentation.
 
 [unit tests]: http://en.wikipedia.org/wiki/Unit_testing
 [functional tests]: http://en.wikipedia.org/wiki/Functional_testing
 [integration tests]: http://en.wikipedia.org/wiki/Integration_testing
-[workflow-e2e]: https://github.com/deisthree/workflow-e2e
-[travis]: https://travis-ci.org/deis
+[workflow-e2e]: https://github.com/teamhephy/workflow-e2e
+[travis]: https://travis-ci.org/teamhephy
 [continuous integration]: http://en.wikipedia.org/wiki/Continuous_integration
 [dev-environment]: development-environment.md

--- a/src/installing-workflow/configuring-registry.md
+++ b/src/installing-workflow/configuring-registry.md
@@ -56,7 +56,7 @@ registry-token-refresher:
     hostname: ""
 ...
 ```
-**Note:** `registryid` and `hostname` should _not_ be set.  See [this issue](https://github.com/deisthree/registry-token-refresher/issues/11) for more info.
+**Note:** `registryid` and `hostname` should _not_ be set.  See [this issue](https://github.com/teamhephy/registry-token-refresher/issues/2) for more info.
 
 ### GCR
 

--- a/src/installing-workflow/experimental-native-ingress.md
+++ b/src/installing-workflow/experimental-native-ingress.md
@@ -86,7 +86,7 @@ After installing Workflow, [register a user and deploy an application](../quicks
 
 ##### Feedback
 
-While this feature is experimental we welcome feedback on the issue. We would like to learn more about use cases, and user experience. Please [open a new issue](https://github.com/deisthree/workflow/issues/new) for feedback.
+While this feature is experimental we welcome feedback on the issue. We would like to learn more about use cases, and user experience. Please [open a new issue](https://github.com/teamhephy/workflow/issues/new) for feedback.
 
 
 [builder]: ../understanding-workflow/components.md#builder

--- a/src/installing-workflow/system-requirements.md
+++ b/src/installing-workflow/system-requirements.md
@@ -50,4 +50,4 @@ If you are using Docker with OverlayFS, you must disable SELinux by adding `--se
 `EXTRA_DOCKER_OPTS`. For more background information, see:
 
 * [https://github.com/docker/docker/issues/7952](https://github.com/docker/docker/issues/7952)
-* [https://github.com/deisthree/workflow/issues/63](https://github.com/deisthree/postgres/issues/63)
+* [https://github.com/deis/workflow/issues/63](https://github.com/deis/postgres/issues/63)

--- a/src/managing-workflow/configuring-load-balancers.md
+++ b/src/managing-workflow/configuring-load-balancers.md
@@ -39,11 +39,11 @@ $ kubectl --namespace=deis annotate service/deis-router service.beta.kubernetes.
 Prepare for a short downtime until both the ELB and the router have converged to the new configuration.
 
 !!! important
-    ELB PROXY protocol support was added in Kubernetes 1.3. If you are still on Kubernetes 1.2, you need to first upgrade to a newer [supported Kubernetes version](https://deis.com/docs/workflow/installing-workflow/system-requirements/#kubernetes-versions).
+    ELB PROXY protocol support was added in Kubernetes 1.3. If you are still on Kubernetes 1.2, you need to first upgrade to a newer [supported Kubernetes version](https://teamhephy.info/docs/workflow/installing-workflow/system-requirements/#kubernetes-versions).
 
 ## Manually configuring a load balancer
 
-If using a Kubernetes distribution or underlying infrastructure that does not support the automated provisioning of a front-facing load balancer, operators will wish to manually configure a load balancer (or use other tricks) to route inbound traffic from beyond the cluster into the cluster to the Deis router(s).  There are many ways to accomplish this.  This documentation will focus on the most common method.  Readers interested in other options may refer to [the router component's own documentation](https://github.com/deisthree/router#front-facing-load-balancer) for further details.
+If using a Kubernetes distribution or underlying infrastructure that does not support the automated provisioning of a front-facing load balancer, operators will wish to manually configure a load balancer (or use other tricks) to route inbound traffic from beyond the cluster into the cluster to the Deis router(s).  There are many ways to accomplish this.  This documentation will focus on the most common method.  Readers interested in other options may refer to [the router component's own documentation](https://github.com/teamhephy/router#front-facing-load-balancer) for further details.
 
 Begin by determining the "node ports" for the `deis-router` service:
 

--- a/src/managing-workflow/extending-workflow.md
+++ b/src/managing-workflow/extending-workflow.md
@@ -41,7 +41,7 @@ Are we missing something? Please open a [documentation pull request][] to add it
 [deis-workflow-aws]: https://github.com/rimusz/deis-workflow-aws
 [deis-workflow-gke]: https://github.com/rimusz/deis-workflow-gke
 [deis-workflow-ruby]: https://github.com/thomas0087/deis-workflow-ruby
-[documentation pull request]: https://github.com/deisthree/workflow/pulls
+[documentation pull request]: https://github.com/teamhephy/workflow/pulls
 [Google Container Engine]: https://cloud.google.com/container-engine/
 [Helm]: https://github.com/kubernetes/helm
 [heroku-to-deis]: https://github.com/emartech/heroku-to-deis

--- a/src/managing-workflow/platform-logging.md
+++ b/src/managing-workflow/platform-logging.md
@@ -1,12 +1,12 @@
 # Platform Logging
 
-The logging platform is made up of 2 components - [Fluentd](https://github.com/deisthree/fluentd) and [Logger](https://github.com/deisthree/logger).
+The logging platform is made up of 2 components - [Fluentd](https://github.com/teamhephy/fluentd) and [Logger](https://github.com/teamhephy/logger).
 
-[Fluentd](https://github.com/deisthree/fluentd) runs on every worker node of the cluster and is deployed as a [Daemon Set](http://kubernetes.io/v1.1/docs/admin/daemons.html). The Fluentd pods capture all of the stderr and stdout streams of every container running on the host (even those not hosted directly by kubernetes). Once the log message arrives in our [custom fluentd plugin](https://github.com/deisthree/fluentd/tree/master/rootfs/opt/fluentd/deis-output) we determine where the message originated.
+[Fluentd](https://github.com/teamhephy/fluentd) runs on every worker node of the cluster and is deployed as a [Daemon Set](http://kubernetes.io/v1.1/docs/admin/daemons.html). The Fluentd pods capture all of the stderr and stdout streams of every container running on the host (even those not hosted directly by kubernetes). Once the log message arrives in our [custom fluentd plugin](https://github.com/teamhephy/fluentd/tree/master/rootfs/opt/fluentd/deis-output) we determine where the message originated.
 
-If the message was from the [Workflow Controller](https://github.com/deisthree/controller) or from an application deployed via workflow we send it to the logs topic on the local [NSQD](http://nsq.io) instance.
+If the message was from the [Workflow Controller](https://github.com/teamhephy/controller) or from an application deployed via workflow we send it to the logs topic on the local [NSQD](http://nsq.io) instance.
 
-If the message is from the [Workflow Router](https://github.com/deisthree/router) we build an Influxdb compatible message and send it to the same NSQD instance but instead place the message on the metrics topic.
+If the message is from the [Workflow Router](https://github.com/teamhephy/router) we build an Influxdb compatible message and send it to the same NSQD instance but instead place the message on the metrics topic.
 
 Logger then acts as a consumer reading messages off of the NSQ logs topic storing those messages in a local Redis instance. When a user wants to retrieve log entries using the `deis logs` command we make an HTTP request from Controller to Logger which then fetches the appropriate data from Redis.
 
@@ -19,7 +19,7 @@ Even though we provide a redis instance with the default Workflow install, it is
 * port = "6379"
 * password = ""
 
-These can be changed by running `helm inspect values deis/workflow > values.yaml` before using
+These can be changed by running `helm inspect values hephy/workflow > values.yaml` before using
 `helm install` to complete the installation. To customize the redis credentials, edit `values.yaml`
 and modify the `redis` section of the file to tune these settings.
 
@@ -71,7 +71,7 @@ Error: There are currently no log messages. Please check the following things:
 By default the Fluentd pod can be configured to talk to numerous syslog endpoints. So for example it is possible to have Fluentd send log messages to both the Logger component and [Papertrail](https://papertrailapp.com/). This allows production deployments of Deis to satisfy stringent logging requirements such as offsite backups of log data.
 
 Configuring Fluentd to talk to multiple syslog endpoints means modifying the Fluentd daemonset
-manifest. This means you will need to fetch the chart with `helm fetch deis/workflow --untar`, then
+manifest. This means you will need to fetch the chart with `helm fetch hephy/workflow --untar`, then
 modify `workflow/charts/fluentd/templates/logger-fluentd-daemon.yaml` with the following:
 
 ```
@@ -101,7 +101,7 @@ Then run `helm install ./workflow --namespace deis` to install the modified char
 
 ### Customizing:
 
-We currently support logging information to Syslog, Elastic Search, and Sumo Logic. However, we will gladly accept pull requests that add support to other locations. For more information please visit the [fluentd repository](https://github.com/deisthree/fluentd).
+We currently support logging information to Syslog, Elastic Search, and Sumo Logic. However, we will gladly accept pull requests that add support to other locations. For more information please visit the [fluentd repository](https://github.com/teamhephy/fluentd).
 
 
 ### Custom Fluentd Plugins
@@ -134,4 +134,4 @@ fluentd:
     INSTALL_BUILD_TOOLS: "|\n              true"
 ```
 
-For more information please see the [Custom Plugins](https://github.com/deisthree/fluentd#custom-plugins) section of the README.
+For more information please see the [Custom Plugins](https://github.com/teamhephy/fluentd#custom-plugins) section of the README.

--- a/src/managing-workflow/platform-monitoring.md
+++ b/src/managing-workflow/platform-monitoring.md
@@ -41,7 +41,7 @@ We now include a monitoring stack for introspection on a running Kubernetes clus
 ```
 
 ## [Grafana](https://grafana.com/)
-Grafana allows users to create custom dashboards that visualize the data captured to the running InfluxDB component. By default Grafana is exposed using a [service annotation](https://github.com/deisthree/router#how-it-works) through the router at the following URL: `http://grafana.mydomain.com`. The default login is `admin/admin`. If you are interested in changing these values please see [Tuning Component Settings][].
+Grafana allows users to create custom dashboards that visualize the data captured to the running InfluxDB component. By default Grafana is exposed using a [service annotation](https://github.com/teamhephy/router#how-it-works) through the router at the following URL: `http://grafana.mydomain.com`. The default login is `admin/admin`. If you are interested in changing these values please see [Tuning Component Settings][].
 
 Grafana will preload several dashboards to help operators get started with monitoring Kubernetes and Deis Workflow.
 These dashboards are meant as starting points and don't include every item that might be desirable to monitor in a
@@ -54,7 +54,7 @@ A production install of Grafana should have the following configuration values c
 
 * Change the default username and password from `admin/admin`. The value for the password is passed in plain text so it is best to set this value on the command line instead of checking it into version control.
 * Enable persistence
-* Use a supported external database such as mysql or postgres. You can find more information [here](https://github.com/deisthree/monitor/blob/master/grafana/rootfs/usr/share/grafana/grafana.ini.tpl#L62)
+* Use a supported external database such as mysql or postgres. You can find more information [here](https://github.com/teamhephy/monitor/blob/master/grafana/rootfs/usr/share/grafana/grafana.ini.tpl#L62)
 
 
 ### On Cluster Persistence
@@ -109,7 +109,7 @@ Telegraf is the metrics collection daemon used within the monitoring stack. It w
 * Container level metrics such as CPU and Memory
 * Kubernetes metrics such as API request latency, Pod Startup Latency, and number of running pods
 
-It is possible to send these metrics to other endpoints besides InfluxDB. For more information please consult the following [file](https://github.com/deisthree/monitor/blob/master/telegraf/rootfs/config.toml.tpl)
+It is possible to send these metrics to other endpoints besides InfluxDB. For more information please consult the following [file](https://github.com/teamhephy/monitor/blob/master/telegraf/rootfs/config.toml.tpl)
 
 ### Customizing the Monitoring Stack
 

--- a/src/managing-workflow/tuning-component-settings.md
+++ b/src/managing-workflow/tuning-component-settings.md
@@ -4,15 +4,15 @@ Helm Charts are a set of Kubernetes manifests that reflect best practices for de
 application or service on Kubernetes.
 
 After you add the Deis Chart Repository, you can customize the chart using
-`helm inspect values deis/workflow > values.yaml` before using `helm install` to complete the
+`helm inspect values hephy/workflow > values.yaml` before using `helm install` to complete the
 installation.
 
 There are a few ways to customize the respective component:
 
  - If the value is exposed in the `values.yaml` file as derived above, one may modify the section of the component to tune these settings.  The modified value(s) will then take effect at chart installation or release upgrade time via either of the two respective commands:
 
-        $ helm install deis/workflow --namespace deis -f values.yaml
-        $ helm upgrade deis -f values.yaml
+        $ helm install hephy/workflow -n hephy --namespace deis -f values.yaml
+        $ helm upgrade hephy -f values.yaml
 
  - If the value hasn't yet been exposed in the `values.yaml` file, one may edit the component deployment with the tuned setting.  Here we edit the `deis-controller` deployment:
 
@@ -22,10 +22,10 @@ There are a few ways to customize the respective component:
 
  - Lastly, one may also fetch and edit the chart as served by version control/the chart repository itself:
 
-        $ helm fetch deis/workflow --untar
+        $ helm fetch hephy/workflow --untar
         $ $EDITOR workflow/charts/controller/templates/controller-deployment.yaml
 
-    Then run `helm install ./workflow --namespace deis --name deis` to apply the changes, or `helm upgrade deis ./workflow` if the cluster is already running.
+    Then run `helm install ./workflow --namespace deis --name hephy` to apply the changes, or `helm upgrade hephy ./workflow` if the cluster is already running.
 
 ## Setting Resource limits
 
@@ -39,7 +39,7 @@ limits set:
 
 ```
 builder:
-  org: "deisci"
+  org: "hephyci"
   pullPolicy: "Always"
   dockerTag: "canary"
   limits_cpu: "100m"
@@ -64,7 +64,7 @@ Setting                                         | Description
 REGISTRATION_MODE                               | set registration to "enabled", "disabled", or "admin_only" (default: "admin_only")
 GUNICORN_WORKERS                                | number of [gunicorn][] workers spawned to process requests (default: CPU cores * 4 + 1)
 RESERVED_NAMES                                  | a comma-separated list of names which applications cannot reserve for routing (default: "deis, deis-builder, deis-workflow-manager")
-SLUGRUNNER_IMAGE_NAME                           | the image used to run buildpack application slugs (default: "quay.io/deisci/slugrunner:canary")
+SLUGRUNNER_IMAGE_NAME                           | the image used to run buildpack application slugs (default: "quay.io/hephyci/slugrunner:canary")
 DEIS_DEPLOY_HOOK_URLS                           | a comma-separated list of URLs to send [deploy hooks][] to.
 DEIS_DEPLOY_HOOK_SECRET_KEY                     | a private key used to compute the HMAC signature for deploy hooks.
 DEIS_DEPLOY_REJECT_IF_PROCFILE_MISSING          | rejects a deploy if the previous build had a Procfile but the current deploy is missing it. A 409 is thrown in the API. Prevents accidental process types removal. (default: "false", allowed values: "true", "false")
@@ -129,7 +129,7 @@ output.disable_deis | false | Disable the Deis output plugin
 boot.install_build_tools | false | Install the build tools package. This is useful when using custom plugins
 daemon_environment | | Takes key-value pairs and turns them into environment variables.
 
-For more information about the various environment variables that can be set please see the [README](https://github.com/deisthree/fluentd/blob/master/README.md)
+For more information about the various environment variables that can be set please see the [README](https://github.com/teamhephy/fluentd/blob/master/README.md)
 
 ## Customizing the Logger
 
@@ -151,24 +151,24 @@ user   | "admin" | The first user created in the database (this user has admin p
 password | "admin" | Password for the first user.
 allow_sign_up | "true" | Allows users to sign up for an account.
 
-For a list of other options you can set by using environment variables please see the [configuration file](https://github.com/deisthree/monitor/blob/master/grafana/rootfs/usr/share/grafana/grafana.ini.tpl) in Github.
+For a list of other options you can set by using environment variables please see the [configuration file](https://github.com/teamhephy/monitor/blob/master/grafana/rootfs/usr/share/grafana/grafana.ini.tpl) in Github.
 
 ### [Telegraf](https://docs.influxdata.com/telegraf)
-For a list of configuration values that can be set by using environment variables please see the following [configuration file](https://github.com/deisthree/monitor/blob/master/telegraf/rootfs/config.toml.tpl).
+For a list of configuration values that can be set by using environment variables please see the following [configuration file](https://github.com/teamhephy/monitor/blob/master/telegraf/rootfs/config.toml.tpl).
 
 ### [InfluxDB](https://docs.influxdata.com/influxdb)
-You can find a list of values that can be set using environment variables [here](https://github.com/deisthree/monitor/blob/master/influxdb/rootfs/home/influxdb/config.toml.tpl).
+You can find a list of values that can be set using environment variables [here](https://github.com/teamhephy/monitor/blob/master/influxdb/rootfs/home/influxdb/config.toml.tpl).
 
 ## Customizing the Registry
 
 The [Registry][] component can be tuned by following the
-[deis/distribution config doc](https://github.com/deisthree/distribution/blob/master/docs/configuration.md).
+[teamhephy/distribution config doc](https://github.com/deis/distribution/blob/master/docs/configuration.md).
 
 ## Customizing the Router
 
 The majority of router settings are tunable through annotations, which allows the router to be
 re-configured with zero downtime post-installation. You can find the list of annotations to tune
-[here](https://github.com/deisthree/router#annotations).
+[here](https://github.com/teamhephy/router#annotations).
 
 The following environment variables are tunable for the [Router][] component:
 
@@ -182,10 +182,10 @@ The following environment variables are tunable for [Workflow Manager][]:
 
 Setting                            | Description
 ---------------------------------- | ---------------------------------
-CHECK_VERSIONS    | Enables the external version check at <https://versions.deis.com/> (default: "true")
+CHECK_VERSIONS    | Enables the external version check at <https://versions.teamhephy.info/> (default: "true")
 POLL_INTERVAL_SEC | The interval when Workflow Manager performs a version check, in seconds (default: 43200, or 12 hours)
-VERSIONS_API_URL  | The versions API URL (default: "<https://versions-staging.deis.com>")
-DOCTOR_API_URL    | The doctor API URL (default: "<https://doctor-staging.deis.com>")
+VERSIONS_API_URL  | The versions API URL (default: "<https://versions-staging.teamhephy.info>")
+DOCTOR_API_URL    | The doctor API URL (default: "<https://doctor-staging.teamhephy.info>")
 API_VERSION       | The version number Workflow Manager sends to the versions API (default: "v2")
 
 [Deploying Apps]: ../applications/deploying-apps.md

--- a/src/managing-workflow/upgrading-workflow.md
+++ b/src/managing-workflow/upgrading-workflow.md
@@ -31,7 +31,7 @@ First, find the name of the release helm gave to your deployment with `helm ls`,
 
 ```
 $ helm repo update
-$ helm upgrade <release-name> deis/workflow
+$ helm upgrade <release-name> hephy/workflow
 ```
 
 
@@ -39,7 +39,7 @@ $ helm upgrade <release-name> deis/workflow
 
 ```
 $ B64_KEY_JSON="$(cat ~/path/to/key.json | base64 -w 0)"
-$ helm upgrade <release_name> deis/workflow -f values.yaml --set gcs.key_json="${B64_KEY_JSON}",registry-token-refresher.gcr.key_json="${B64_KEY_JSON}"
+$ helm upgrade <release_name> hephy/workflow -f values.yaml --set gcs.key_json="${B64_KEY_JSON}",registry-token-refresher.gcr.key_json="${B64_KEY_JSON}"
 ```
 
 Alternatively, simply replace the appropriate values in values.yaml and do without the `--set`
@@ -87,6 +87,6 @@ curl -sSL http://deis.io/deis-cli/install-v2.sh | bash && sudo mv deis $(which d
 ```
 
 
-[minio]: https://github.com/deisthree/minio
+[minio]: https://github.com/teamhephy/minio
 [Configuring Object Storage]: ../installing-workflow/configuring-object-storage.md
-[Workflow-Migration]: https://github.com/deisthree/workflow-migration/blob/master/README.md
+[Workflow-Migration]: https://github.com/teamhephy/workflow-migration/blob/master/README.md

--- a/src/quickstart/deploy-an-app.md
+++ b/src/quickstart/deploy-an-app.md
@@ -129,8 +129,8 @@ There is a lot more you can do with Deis Workflow, play around with the CLI:
 * Roll back to a previous release with `deis rollback -a proper-barbecue`
 * See application logs with `deis logs -a proper-barbecue`
 * Try one of our other example applications like:
-    * [deis/example-ruby-sinatra](https://github.com/deisthree/example-ruby-sinatra)
-    * [deis/example-nodejs-express](https://github.com/deisthree/example-nodejs-express)
-    * [deis/example-java-jetty](https://github.com/deisthree/example-java-jetty)
+    * [deis/example-ruby-sinatra](https://github.com/teamhephy/example-ruby-sinatra)
+    * [deis/example-nodejs-express](https://github.com/teamhephy/example-nodejs-express)
+    * [deis/example-java-jetty](https://github.com/teamhephy/example-java-jetty)
 * Read about using application [Buildpacks](../applications/using-buildpacks) or [Dockerfiles](../applications/using-dockerfiles.md)
 * Join our [#community slack channel](https://slack.deis.io) and meet the team!

--- a/src/roadmap/releases.md
+++ b/src/roadmap/releases.md
@@ -62,7 +62,7 @@ Major or minor releases should happen on the master branch. Patch releases
 should check out the previous release tag and cherry-pick specific commits from master.
 
 **Note:** if a patch release, the release artifact will have to be manually promoted by triggering
-the [component-promote](https://ci.deis.io/job/component-promote) job with the following values:
+the [component-promote](https://ci.teamhephy.info/job/component-promote) job with the following values:
 
 ```bash
 COMPONENT_NAME=<component name>
@@ -86,7 +86,7 @@ Creating changelog for controller with tag v2.8.1 through commit 943a49267eeb285
 
 #### Fixes
 
-- [`615b834`](https://github.com/deisthree/controller/commit/615b834f39cb68a854cc1f1e2f0f82d862ea2731) boot: Ensure DEIS_DEBUG==true for debug output
+- [`615b834`](https://github.com/teamhephy/controller/commit/615b834f39cb68a854cc1f1e2f0f82d862ea2731) boot: Ensure DEIS_DEBUG==true for debug output
 ```
 
 Based on the changelog content, determine whether the component deserves a minor or patch
@@ -103,7 +103,7 @@ Creating changelog for controller with tag v2.8.1 through commit 943a49267eeb285
 
 #### Fixes
 
-- [`615b834`](https://github.com/deisthree/controller/commit/615b834f39cb68a854cc1f1e2f0f82d862ea2731) boot: Ensure DEIS_DEBUG==true for debug output
+- [`615b834`](https://github.com/teamhephy/controller/commit/615b834f39cb68a854cc1f1e2f0f82d862ea2731) boot: Ensure DEIS_DEBUG==true for debug output
 
 
 Please review the above changelog contents and ensure:
@@ -111,21 +111,21 @@ Please review the above changelog contents and ensure:
   2. The changes agree with the semver release tag (major, minor, or patch)
 
 Create release for Deis Controller v2.8.2? [y/n]: y
-New release is available at https://github.com/deisthree/controller/releases/tag/v2.8.2
+New release is available at https://github.com/teamhephy/controller/releases/tag/v2.8.2
 ```
 
 ### Step 2: Verify the Component is Available
 
 Tagging the component (see [Step 1](/roadmap/releases/#step-1-update-code-and-run-the-release-tool))
 starts a CI job that eventually results in an artifact being made available for public download.
-Please see the [CI flow diagrams](https://github.com/deisthree/jenkins-jobs/#flow) for details.
+Please see the [CI flow diagrams](https://github.com/teamhephy/jenkins-jobs/#flow) for details.
 
 Double-check that the artifact is available, either by a `docker pull` command or by running the
 appropriate installer script.
 
 If the artifact can't be downloaded, ensure that its CI release jobs are still in progress, or
 fix whatever issue arose in the pipeline. For example, the
-[master merge pipeline](https://github.com/deisthree/jenkins-jobs/#when-a-component-pr-is-merged-to-master)
+[master merge pipeline](https://github.com/teamhephy/jenkins-jobs/#when-a-component-pr-is-merged-to-master)
 may have failed to promote the `:git-abc1d23` candidate image and needs to be restarted with
 that component and commit.
 
@@ -134,7 +134,7 @@ this chart will also be packaged, signed and uploaded to its production chart re
 verify it can be fetched (and verified):
 
 ```
-$ helm repo add controller https://charts.deis.com/controller
+$ helm repo add controller https://charts.teamhephy.com/controller
 "controller" has been added to your repositories
 $ helm fetch --verify controller/controller --version v2.17.0
 Verification: &{0xc4207ec870 sha256:026e766e918ff28d2a7041bc3d560d149ee7eb0cb84165c9d9d00a3045ff45c3 controller-v2.17.0.tgz}
@@ -159,15 +159,15 @@ Some Workflow components not in the Helm chart must also be tagged in sync with 
 Follow the [component release process](#how-to-release-a-component) above and ensure that
 these components are tagged:
 
-- [deis/workflow-cli][]
-- [deis/workflow-e2e][]
+- [teamhephy/workflow-cli][]
+- [teamhephy/workflow-e2e][]
 
-The version number for [deis/workflow-cli][] should always match the overall Workflow version
+The version number for [teamhephy/workflow-cli][] should always match the overall Workflow version
 number.
 
 ### Step 3: Create Helm Chart
 
-To create and stage a release candidate chart for Workflow, we will build the [workflow-chart-stage](https://ci.deis.io/job/workflow-chart-stage) job with the following parameters:
+To create and stage a release candidate chart for Workflow, we will build the [workflow-chart-stage](https://ci.teamhephy.info/job/workflow-chart-stage) job with the following parameters:
 
 `RELEASE_TAG=$WORKFLOW_RELEASE`
 
@@ -192,7 +192,7 @@ When showstopper-level bugs are found, the process is as follows:
 
 ### Step 5: Release the Chart
 
-When testing has completed without uncovering any new showstopper bugs, kick off the [workflow-chart-release](https://ci.deis.io/job/workflow-chart-release) job with the following parameter:
+When testing has completed without uncovering any new showstopper bugs, kick off the [workflow-chart-release](https://ci.teamhephy.info/job/workflow-chart-release) job with the following parameter:
 
 `RELEASE_TAG=$WORKFLOW_RELEASE`
 
@@ -204,13 +204,13 @@ it if it has not done so already.
 Each component already updated its release notes on GitHub with CHANGELOG content. We'll now
 generate the master changelog for the Workflow chart, consisting of all component and auxilliary repo changes.
 
-We'll employ the `requirements.lock` file from the `WORKFLOW_PREV_RELEASE` chart, as well as a repo-to-chart-name [mapping file](https://github.com/deisthree/deisrel/blob/master/map.json), this time invoking `deisrel changelog global` to get all component changes between
+We'll employ the `requirements.lock` file from the `WORKFLOW_PREV_RELEASE` chart, as well as a repo-to-chart-name [mapping file](https://github.com/teamhephy/deisrel/blob/master/map.json), this time invoking `deisrel changelog global` to get all component changes between
 the chart versions existing in the `WORKFLOW_PREV_RELEASE` chart and the _most recent_ releases existing in GitHub.
 (Therefore, if there are any unreleased commits in a component repo, they will not appear here):
 
 ```bash
-helm repo add deis https://charts.deis.com/workflow
-helm fetch --untar deis/workflow --version $WORKFLOW_PREV_RELEASE
+helm repo add hephy https://charts.teamhephy.com/workflow
+helm fetch --untar hephy/workflow --version $WORKFLOW_PREV_RELEASE
 deisrel changelog global workflow/requirements.lock map.json > changelog-$WORKFLOW_RELEASE.md
 ```
 
@@ -219,7 +219,7 @@ update PR created in the next step.
 
 ### Step 7: Update Documentation
 
-Create a new pull request at [deis/workflow][] that updates version references to the new release.
+Create a new pull request at [teamhephy/workflow][] that updates version references to the new release.
 Use `git grep $WORKFLOW_PREV_RELEASE` to find any references, but be careful not to change
 `CHANGELOG.md`.
 
@@ -231,24 +231,24 @@ Make sure to add a header to the page to make it clear that this is for a Workfl
 ```
 
 Once the PR has been reviewed and merged, do a [component release](#how-to-release-a-component) of
-[deis/workflow][] itself. The version number for [deis/workflow][] should always match the
+[teamhephy/workflow][] itself. The version number for [teamhephy/workflow][] should always match the
 overall Workflow version number.
 
 ### Step 8: Close GitHub Milestones
 
-Create a pull request at [seed-repo](https://github.com/deisthree/seed-repo) to close the release
+Create a pull request at [seed-repo](https://github.com/teamhephy/seed-repo) to close the release
 milestone and create the next one. When changes are merged to seed-repo, milestones on all
 relevant projects will be updated. If there are open issues attached to the milestone, move them
 to the next upcoming milestone before merging the pull request.
 
-Milestones map to Deis Workflow releases in [deis/workflow][]. These milestones do not correspond
+Milestones map to Deis Workflow releases in [teamhephy/workflow][]. These milestones do not correspond
 to individual component release tags.
 
 ### Step 9: Release Workflow CLI Stable
 
 Now that the `$WORKFLOW_RELEASE` version of Workflow CLI has been vetted, we can push `stable` artifacts based on this version.
 
-Kick off https://ci.deis.io/job/workflow-cli-build-stable/ with the `TAG` build parameter of `$WORKFLOW_RELEASE`
+Kick off https://ci.teamhephy.info/job/workflow-cli-build-stable/ with the `TAG` build parameter of `$WORKFLOW_RELEASE`
 and then verify `stable` artifacts are available and appropriately updated after the job completes:
 
 ```
@@ -265,16 +265,16 @@ master CHANGELOG:
 
 ```
 @here Deis Workflow v2.17.0 is now live!
-Master CHANGELOG: https://deis.com/docs/workflow/changelogs/v2.17.0/
+Master CHANGELOG: https://teamhephy.info/docs/workflow/changelogs/v2.17.0/
 ```
 
 You're done with the release. Nice job!
 
 [component release]: /roadmap/releases/#how-to-release-a-component
 [continuous delivery]: https://en.wikipedia.org/wiki/Continuous_delivery
-[deis/workflow]: https://github.com/deisthree/workflow
-[deis/workflow-cli]: https://github.com/deisthree/workflow-cli
-[deis/workflow-e2e]: https://github.com/deisthree/workflow-e2e
-[deisrel]: https://github.com/deisthree/deisrel
+[teamhephy/workflow]: https://github.com/teamhephy/workflow
+[teamhephy/workflow-cli]: https://github.com/teamhephy/workflow-cli
+[teamhephy/workflow-e2e]: https://github.com/teamhephy/workflow-e2e
+[deisrel]: https://github.com/teamhephy/deisrel
 [Kubernetes Helm]: https://github.com/kubernetes/helm
 [semantic version]: http://semver.org

--- a/src/roadmap/roadmap.md
+++ b/src/roadmap/roadmap.md
@@ -14,12 +14,12 @@ their application environment.
 
 Related issues:
 
-* <https://github.com/deisthree/workflow-cli/issues/98>
-* <https://github.com/deisthree/deis/issues/117>
+* <https://github.com/teamhephy/workflow-cli/issues/28>
+* <https://github.com/deis/deis/issues/117>
 
 ## Log Streaming
 
-Stream application logs via `deis logs -f` <https://github.com/deisthree/deis/issues/465>
+Stream application logs via `deis logs -f` <https://github.com/deis/deis/issues/465>
 
 ## Teams and Permissions
 
@@ -30,21 +30,21 @@ reconciled for Deis Workflow before we begin implementation.
 
 Related issues:
 
-* Deploy Keys: <https://github.com/deisthree/deis/issues/3875>
-* Teams: <https://github.com/deisthree/deis/issues/4173>
-* Fine grained permissions: <https://github.com/deisthree/deis/issues/4150>
-* Admins create apps only: <https://github.com/deisthree/deis/issues/4052>
-* Admin Certificate Permissions: <https://github.com/deisthree/deis/issues/4576#issuecomment-170987223>
+* Deploy Keys: <https://github.com/deis/deis/issues/3875>
+* Teams: <https://github.com/deis/deis/issues/4173>
+* Fine grained permissions: <https://github.com/deis/deis/issues/4150>
+* Admins create apps only: <https://github.com/deis/deis/issues/4052>
+* Admin Certificate Permissions: <https://github.com/deis/deis/issues/4576#issuecomment-170987223>
 
 ## Monitoring
 
-* [ ] Define and deliver alerts with Kapacitor: <https://github.com/deisthree/monitor/issues/44>
+* [ ] Define and deliver alerts with Kapacitor: <https://github.com/deis/monitor/issues/44>
 
 ## Workflow Addons/Services
 
 Developers should be able to quickly and easily provision application
 dependencies using a services or addon abstraction.
-<https://github.com/deisthree/deis/issues/231>
+<https://github.com/deis/deis/issues/231>
 
 ## Inbound/Outbound Webhooks
 
@@ -52,4 +52,4 @@ Deis Workflow should be able to send and receive webhooks from external
 systems. Facilitating integration with third party services like GitHub,
 Gitlab, Slack, Hipchat.
 
-* [X] Send webhook on platform events: <https://github.com/deisthree/deis/issues/1486> (Workflow v2.10)
+* [X] Send webhook on platform events: <https://github.com/deis/deis/issues/1486> (Workflow v2.10)

--- a/src/troubleshooting/index.md
+++ b/src/troubleshooting/index.md
@@ -29,6 +29,6 @@ Running into something not detailed here? Please [open an issue][issue] or hop i
 [#community on Slack][slack] for help!
 
 [kubectl]: kubectl.md
-[issue]: https://github.com/deisthree/workflow/issues/new
+[issue]: https://github.com/teamhephy/workflow/issues/new
 [slack]: http://slack.deis.io/
 [troubleshooting-app]: applications.md

--- a/src/understanding-workflow/components.md
+++ b/src/understanding-workflow/components.md
@@ -12,7 +12,7 @@ the functionality in your own project we invite you to give it a shot!
 
 ## Controller
 
-**Project Location:** [deis/controller](https://github.com/deisthree/controller)
+**Project Location:** [teamhephy/controller](https://github.com/teamhephy/controller)
 
 The controller component is an HTTP API server which serves as the endpoint for
 the `deis` CLI. The controller provides all of the platform functionality as
@@ -21,7 +21,7 @@ of its data to the database component.
 
 ## Database
 
-**Project Location:** [deis/postgres](https://github.com/deisthree/postgres)
+**Project Location:** [teamhephy/postgres](https://github.com/teamhephy/postgres)
 
 The database component is a managed instance of [PostgreSQL][] which holds a
 majority of the platforms state. Backups and WAL files are pushed to object
@@ -30,7 +30,7 @@ replayed from object storage so no data is lost.
 
 ## Builder
 
-**Project Location:** [deis/builder](https://github.com/deisthree/builder)
+**Project Location:** [teamhephy/builder](https://github.com/teamhephy/builder)
 
 
 The builder component is responsible for accepting code pushes via [Git][] and
@@ -44,7 +44,7 @@ managing the build process of your [Application][]. The builder process is:
 
 Builder currently supports both buildpack and Dockerfile based builds.
 
-**Project Location:** [deis/slugbuilder](https://github.com/deisthree/slugbuilder)
+**Project Location:** [teamhephy/slugbuilder](https://github.com/teamhephy/slugbuilder)
 
 For Buildpack-based deploys, the builder component will launch a one-shot Pod
 in the `deis` namespace. This pod runs `slugbuilder` component which handles
@@ -54,7 +54,7 @@ its dependencies as determined by the buildpack. The slug is pushed to the
 cluster-configured object storage for later execution. For more information
 about buildpacks see [using buildpacks][using-buildpacks].
 
-**Project Location:** [deis/dockerbuilder](https://github.com/deisthree/dockerbuilder)
+**Project Location:** [teamhephy/dockerbuilder](https://github.com/teamhephy/dockerbuilder)
 
 For Applications which contain a `Dockerfile` in the root of the repository,
 `builder` will instead launch the `dockerbuilder` to package your application.
@@ -64,7 +64,7 @@ Docker registry on cluster. For more information see [using Dockerfiles][using-d
 
 ## Slugrunner
 
-**Project Location:** [deis/slugrunner](https://github.com/deisthree/slugrunner)
+**Project Location:** [teamhephy/slugrunner](https://github.com/teamhephy/slugrunner)
 
 Slugrunner is the component responsible for executing buildpack-based
 Applications. Slugrunner receives slug information from the controller and
@@ -73,7 +73,7 @@ processes.
 
 ## Object Storage
 
-**Project Location:** [deis/minio](https://github.com/deisthree/minio)
+**Project Location:** [teamhephy/minio](https://github.com/teamhephy/minio)
 
 All of the Workflow components that need to persist data will ship them to the
 object storage that was configured for the cluster.For example, database ships
@@ -90,7 +90,7 @@ configure minio to use persistent storage available in your environment.
 
 ## Registry
 
-**Project Location:** [deis/registry](https://github.com/deisthree/registry)
+**Project Location:** [teamhephy/registry](https://github.com/teamhephy/registry)
 
 The registry component is a managed docker registry which holds application
 images generated from the builder component. Registry persists the Docker image
@@ -99,7 +99,7 @@ configured for the cluster.
 
 ## Router
 
-**Project Location:** [deis/router](https://github.com/deisthree/router)
+**Project Location:** [teamhephy/router](https://github.com/teamhephy/router)
 
 The router component is based on [Nginx][] and is responsible for routing
 inbound HTTP(S) traffic to your applications. The default workflow charts
@@ -117,14 +117,14 @@ The logging subsystem consists of two components. Fluentd handles log shipping
 and logger maintains a ring-buffer of application logs.
 
 
-**Project Location:** [deis/fluentd](https://github.com/deisthree/fluentd)
+**Project Location:** [teamhephy/fluentd](https://github.com/teamhephy/fluentd)
 
 Fluentd is deployed to your Kubernetes cluster via Daemon Sets. Fluentd
 subscribes to all container logs, decorates the output with Kubernetes metadata
 and can be configured to drain logs to multiple destinations. By default,
 fluentd ships logs to the logger component, which powers `deis logs`.
 
-**Project Location:** [deis/logger](https://github.com/deisthree/logger)
+**Project Location:** [teamhephy/logger](https://github.com/teamhephy/logger)
 
 The `logger` component receives log streams from `fluentd`, collating by
 Application name. Logger does not persist logs to disk, instead maintaining an
@@ -133,7 +133,7 @@ documentation][logger-documentation].
 
 ## Monitor
 
-**Project Location:** [deis/monitor](https://github.com/deisthree/monitor)
+**Project Location:** [teamhephy/monitor](https://github.com/teamhephy/monitor)
 
 The monitoring subsystem consists of three components: Telegraf, InfluxDB and Grafana.
 
@@ -152,7 +152,7 @@ as a starting point for creating more custom dashboards to suit a user's needs.
 
 ## Workflow Manager
 
-**Project Location:** [deis/workflow-manager](https://github.com/deisthree/workflow-manager)
+**Project Location:** [teamhephy/workflow-manager](https://github.com/teamhephy/workflow-manager)
 
 `Workflow Manager` will regularly check your cluster against the latest stable
 components. If components are missing due to failure or are simply out of date,
@@ -175,9 +175,9 @@ Workflow Manager's Deployment.
 [architecture]: architecture.md
 [concepts]: concepts.md
 [configure-objectstorage]: ../installing-workflow/configuring-object-storage.md
-[logger-documentation]: https://github.com/deisthree/logger
+[logger-documentation]: https://github.com/teamhephy/logger
 [release]: ../reference-guide/terms.md#release
-[router-documentation]: https://github.com/deisthree/router
+[router-documentation]: https://github.com/teamhephy/router
 [router]: #router
 [using-buildpacks]: ../applications/using-buildpacks.md
 [using-dockerfiles]: ../applications/using-dockerfiles.md

--- a/themes/deis/footer.html
+++ b/themes/deis/footer.html
@@ -62,7 +62,7 @@
               <dt><a id="footer-projects" href="https://deis.com/workflow">Projects</a></dt>
               <dd><a id="footer-workflow" href="https://deis.com/workflow">Workflow</a></dd>
               <dd><a id="footer-helm" href="//helm.sh">Helm</a></dd>
-              <dd><a id="footer-steward" href="https://github.com/deisthree/steward">Steward</a></dd>
+              <dd><a id="footer-steward" href="https://github.com/deis/steward">Steward</a></dd>
             </dl>
           </div>
           <div class="small-6 medium-3 columns">

--- a/themes/deis/topbar.html
+++ b/themes/deis/topbar.html
@@ -43,7 +43,7 @@
       <h3>Helm</h3>
       <p>The Package manager for Kubernetes.</p>
     </a></li>
-    <li class="small-6 medium-4 end columns"><a href="https://github.com/deisthree/steward" title="Steward">
+    <li class="small-6 medium-4 end columns"><a href="https://github.com/deis/steward" title="Steward">
       <img src="{{ base_url }}/static/img/svg/steward-logo.svg" alt="Steward - The Kubernetes-native Service Broker">
       <h3>Steward</h3>
       <p>The Kubernetes-native Service Broker.</p>


### PR DESCRIPTION
This is the Deis Docs repo.  This PR is the set of changes I've applied to teamhephy/workflow in order to make https://docs.teamhephy.info

I'm trying to carefully ensure that all links are maintained in good working order or ported forward if needed, so I reverted some "deisthree" strings to plain old "deis" where it made sense, and changed some remaining "deis" and "deisthree" strings into "teamhephy" or "hephy" where it made sense.

We've rebuilt the charts as http://charts.teamhephy.info/ and that's usable now, except for the minor component workflow-manager which still believes all of the components should be called `deis-*`: https://github.com/teamhephy/workflow-manager/issues/2

There are a lot of moving parts labeled "deis" and it's going to be a fairly long process to change them all to say "hephy".  Some of them may stay the way they are, but docs should all be updated before our work is done.

This process should not be short-circuited as the update will serve as a reminder that we have visited and rebuilt a component and at least nominally confirmed it works in the new hephy builds.

Notably, at least for now, the namespace to deploy into has to stay `deis` because one of the components has hardcoded a reference to the Kubernetes namespace `deis` (and I can't remember which, or I'd tell you...) this will break if you tried to deploy Deis/Hephy into another namespace.