### PR TITLE
docs(changelogs): add new patch release v2.20.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 |![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Hephy Workflow is the open source fork of Deis Workflow.<br />Please [read the announcement][] for more detail. |
 |---:|---|
+| 03/08/2019 | Hephy Workflow [v2.20.2][] patch release |
 | 02/14/2019 | Hephy Workflow [v2.20.1][] patch release |
 | 11/29/2018 | Hephy Workflow [v2.20.0][] new release|
 | 08/27/2018 | Team Hephy [blog][] comes online |
@@ -98,3 +99,4 @@ Then view the documentation on [http://localhost:8000](http://localhost:8000) or
 [v2.19.0]: https://gist.github.com/Cryptophobia/24c204583b18b9fc74c629fb2b62dfa3
 [v2.20.0]: https://gist.github.com/Cryptophobia/667cc30f42dc38d6784212eea00bfc58
 [v2.20.1]: https://gist.github.com/Cryptophobia/54b4d28f29c1f272fb892586a94f8223
+[v2.20.2]: https://gist.github.com/Cryptophobia/31f5cded1dc91719ea0c0a0d4a3d7ad7

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ pages:
     - Controller API v2.2: reference-guide/controller-api/v2.2.md
     - Controller API v2.3: reference-guide/controller-api/v2.3.md
   - Changelogs:
+    - v2.20.2: changelogs/v2.20.2.md
     - v2.20.1: changelogs/v2.20.1.md
     - v2.20.0: changelogs/v2.20.0.md
     - v2.19.0: changelogs/v2.19.0.md

--- a/src/changelogs/v2.20.2.md
+++ b/src/changelogs/v2.20.2.md
@@ -1,0 +1,27 @@
+
+## Workflow v2.20.1 -> v2.20.2
+
+#### Releases
+
+- controller v2.20.1 -> v2.20.2
+- postgres v2.7.2 -> v2.7.3
+- minio v2.4.3 -> v2.4.3
+- workflow v2.20.1 -> v2.20.2
+- workflow-cli v2.20.1 -> v2.20.2
+- workflow-e2e v2.20.1 -> v2.20.2
+
+#### Fixes
+
+- [`a6608b5`](https://github.com/teamhephy/postgres/commit/a6608b5b989b3b2713918bbd4ab709ca78bba320) (postgres) charts: fix to point to our hub.docker repository for images
+
+#### Documentation
+
+- [`5d71202`](https://github.com/teamhephy/workflow/commit/5d71202c9f9db7293bb49a6a865d702e9010a7ae) (workflow) - workflow: s/Deis/Hephy/,/charts.deis/hephy/
+- [`8f2433a`](https://github.com/teamhephy/workflow/commit/8f2433aa6a2811147154a62c6365d8fca18cb306) (workflow) - workflow: troubleshooting docs cleanup
+- [`354a281`](https://github.com/teamhephy/workflow/commit/354a2810cfb73b965afc41605f89ebbc08b08fe4) (workflow) - workflow: quay.io/hephyci is not the source
+
+#### Maintenance
+
+- [`b73da6e`](https://github.com/teamhephy/controller/commit/b73da6e6e08c07d87de8254ab496ed13e1d96c9f) (controller) - django: upgrade to django version 1.11.20 latest patch
+- [`b4af9c9`](https://github.com/teamhephy/controller/commit/b4af9c9427f15f179cac7fc1a37cd229d69a9d51) (controller) - *: Revert "set deployment API to apps/v1 if k8s >= 1.9"
+- [`acd588d`](https://github.com/teamhephy/minio/commit/acd588d1d7fd2f372069508fb1ea936cbe99d947) (minio) - minio: upgrading to the latest release

--- a/src/index.md
+++ b/src/index.md
@@ -9,7 +9,7 @@ application configuration, creating and rolling back releases, managing domain n
 certificates, providing seamless edge routing, aggregating logs, and sharing applications with
 teams. All of this is exposed through a simple REST API and command line interface.
 
-Please note that this documentation is for Hephy Workflow (v2.20.1).  Older versions of Deis and
+Please note that this documentation is for Hephy Workflow (v2.20.2).  Older versions of Deis and
 Hephy Workflow are not supported.
 
 ## Getting Started


### PR DESCRIPTION
It's official. Hephy Workflow v2.20.2