### PR TITLE
Fix missing storage values in Azure database

### DIFF
--- a/charts/workflow/templates/objectstorage-secret.yaml
+++ b/charts/workflow/templates/objectstorage-secret.yaml
@@ -12,6 +12,7 @@ data: {{ if eq .Values.global.storage "gcs"}}
   builder-bucket: {{.Values.gcs.builder_bucket | b64enc }}
   registry-bucket: {{.Values.gcs.registry_bucket | b64enc }}
   database-bucket: {{.Values.gcs.database_bucket | b64enc }}{{ else if eq .Values.global.storage "azure"}}
+  azure-storage-conn-string: {{ .Values.azure.storage_conn_string | b64enc }}
   accountname: {{.Values.azure.accountname | b64enc }}
   accountkey: {{ .Values.azure.accountkey | b64enc }}
   builder-container: {{ .Values.azure.builder_container | b64enc }}

--- a/charts/workflow/values.yaml
+++ b/charts/workflow/values.yaml
@@ -92,7 +92,7 @@ azure:
   # Starting with hephy v2.22.1 only AZURE_STORAGE_CONNECTION_STRING is
   # necesssary for the postgres wal-e db blob backups and accountname and
   # accountkey will not be used.
-  azure-storage-conn-string: "YOUR_AZURE_STORAGE_CONNECTION_STRING"
+  storage_conn_string: "YOUR_AZURE_STORAGE_CONNECTION_STRING"
   accountname: "YOUR ACCOUNT NAME"
   accountkey: "YOUR ACCOUNT KEY"
   registry_container: "your-registry-container-name"


### PR DESCRIPTION
These values are missing at runtime, and do not make it all the way to WAL-E

I think we planned to roll this back, (but for the sake of documentation this is one thing that was wrong in v2.22.1 final)

There seems to still be a bug in WAL-E latest release for Azure, the packaged version is at least 9 or 10 minor CLI versions behind