### PR TITLE
docs(changelogs): add new patch release v2.21.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 |![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Hephy Workflow is the open source fork of Deis Workflow.<br />Please [read the announcement][] for more detail. |
 |---:|---|
+| 09/11/2019 | Hephy Workflow [v2.21.3][] patch release |
 | 08/11/2019 | Hephy Workflow [v2.21.2][] patch release |
 | 06/21/2019 | Hephy Workflow [v2.21.1][] patch release |
 | 05/05/2019 | Hephy Workflow [v2.21.0][] release |
@@ -106,3 +107,4 @@ Then view the documentation on [http://localhost:8000](http://localhost:8000) or
 [v2.21.0]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.0.md
 [v2.21.1]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.1.md
 [v2.21.2]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.2.md
+[v2.21.3]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.3.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ pages:
     - Controller API v2.2: reference-guide/controller-api/v2.2.md
     - Controller API v2.3: reference-guide/controller-api/v2.3.md
   - Changelogs:
+    - v2.21.3: changelogs/v2.21.3.md
     - v2.21.2: changelogs/v2.21.2.md
     - v2.21.1: changelogs/v2.21.1.md
     - v2.21.0: changelogs/v2.21.0.md

--- a/src/changelogs/v2.21.3.md
+++ b/src/changelogs/v2.21.3.md
@@ -1,0 +1,21 @@
+## Workflow v2.21.2 -> v2.21.3
+
+#### Releases
+
+- router v2.16.0 -> v2.16.1
+- workflow v2.21.2 -> v2.21.3
+- workflow-cli v2.21.2 -> v2.21.3
+- workflow-e2e v2.21.2 -> v2.21.3
+
+#### Refactors
+
+- [`d253929`](https://github.com/teamhephy/router/commit/d253929ac61764cb1f02b843355b23c565ffe0b0) (router) - tcell: DEPRECATION - removing Tcell module security option in nginx
+
+#### Fixes
+
+- [`7790869`](https://github.com/teamhephy/workflow/commit/77908694f7be7f04fc89a3e4c9572799f769be93) (workflow) - html: fix docker-file links for modsecurity
+
+#### Maintenance
+
+- [`32d7fd3`](https://github.com/teamhephy/router/commit/32d7fd353b213db6216e9984fd01c06bb2771a44) (router) - nginx: upgrading nginx to latest stable release v1.16.1
+- [`322a0a8`](https://github.com/teamhephy/router/commit/322a0a81e5b0a4e6cba8eae502bdf21facad985a) (router) - nginx: upgrading nginx to latest stable release v1.16.1

--- a/src/index.md
+++ b/src/index.md
@@ -9,7 +9,7 @@ application configuration, creating and rolling back releases, managing domain n
 certificates, providing seamless edge routing, aggregating logs, and sharing applications with
 teams. All of this is exposed through a simple REST API and command line interface.
 
-Please note that this documentation is for Hephy Workflow (v2.21.2).  Older versions of Hephy Workflow and Deis Workflow are not supported.
+Please note that this documentation is for Hephy Workflow (v2.21.3).  Older versions of Hephy Workflow and Deis Workflow are not supported.
 
 ## Getting Started
 


### PR DESCRIPTION
Hephy Workflow v2.21.3 patch release with nginx upgrade to 1.16.1. Thanks to @pdomagala