### PR TITLE
docs(changelogs): add new patch release v2.21.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 |![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Hephy Workflow is the open source fork of Deis Workflow.<br />Please [read the announcement][] for more detail. |
 |---:|---|
+| 12/31/2019 | Hephy Workflow [v2.21.4][] patch release |
 | 09/11/2019 | Hephy Workflow [v2.21.3][] patch release |
 | 08/11/2019 | Hephy Workflow [v2.21.2][] patch release |
 | 06/21/2019 | Hephy Workflow [v2.21.1][] patch release |
@@ -113,3 +114,4 @@ Then view the documentation on [http://localhost:8000](http://localhost:8000) or
 [v2.21.1]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.1.md
 [v2.21.2]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.2.md
 [v2.21.3]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.3.md
+[v2.21.4]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.4.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ pages:
     - Controller API v2.2: reference-guide/controller-api/v2.2.md
     - Controller API v2.3: reference-guide/controller-api/v2.3.md
   - Changelogs:
+    - v2.21.4: changelogs/v2.21.4.md
     - v2.21.3: changelogs/v2.21.3.md
     - v2.21.2: changelogs/v2.21.2.md
     - v2.21.1: changelogs/v2.21.1.md

--- a/src/changelogs/v2.21.4.md
+++ b/src/changelogs/v2.21.4.md
@@ -1,0 +1,28 @@
+## Workflow v2.21.3 -> v2.21.4
+
+#### Releases
+
+- builder v2.13.2 -> v2.13.3
+- controller v2.20.4 -> v2.20.5
+- router v2.16.1 -> v2.16.2
+- slugbuilder v2.7.2 -> v2.7.3
+- workflow v2.21.3 -> v2.21.4
+- workflow-cli v2.21.3 -> v2.21.4
+- workflow-e2e v2.21.3 -> v2.21.4
+
+#### Features
+
+- [`e46e3df`](https://github.com/teamhephy/controller/commit/e46e3df2b5500625f1b30e86d3915112dde7ee9d) (controller) - controller/scheduler/resources/pod: Pod scheduling errors
+- [`6016a3d`](https://github.com/teamhephy/router/commit/6016a3d8ec6450fa797db56c7d936d78494e3666) (router) - router: Add ability to set X-Request-Start header per app #42
+
+#### Documentation
+
+- [`58e0086`](https://github.com/teamhephy/workflow/commit/58e00865595d01f2cf0df2a2fd9e10711abc0806) (workflow) - README: fix some broken links on the README
+- [`e15c401`](https://github.com/teamhephy/workflow/commit/e15c40181871256fbe21e58c0ff0aafa60d99f02) (workflow) - README: add new hephy static logos and insert one
+- [`3572c9f`](https://github.com/teamhephy/workflow/commit/3572c9fda970424e5e13a1fa72d59cddd46d1dd5) (workflow) - controller: Document DEIS_IGNORE_SCHEDULING_FAILURE
+
+#### Maintenance
+
+- [`cf9c333`](https://github.com/teamhephy/builder/commit/cf9c333a745c555178e42613a15b8335c5018dff) (builder) - sshd: exclude deprecated SSHv2 key exchange algorithms
+- [`eceae44`](https://github.com/teamhephy/slugbuilder/commit/eceae44f5d3785ddf5c4e22a6971a4cf425d83c8) (slugbuilder) - buildpacks: update all buildpacks to latest versions
+- [`45c357e`](https://github.com/teamhephy/slugbuilder/commit/45c357e5986f7d117a26ddfba99792d0eea6ac9c) (slugbuilder) - buildpacks: update all buildpacks to latest versions

--- a/src/index.md
+++ b/src/index.md
@@ -9,7 +9,7 @@ application configuration, creating and rolling back releases, managing domain n
 certificates, providing seamless edge routing, aggregating logs, and sharing applications with
 teams. All of this is exposed through a simple REST API and command line interface.
 
-Please note that this documentation is for Hephy Workflow (v2.21.3).  Older versions of Hephy Workflow and Deis Workflow are not supported.
+Please note that this documentation is for Hephy Workflow (v2.21.4).  Older versions of Hephy Workflow and Deis Workflow are not supported.
 
 ## Getting Started
 


### PR DESCRIPTION
Hephy Workflow v2.21.3 patch release.

## Workflow v2.21.3 -> v2.21.4

#### Releases

- builder v2.13.2 -> v2.13.3
- controller v2.20.4 -> v2.20.5
- router v2.16.1 -> v2.16.2
- slugbuilder v2.7.2 -> v2.7.3
- workflow v2.21.3 -> v2.21.4
- workflow-cli v2.21.3 -> v2.21.4
- workflow-e2e v2.21.3 -> v2.21.4

#### Features

- [`e46e3df`](https://github.com/teamhephy/controller/commit/e46e3df2b5500625f1b30e86d3915112dde7ee9d) (controller) - controller/scheduler/resources/pod: Pod scheduling errors
- [`6016a3d`](https://github.com/teamhephy/router/commit/6016a3d8ec6450fa797db56c7d936d78494e3666) (router) - router: Add ability to set X-Request-Start header per app #42

#### Documentation

- [`58e0086`](https://github.com/teamhephy/workflow/commit/58e00865595d01f2cf0df2a2fd9e10711abc0806) (workflow) - README: fix some broken links on the README
- [`e15c401`](https://github.com/teamhephy/workflow/commit/e15c40181871256fbe21e58c0ff0aafa60d99f02) (workflow) - README: add new hephy static logos and insert one
- [`3572c9f`](https://github.com/teamhephy/workflow/commit/3572c9fda970424e5e13a1fa72d59cddd46d1dd5) (workflow) - controller: Document DEIS_IGNORE_SCHEDULING_FAILURE

#### Maintenance

- [`cf9c333`](https://github.com/teamhephy/builder/commit/cf9c333a745c555178e42613a15b8335c5018dff) (builder) - sshd: exclude deprecated SSHv2 key exchange algorithms
- [`eceae44`](https://github.com/teamhephy/slugbuilder/commit/eceae44f5d3785ddf5c4e22a6971a4cf425d83c8) (slugbuilder) - buildpacks: update all buildpacks to latest versions
- [`45c357e`](https://github.com/teamhephy/slugbuilder/commit/45c357e5986f7d117a26ddfba99792d0eea6ac9c) (slugbuilder) - buildpacks: update all buildpacks to latest versions
