### PR TITLE
fix(charts): allow "" for Values.s3.accesskey|secretkey for helm3

### DIFF
--- a/charts/workflow/templates/objectstorage-secret.yaml
+++ b/charts/workflow/templates/objectstorage-secret.yaml
@@ -17,8 +17,8 @@ data: {{ if eq .Values.global.storage "gcs"}}
   builder-container: {{ .Values.azure.builder_container | b64enc }}
   database-container: {{ .Values.azure.database_container | b64enc }}
   registry-container: {{ .Values.azure.registry_container | b64enc }}{{ else if eq .Values.global.storage "s3"}}
-  accesskey: {{ .Values.s3.accesskey | b64enc }}
-  secretkey: {{ .Values.s3.secretkey | b64enc }}
+  accesskey: {{ .Values.s3.accesskey | default "" | b64enc | default ("" | quote) }}
+  secretkey: {{ .Values.s3.secretkey | default "" | b64enc | default ("" | quote) }}
   region: {{ .Values.s3.region | b64enc }}
   builder-bucket: {{ .Values.s3.builder_bucket | b64enc }}
   registry-bucket: {{.Values.s3.registry_bucket | b64enc }}


### PR DESCRIPTION
Allows values file to work the same as with helm2:
```
s3:
  # Your AWS access key. Leave it empty if you want to use IAM credentials.
  accesskey: ""
  # Your AWS secret key. Leave it empty if you want to use IAM credentials.
  secretkey: ""
```