### PR TITLE
Close #84

### DIFF
--- a/src/_includes/install-workflow.md
+++ b/src/_includes/install-workflow.md
@@ -10,22 +10,22 @@ Server: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b
 
 Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.
 
-## Add the Deis Chart Repository
+## Add the Hephy Chart Repository
 
-The Deis Chart Repository contains everything needed to install Deis Workflow onto a Kubernetes cluster, with a single `helm install deis/workflow --namespace deis` command.
+The Team Hephy Chart Repository contains everything needed to install Hephy Workflow onto a Kubernetes cluster, with a single `helm install hephy/workflow --namespace deis` command.
 
 Add this repository to Helm:
 
 ```
-$ helm repo add deis https://charts.deis.com/workflow
+$ helm repo add hephy https://charts.teamhephy.com/
 ```
 
-## Install Deis Workflow
+## Install Hephy Workflow
 
 Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helm install deis/workflow --namespace deis
+$ helm install hephy/workflow --namespace deis
 ```
 
 Helm will install a variety of Kubernetes resources in the `deis` namespace.

--- a/src/installing-workflow/chart-provenance.md
+++ b/src/installing-workflow/chart-provenance.md
@@ -31,10 +31,10 @@ $ curl https://keybase.io/deis/key.asc | gpg --import
 Charts signed with this key can then be verified when fetched:
 
 ```
-$ helm repo add deis https://charts.deis.com/workflow
-"deis" has been added to your repositories
+$ helm repo add hephy https://charts.teamhephy.com/
+"hephy" has been added to your repositories
 
-$ helm fetch --verify deis/workflow --version v2.17.0
+$ helm fetch --verify hephy/workflow --version v2.17.0
 Verification: &{0xc420704c80 sha256:a2a140dca075a2eabe20422f1aa5bc1ce210b18a326472d6b2708e1a93afebea workflow-v2.17.0.tgz}
 ```
 
@@ -43,13 +43,13 @@ One can then inspect the fetched `workflow-v2.17.0.tgz.prov` provenance file.
 If the chart was not signed, the command above would result in:
 
 ```
-Error: Failed to fetch provenance "https://charts.deis.com/workflow/workflow-v2.17.0.tgz.prov"
+Error: Failed to fetch provenance "https://charts.teamhephy.com/workflow-v2.17.0.tgz.prov"
 ```
 
 Alternatively, the chart can also be verified at install time:
 
 ```
-$ helm install --verify deis/workflow --namespace deis
+$ helm install --verify hephy/workflow --namespace deis
 NAME:   exiled-mink
 LAST DEPLOYED: Wed Aug  9 08:22:16 2017
 NAMESPACE: deis

--- a/src/installing-workflow/configuring-object-storage.md
+++ b/src/installing-workflow/configuring-object-storage.md
@@ -29,7 +29,7 @@ If you are using AWS S3 and your Kubernetes nodes are configured with appropriat
 
 ### Step 3: Add Deis Repo
 
-If you haven't already added the Helm repo, do so with `helm repo add deis https://charts.deis.com/workflow`
+If you haven't already added the Helm repo, do so with `helm repo add hephy https://charts.teamhephy.com/`
 
 ### Step 4: Configure Workflow Chart
 

--- a/src/installing-workflow/index.md
+++ b/src/installing-workflow/index.md
@@ -1,13 +1,13 @@
-# Installing Deis Workflow
+# Installing Hephy Workflow
 
 This document is aimed at those who have already provisioned a [Kubernetes v1.3.4+][] cluster
-and want to install Deis Workflow. If help is required getting started with Kubernetes and
-Deis Workflow, follow the [quickstart guide](../quickstart/index.md) for assistance.
+and want to install Hephy Workflow. If help is required getting started with Kubernetes and
+Hephy Workflow, follow the [quickstart guide](../quickstart/index.md) for assistance.
 
 ## Prerequisites
 
 1. Verify the [Kubernetes system requirements](system-requirements.md)
-1. Install [Helm and Deis Workflow CLI](../quickstart/install-cli-tools.md) tools
+1. Install [Helm and Hephy Workflow CLI](../quickstart/install-cli-tools.md) tools
 
 ## Check Your Setup
 
@@ -36,7 +36,7 @@ If `helm` is already installed in cluster without sufficient rights, simply add 
 
 ## Choose Your Deployment Strategy
 
