### PR TITLE
docs(changelogs): add new patch release v2.21.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 |![](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png) | Hephy Workflow is the open source fork of Deis Workflow.<br />Please [read the announcement][] for more detail. |
 |---:|---|
+| 04/23/2019 | Hephy Workflow [v2.21.5][] patch release |
 | 12/31/2019 | Hephy Workflow [v2.21.4][] patch release |
 | 09/11/2019 | Hephy Workflow [v2.21.3][] patch release |
 | 08/11/2019 | Hephy Workflow [v2.21.2][] patch release |
@@ -115,3 +116,4 @@ Then view the documentation on [http://localhost:8000](http://localhost:8000) or
 [v2.21.2]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.2.md
 [v2.21.3]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.3.md
 [v2.21.4]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.4.md
+[v2.21.5]: https://github.com/teamhephy/workflow/blob/master/src/changelogs/v2.21.5.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ pages:
     - Controller API v2.2: reference-guide/controller-api/v2.2.md
     - Controller API v2.3: reference-guide/controller-api/v2.3.md
   - Changelogs:
+    - v2.21.5: changelogs/v2.21.5.md
     - v2.21.4: changelogs/v2.21.4.md
     - v2.21.3: changelogs/v2.21.3.md
     - v2.21.2: changelogs/v2.21.2.md

--- a/src/changelogs/v2.21.5.md
+++ b/src/changelogs/v2.21.5.md
@@ -1,0 +1,53 @@
+## Workflow v2.21.4 -> v2.21.5
+
+#### Releases
+
+- builder v2.13.3 -> v2.13.4
+- controller v2.20.5 -> v2.20.6
+- fluentd v2.14.0 -> v2.14.1
+- router v2.16.2 -> v2.16.3
+- slugbuilder v2.7.3 -> v2.7.4
+- workflow v2.21.4 -> v2.21.5
+- workflow-cli v2.21.4 -> v2.21.5
+- workflow-e2e v2.21.4 -> v2.21.5
+
+#### Features
+
+- [`e124995`](https://github.com/teamhephy/builder/commit/e124995ceb6c38f735046b77b0070cdba5f7f6e1) (builder) - builder: Less verbose buildpack output
+- [`5c21be2`](https://github.com/teamhephy/builder/commit/5c21be2aaca7a60e874391b24380f52cd31589d7) (builder) - builder: add git_lock_timeout in values.yml
+- [`420f7f9`](https://github.com/teamhephy/controller/commit/420f7f97d14725191c66494cc9482118740ca2f8) (controller) - logging: added LDAP auth config logging (#120)
+- [`69ab98a`](https://github.com/teamhephy/fluentd/commit/69ab98af43a82180c61fd107a38e2ce288f1f8dc) (fluentd) - fluentd: Allow option to only log router logs to elasticsearch
+- [`e1e1d5c`](https://github.com/teamhephy/slugbuilder/commit/e1e1d5cc5eba02c6d1a9daf262aee567fc984291) (slugbuilder) - slugbuilder: Less verbose buildpack output
+
+#### Fixes
+
+- [`e1da4c5`](https://github.com/teamhephy/controller/commit/e1da4c584e774e642a0b56ed080cb0267682e1cd) (controller) - controller: Fix deployment status validation when number of pods more than 256
+- [`af87560`](https://github.com/teamhephy/workflow/commit/af87560e603e37e2d7f92f54970851fb6b38ecf8) (workflow) - build: remove auto Procfile lookup for deis pull
+- [`b4dabeb`](https://github.com/teamhephy/workflow-cli/commit/b4dabebae0cd22ef0a329b6d44f9a891bb073fb5) (workflow-cli) - build: remove auto Procfile lookup for deis pull
+- [`90bd541`](https://github.com/teamhephy/workflow-cli/commit/90bd5414ec1e409986819a4ab95fc8a0d75c1efb) (workflow-cli) - build: remove auto Procfile lookup for deis pull
+
+#### Documentation
+
+- [`7a4c348`](https://github.com/teamhephy/workflow/commit/7a4c3486632998a14ae1557a7563f8da8186422d) (workflow) - apps: document buildpack env settings
+- [`a68991b`](https://github.com/teamhephy/workflow/commit/a68991bbb1f3ce1a375e3fd7db035c7b3ba706de) (workflow) - quickstart: Refs #16 -- Fix broken links
+
+#### Maintenance
+
+- [`250b066`](https://github.com/teamhephy/builder/commit/250b066dff75d100046c13d009a4f7b97eea1a64) (builder) - glide: update the google api and grpc packages
+- [`1dae578`](https://github.com/teamhephy/builder/commit/1dae5787cacf00e053abed38f6e23fd5119bb532) (builder) - travis: add travis ci build status badge
+- [`227bc7a`](https://github.com/teamhephy/builder/commit/227bc7af239b60e0f910c119b3e006b51db4450a) (builder) - travis: running gofmt to fix lint errors
+- [`9bdabc8`](https://github.com/teamhephy/builder/commit/9bdabc8b30b7a27877f725e3c5cdacd5077fce45) (builder) - travis: trying go version 1.12.x
+- [`2ff442f`](https://github.com/teamhephy/builder/commit/2ff442fa10136593af0c299db6bcae9e2761b5bc) (builder) - go-dev: upgrading go-dev container to v1.25.0
+- [`77a6c09`](https://github.com/teamhephy/builder/commit/77a6c090d3caf634936f9ef5c74ccce0d39c63a5) (builder) - linter: Make the mandatory linters happy
+- [`7bae8b6`](https://github.com/teamhephy/builder/commit/7bae8b64c501e76d4f79253cc38fb4829ac169d8) (builder) - linter: gofmt -s
+- [`79eaf4e`](https://github.com/teamhephy/builder/commit/79eaf4ed0f1a528a999fab86eb36f03fa3090f22) (builder) - linter: fix missing buildPackDebug in k8s_util_test
+- [`c765eaf`](https://github.com/teamhephy/builder/commit/c765eaf58d92e6868913765e65795548931032d5) (builder) - go-dev: move to image fork hephy/go-dev:v1.25.1
+- [`901b8f1`](https://github.com/teamhephy/controller/commit/901b8f1f964e47d4596b9378785c88521fb12238) (controller) - charts: add DEIS_IGNORE_SCHEDULING_FAILURE to helm chart
+- [`ed51525`](https://github.com/teamhephy/controller/commit/ed51525b6d2f3d17c4c8578ab55de937a769412d) (controller) - deps: bump django from 1.11.23 to 1.11.27 in /rootfs
+- [`82dfa0b`](https://github.com/teamhephy/controller/commit/82dfa0b74e25b990e6f17c92e7bce2e7e9d5b94f) (controller) - deps: bump django from 1.11.27 to 1.11.28 in /rootfs
+- [`2bb1f48`](https://github.com/teamhephy/fluentd/commit/2bb1f48662e94cf98caaf5c0408d27414f4aa80c) (fluentd) - deps-dev: update rake requirement from ~> 10.0 to ~> 12.3
+- [`d05ce54`](https://github.com/teamhephy/router/commit/d05ce54099065c5f4aa9888cfa8a2617c49f56f9) (router) - go-dev: upgrading go-dev container to v1.25.1
+- [`4870d62`](https://github.com/teamhephy/router/commit/4870d620fccbae3dcbdb08cd631e3901d013fbfa) (router) - go-dev: move to image hephy/go-dev:v1.25.1
+- [`b57af74`](https://github.com/teamhephy/router/commit/b57af74874071886651e609f5bd3dfc3adfcc2f4) (router) - go: new repo location for teamhephy/router
+- [`8c08192`](https://github.com/teamhephy/slugbuilder/commit/8c081921c21bec0c3aeafcd02454d20826abc172) (slugbuilder) - buildpacks: update all buildpacks to latest versions
+- [`41fc96a`](https://github.com/teamhephy/slugbuilder/commit/41fc96af1c0e1cb99bbdb5cdd5f95ec680e15f6d) (slugbuilder) - buildpacks: update all buildpacks to latest versions

--- a/src/index.md
+++ b/src/index.md
@@ -9,7 +9,7 @@ application configuration, creating and rolling back releases, managing domain n
 certificates, providing seamless edge routing, aggregating logs, and sharing applications with
 teams. All of this is exposed through a simple REST API and command line interface.
 
-Please note that this documentation is for Hephy Workflow (v2.21.4).  Older versions of Hephy Workflow and Deis Workflow are not supported.
+Please note that this documentation is for Hephy Workflow (v2.21.5).  Older versions of Hephy Workflow and Deis Workflow are not supported.
 
 ## Getting Started
 


### PR DESCRIPTION
Signed-off-by: Cryptophobia <aouzounov@gmail.com>

## Workflow v2.21.4 -> v2.21.5

#### Releases

- builder v2.13.3 -> v2.13.4
- controller v2.20.5 -> v2.20.6
- fluentd v2.14.0 -> v2.14.1
- router v2.16.2 -> v2.16.3
- slugbuilder v2.7.3 -> v2.7.4
- workflow v2.21.4 -> v2.21.5
- workflow-cli v2.21.4 -> v2.21.5
- workflow-e2e v2.21.4 -> v2.21.5

#### Features

- [`e124995`](https://github.com/teamhephy/builder/commit/e124995ceb6c38f735046b77b0070cdba5f7f6e1) (builder) - builder: Less verbose buildpack output
- [`5c21be2`](https://github.com/teamhephy/builder/commit/5c21be2aaca7a60e874391b24380f52cd31589d7) (builder) - builder: add git_lock_timeout in values.yml
- [`420f7f9`](https://github.com/teamhephy/controller/commit/420f7f97d14725191c66494cc9482118740ca2f8) (controller) - logging: added LDAP auth config logging (#120)
- [`69ab98a`](https://github.com/teamhephy/fluentd/commit/69ab98af43a82180c61fd107a38e2ce288f1f8dc) (fluentd) - fluentd: Allow option to only log router logs to elasticsearch
- [`e1e1d5c`](https://github.com/teamhephy/slugbuilder/commit/e1e1d5cc5eba02c6d1a9daf262aee567fc984291) (slugbuilder) - slugbuilder: Less verbose buildpack output

#### Fixes

- [`e1da4c5`](https://github.com/teamhephy/controller/commit/e1da4c584e774e642a0b56ed080cb0267682e1cd) (controller) - controller: Fix deployment status validation when number of pods more than 256
- [`af87560`](https://github.com/teamhephy/workflow/commit/af87560e603e37e2d7f92f54970851fb6b38ecf8) (workflow) - build: remove auto Procfile lookup for deis pull
- [`b4dabeb`](https://github.com/teamhephy/workflow-cli/commit/b4dabebae0cd22ef0a329b6d44f9a891bb073fb5) (workflow-cli) - build: remove auto Procfile lookup for deis pull
- [`90bd541`](https://github.com/teamhephy/workflow-cli/commit/90bd5414ec1e409986819a4ab95fc8a0d75c1efb) (workflow-cli) - build: remove auto Procfile lookup for deis pull

#### Documentation

- [`7a4c348`](https://github.com/teamhephy/workflow/commit/7a4c3486632998a14ae1557a7563f8da8186422d) (workflow) - apps: document buildpack env settings
- [`a68991b`](https://github.com/teamhephy/workflow/commit/a68991bbb1f3ce1a375e3fd7db035c7b3ba706de) (workflow) - quickstart: Refs #16 -- Fix broken links

#### Maintenance

- [`250b066`](https://github.com/teamhephy/builder/commit/250b066dff75d100046c13d009a4f7b97eea1a64) (builder) - glide: update the google api and grpc packages
- [`1dae578`](https://github.com/teamhephy/builder/commit/1dae5787cacf00e053abed38f6e23fd5119bb532) (builder) - travis: add travis ci build status badge
- [`227bc7a`](https://github.com/teamhephy/builder/commit/227bc7af239b60e0f910c119b3e006b51db4450a) (builder) - travis: running gofmt to fix lint errors
- [`9bdabc8`](https://github.com/teamhephy/builder/commit/9bdabc8b30b7a27877f725e3c5cdacd5077fce45) (builder) - travis: trying go version 1.12.x
- [`2ff442f`](https://github.com/teamhephy/builder/commit/2ff442fa10136593af0c299db6bcae9e2761b5bc) (builder) - go-dev: upgrading go-dev container to v1.25.0
- [`77a6c09`](https://github.com/teamhephy/builder/commit/77a6c090d3caf634936f9ef5c74ccce0d39c63a5) (builder) - linter: Make the mandatory linters happy
- [`7bae8b6`](https://github.com/teamhephy/builder/commit/7bae8b64c501e76d4f79253cc38fb4829ac169d8) (builder) - linter: gofmt -s
- [`79eaf4e`](https://github.com/teamhephy/builder/commit/79eaf4ed0f1a528a999fab86eb36f03fa3090f22) (builder) - linter: fix missing buildPackDebug in k8s_util_test
- [`c765eaf`](https://github.com/teamhephy/builder/commit/c765eaf58d92e6868913765e65795548931032d5) (builder) - go-dev: move to image fork hephy/go-dev:v1.25.1
- [`901b8f1`](https://github.com/teamhephy/controller/commit/901b8f1f964e47d4596b9378785c88521fb12238) (controller) - charts: add DEIS_IGNORE_SCHEDULING_FAILURE to helm chart
- [`ed51525`](https://github.com/teamhephy/controller/commit/ed51525b6d2f3d17c4c8578ab55de937a769412d) (controller) - deps: bump django from 1.11.23 to 1.11.27 in /rootfs
- [`82dfa0b`](https://github.com/teamhephy/controller/commit/82dfa0b74e25b990e6f17c92e7bce2e7e9d5b94f) (controller) - deps: bump django from 1.11.27 to 1.11.28 in /rootfs
- [`2bb1f48`](https://github.com/teamhephy/fluentd/commit/2bb1f48662e94cf98caaf5c0408d27414f4aa80c) (fluentd) - deps-dev: update rake requirement from ~> 10.0 to ~> 12.3
- [`d05ce54`](https://github.com/teamhephy/router/commit/d05ce54099065c5f4aa9888cfa8a2617c49f56f9) (router) - go-dev: upgrading go-dev container to v1.25.1
- [`4870d62`](https://github.com/teamhephy/router/commit/4870d620fccbae3dcbdb08cd631e3901d013fbfa) (router) - go-dev: move to image hephy/go-dev:v1.25.1
- [`b57af74`](https://github.com/teamhephy/router/commit/b57af74874071886651e609f5bd3dfc3adfcc2f4) (router) - go: new repo location for teamhephy/router
- [`8c08192`](https://github.com/teamhephy/slugbuilder/commit/8c081921c21bec0c3aeafcd02454d20826abc172) (slugbuilder) - buildpacks: update all buildpacks to latest versions
- [`41fc96a`](https://github.com/teamhephy/slugbuilder/commit/41fc96af1c0e1cb99bbdb5cdd5f95ec680e15f6d) (slugbuilder) - buildpacks: update all buildpacks to latest versions
