### PR TITLE
chore(charts): use_rbac set to true by default

### DIFF
--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -73,7 +73,7 @@ global:
   # Valid values are:
   # - true: all RBAC-related manifests will be installed (in case your cluster supports RBAC)
   # - false: no RBAC-related manifests will be installed
-  use_rbac: false
+  use_rbac: true
 
 
 s3:


### PR DESCRIPTION
Every major supported cloud provider now enables RBAC by default, we should follow suit. (This is for merge into the upcoming minor release expected soon, v2.22.0)