-Deis Workflow includes everything it needs to run out of the box. However, these defaults are aimed at simplicity rather than
+Hephy Workflow includes everything it needs to run out of the box. However, these defaults are aimed at simplicity rather than
 production readiness. Production and staging deployments of Workflow should, at a minimum, use off-cluster storage
 which is used by Workflow components to store and backup critical data. Should an operator need to completely re-install
 Workflow, the required components can recover from off-cluster storage. See the documentation for [configuring object
@@ -52,22 +52,22 @@ More rigorous installations would benefit from using outside sources for the fol
 
 Workflow now offers [experimental native ingress](experimental-native-ingress.md) to take advantage of native Kubernetes routing. Any compatible Kubernetes ingress controller can be used in place of Workflow's nginx-based deis-router. Follow [this guide](experimental-native-ingress.md) to enable experimental native ingress.
 
-## Add the Deis Chart Repository
+## Add the Hephy Chart Repository
 
-The Deis Chart Repository contains everything needed to install Deis Workflow onto a Kubernetes cluster, with a single `helm install deis/workflow --namespace deis` command.
+The Team Hephy Chart Repository contains everything needed to install Hephy Workflow onto a Kubernetes cluster, with a single `helm install hephy/workflow --namespace deis` command.
 
 Add this repository to Helm:
 
 ```
-$ helm repo add deis https://charts.deis.com/workflow
+$ helm repo add hephy https://charts.teamhephy.com/
 ```
 
-## Install Deis Workflow
+## Install Hephy Workflow
 
 Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helm install deis/workflow --namespace deis
+$ helm install hephy/workflow --namespace deis
 ```
 
 Helm will install a variety of Kubernetes resources in the `deis` namespace.
@@ -109,10 +109,10 @@ deis-router-2126433040-6sl6z             1/1       Running   0          4m
 deis-workflow-manager-2528409207-jkz2r   1/1       Running   0          4m
 ```
 
-Once all of the pods are in the `READY` state, Deis Workflow is up and running!
+Once all of the pods are in the `READY` state, Hephy Workflow is up and running!
 
 After installing Workflow, [register a user and deploy an application](../quickstart/deploy-an-app.md).
 
 [Kubernetes v1.3.4+]: system-requirements.md#kubernetes-versions
 [helm]: https://github.com/kubernetes/helm/blob/master/docs/install.md
-[valuesfile]: https://charts.deis.com/workflow/values-v2.17.0.yaml
+[valuesfile]: https://charts.teamhephy.com/workflow/values-v2.17.0.yaml

--- a/src/managing-workflow/tuning-component-settings.md
+++ b/src/managing-workflow/tuning-component-settings.md
@@ -64,7 +64,7 @@ Setting                                         | Description
 REGISTRATION_MODE                               | set registration to "enabled", "disabled", or "admin_only" (default: "admin_only")
 GUNICORN_WORKERS                                | number of [gunicorn][] workers spawned to process requests (default: CPU cores * 4 + 1)
 RESERVED_NAMES                                  | a comma-separated list of names which applications cannot reserve for routing (default: "deis, deis-builder, deis-workflow-manager")
-SLUGRUNNER_IMAGE_NAME                           | the image used to run buildpack application slugs (default: "quay.io/hephyci/slugrunner:canary")
+SLUGRUNNER_IMAGE_NAME                           | the image used to run buildpack application slugs (default: "hephy/slugrunner:v2.6.1")
 DEIS_DEPLOY_HOOK_URLS                           | a comma-separated list of URLs to send [deploy hooks][] to.
 DEIS_DEPLOY_HOOK_SECRET_KEY                     | a private key used to compute the HMAC signature for deploy hooks.
 DEIS_DEPLOY_REJECT_IF_PROCFILE_MISSING          | rejects a deploy if the previous build had a Procfile but the current deploy is missing it. A 409 is thrown in the API. Prevents accidental process types removal. (default: "false", allowed values: "true", "false")

--- a/src/quickstart/provider/azure-acs/install-azure-acs.md
+++ b/src/quickstart/provider/azure-acs/install-azure-acs.md
@@ -1,4 +1,4 @@
-# Install Deis Workflow on Azure Container Service
+# Install Hephy Workflow on Azure Container Service
 
 ## Check Your Setup
 
@@ -17,14 +17,14 @@ helm init
 
 Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.
 
-## Add the Deis Chart Repository
+## Add the Hephy Chart Repository
 
-The Deis Chart Repository contains everything needed to install Deis Workflow onto a Kubernetes cluster, with a single `helm install deis/workflow --namespace deis` command.
+The Team Hephy Chart Repository contains everything needed to install Hephy Workflow onto a Kubernetes cluster, with a single `helm install hephy/workflow --namespace deis` command.
 
 Add this repository to Helm:
 
 ```
-$ helm repo add deis https://charts.deis.com/workflow
+$ helm repo add hephy https://charts.teamhephy.com/
 ```
 
 ## Create New Azure Storage Account
@@ -39,12 +39,12 @@ $ export AZURE_SA_KEY=`az storage account keys list -n $AZURE_SA_NAME -g $AZURE_
 
  > Note: Premium Storage skus are not supported yet due to [lack of block blob storage support](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/using-blob-service-operations-with-azure-premium-storage) required for the deis database to function.
 
-## Install Deis Workflow
+## Install Hephy Workflow
 
 Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helm install deis/workflow --namespace=deis --set global.storage=azure,azure.accountname=$AZURE_SA_NAME,azure.accountkey=$AZURE_SA_KEY,azure.registry_container=registry,azure.database_container=database,azure.builder_container=builder
+$ helm install hephy/workflow --namespace=deis --set global.storage=azure,azure.accountname=$AZURE_SA_NAME,azure.accountkey=$AZURE_SA_KEY,azure.registry_container=registry,azure.database_container=database,azure.builder_container=builder
 ```
 
 Helm will install a variety of Kubernetes resources in the `deis` namespace.
@@ -81,7 +81,7 @@ deis-router-k1ond             1/1       Running   0          5m
 deis-workflow-manager-68nu6   1/1       Running   0          5m
 ```
 
-Once all of the pods are in the `READY` state, Deis Workflow is up and running!
+Once all of the pods are in the `READY` state, Hephy Workflow is up and running!
 
 Next, [configure dns](dns.md) so you can register your first user and deploy an application.
 

--- a/src/quickstart/provider/minikube/install-minikube.md
+++ b/src/quickstart/provider/minikube/install-minikube.md
@@ -1,4 +1,4 @@
-# Install Deis Workflow on Minikube
+# Install Hephy Workflow on Minikube
 
 ## Check Your Setup
 
@@ -12,22 +12,22 @@ Server: &version.Version{SemVer:"v2.5.0", GitCommit:"012cb0ac1a1b2f888144ef5a67b
 
 Ensure the `kubectl` client is installed and can connect to your Kubernetes cluster.
 
-## Add the Deis Chart Repository
+## Add the Hephy Chart Repository
 
-The Deis Chart Repository contains everything needed to install Deis Workflow onto a Kubernetes cluster, with a single `helm install deis/workflow --namespace deis` command.
+The Team Hephy Chart Repository contains everything needed to install Hephy Workflow onto a Kubernetes cluster, with a single `helm install hephy/workflow --namespace deis` command.
 
 Add this repository to Helm:
 
 ```
-$ helm repo add deis https://charts.deis.com/workflow
+$ helm repo add hephy https://charts.teamhephy.com/
 ```
 
-## Install Deis Workflow
+## Install Hephy Workflow
 
 Now that Helm is installed and the repository has been added, install Workflow by running:
 
 ```
-$ helm install deis/workflow --namespace deis --set router.host_port.enabled=true
+$ helm install hephy/workflow --namespace deis --set router.host_port.enabled=true
 ```
 
 Helm will install a variety of Kubernetes resources in the `deis` namespace.
@@ -64,6 +64,6 @@ deis-router-k1ond             1/1       Running   0          5m
 deis-workflow-manager-68nu6   1/1       Running   0          5m
 ```
 
-Once all of the pods are in the `READY` state, Deis Workflow is up and running!
+Once all of the pods are in the `READY` state, Hephy Workflow is up and running!
 
 Next, [configure dns](dns.md) so you can register your first user and deploy an application.

--- a/src/troubleshooting/applications.md
+++ b/src/troubleshooting/applications.md
@@ -51,7 +51,12 @@ health checks to better suit the application's needs.
 [healthchecks]: ../applications/managing-app-configuration.md#custom-health-checks
 [troubleshooting-kubectl]: kubectl.md
 
-## Application fails to connect to external services
-If the app is trying to connect to external services located in same region as the kubernetes such ie. off-cluster database, it might fail depending on how the kubernetes automatic firewall is implemented.
+## Application or Workflow component fails to connect to external services
+If a Workflow pod is trying to connect to external services hosted in the cloud with the Kubernetes
+cluster, ie. off-cluster database, it might fail depending on the Kubernetes automatic firewall 
+configuration. Since Kubernetes 1.9.x, Google Cloud has implemented new Automatic Firewall rules.
 
-In order to trobleshoot, google cloud GKE has this [guide](https://cloud.google.com/kubernetes-engine/docs/troubleshooting#autofirewall) covering the auto firewall rules.
+In order to troubleshoot these issues with the automatic firewall, Google Cloud/GKE has provided
+this [guide][gke-autofirewall-guide] covering the auto firewall rules.
+
+[gke-autofirewall-guide]: https://cloud.google.com/kubernetes-engine/docs/troubleshooting#autofirewall


### PR DESCRIPTION
This PR fixes #84, removing references to the defunct charts.deis.com helm repo server.

I also updated the pointer to `quay.io/hephyci/slugrunner:canary` which was part of a big indiscriminate global search-and-replace.  I don't know how this image got chosen as the default for documentation.  Maybe "latest" would be good enough for the purposes of a ref like this one.

But #85 should stay open until we have a proper Canary version hosted somewhere or other.

(I do like quay.io for canary hosting, I'm just not sure why this image ref is here.)