### PR TITLE
(WIP) Re-hosting Docs

### DIFF
--- a/.github/workflows/push-workflow-serve.yaml
+++ b/.github/workflows/push-workflow-serve.yaml
@@ -1,0 +1,37 @@
+name: Build docs server
+
+env:
+  PUSH_TARGET_IMG: ghcr.io/kingdonb/sites/workflow # assumed to be on GHCR, ambient credentials are used
+  PUSH_TARGET_TAG: serve # Configure what tag will push
+  BUILDDIR: ./site
+
+on:
+  push:
+    branches: [ main ] # Configure the branchs which you want to run this workflow
+
+jobs:
+  build-push:
+    name: "Build & Push docs server"
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # Checkout source code
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # Make server with latest published artifact
+    # FIXME: this will always/occasionally pick up the "last" image published
+    # so you may need to push twice to publish a change, unless this is fixed
+    - name: Docker build and push
+      run: |
+        SITE=${PUSH_TARGET_IMG}:${PUSH_TARGET_TAG}
+        docker build -t ${SITE} .
+        docker push ${SITE}

--- a/.github/workflows/push-workflow-site.yaml
+++ b/.github/workflows/push-workflow-site.yaml
@@ -1,0 +1,86 @@
+name: Build documentation (tag)
+
+env:
+  PIP_CACHE_DIR: .pip # Configure the PIP cache directory
+  PUSH_TARGET: ghcr.io/kingdonb/sites/workflow # assumed to be on GHCR, ambient credentials are used
+  BUILDDIR: ./site
+
+on:
+  push:
+    # paths: [ src/**.md ] # Only trigger workflow when there are changes on docs
+    # branches: [ main ] # Configure the branchs which you want to run this workflow
+    tags: [ "*" ]
+
+jobs:
+  build-push:
+    permissions:
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token **not production ready**
+
+    name: "Build & Push docs"
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # Checkout source code
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Use Flux to publish mkdocs build output as OCI
+    - name: Setup Flux CLI
+      uses: fluxcd/flux2/action@main
+
+    # Use Cosign to sign and verify site content as OCI
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@main
+
+    # Cache mkdocs dependencies for faster build time
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ./.pip
+        key: ${{ runner.os }}-modules-${{ hashFiles('./requirements.txt') }}
+
+    # Install dependencies for build process
+    - name: Install build dependencies
+      run: |
+        make deps
+
+    # Build docs
+    - name: Build mkdocs
+      run: |
+        make build BUILDDIR=$BUILDDIR
+
+    # Use docker/metadata-action eventually (not used for now)
+    - id: docker_meta
+      uses: docker/metadata-action@v4.1.1
+      with:
+        images: ${{ env.PUSH_TARGET }}
+        tags: |
+          type=sha,format=long
+          type=semver,pattern={{version}}
+        #,value=v1.0.0
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # Make build published as Flux OCI artifact
+    - name: Flux push
+      run: |
+        flux push artifact oci://${{ env.PUSH_TARGET }}:${{ steps.docker_meta.outputs.version }} --path=$BUILDDIR \
+          --source="$(git config --get remote.origin.url)" \
+          --revision="$(git tag --points-at HEAD)/$(git rev-parse HEAD)"
+        flux tag artifact oci://${{ env.PUSH_TARGET }}:${{ steps.docker_meta.outputs.version }} \
+          --tag testing
+
+    # Sign the docs tag with cosign (keyless/experimental)
+    - name: Cosign (keyless)
+      run: cosign sign ${{ env.PUSH_TARGET }}:${{ steps.docker_meta.outputs.version }}
+      env:
+        TAGS: ${{ env.PUSH_TARGET }}:${{ steps.docker_meta.outputs.version }}
+        COSIGN_EXPERIMENTAL: true

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ bower_components
 venv/
 
 _build/
+site/
 
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM python:3.10.8-alpine
+###
+FROM ghcr.io/fluxcd/flux-cli:v0.36.0 AS flux
 
-COPY . /app
-WORKDIR /app
+###
+FROM nginx:1.23.2-alpine AS server
 
-RUN pip install -r requirements.txt
+COPY --from=flux /usr/local/bin/flux /usr/local/bin/flux
 
-EXPOSE 8000
-CMD ["mkdocs", "serve", "-a", "0.0.0.0:8000"]
+RUN apk add rsync
+
+ADD _scripts/flux-pull.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/flux-pull.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5.1-alpine
+FROM python:3.10.8-alpine
 
 COPY . /app
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,6 @@ docker-serve:
 	${DEV_ENV_CMD} ${IMAGE} $(MKDOCSSERVE)
 
 run: docker-build docker-serve
+
+pull:
+	flux pull artifact oci://ghcr.io/kingdonb/sites/workflow:testing --output ./

--- a/_scripts/flux-pull.sh
+++ b/_scripts/flux-pull.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+set -x
+
+rm -rf /tmp/oci-pull
+mkdir /tmp/oci-pull
+
+flux pull artifact \
+  oci://ghcr.io/kingdonb/sites/workflow:testing \
+  --output /tmp/oci-pull && \
+  rsync --delete -rlv /tmp/oci-pull/site/ /usr/share/nginx/html
+
+rm -rf /tmp/oci-pull

--- a/manifests/teamhephy.info/deployment.yaml
+++ b/manifests/teamhephy.info/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-docs
+spec:
+  selector:
+    matchLabels:
+      app: workflow-docs-nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: workflow-docs-nginx
+    spec:
+      initContainers:
+      - name: flux-pull
+        image: ghcr.io/kingdonb/sites/workflow:serve
+        imagePullPolicy: Always
+        command:
+          - "/usr/local/bin/flux-pull.sh"
+        volumeMounts:
+          - mountPath: /usr/share/nginx/html
+            name: html
+      containers:
+      - name: nginx
+        image: ghcr.io/kingdonb/sites/workflow:serve # build
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - mountPath: /usr/share/nginx/html
+            name: html
+      volumes:
+      - name: html
+        emptyDir:
+          sizeLimit: 100Mi

--- a/manifests/teamhephy.info/ingress.yaml
+++ b/manifests/teamhephy.info/ingress.yaml
@@ -1,0 +1,49 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: workflow-docs
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    cert-manager.io/cluster-issuer: production-letsencrypt
+spec:
+  ingressClassName: public
+  rules:
+  - host: docs.teamhephy.info
+    http:
+      paths:
+      - path: /()(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: workflow-docs
+            port:
+              number: 80
+      - path: /workflow/docs(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: workflow-docs
+            port:
+              number: 80
+  - host: teamhephy.info
+    http:
+      paths:
+      - path: /()(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: workflow-docs
+            port:
+              number: 80
+      - path: /workflow/docs(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: workflow-docs
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - teamhephy.info
+    - docs.teamhephy.info
+    secretName: workflow-docs

--- a/manifests/teamhephy.info/kustomization.yaml
+++ b/manifests/teamhephy.info/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- service.yaml
+- ingress.yaml
+images:
+- name: ghcr.io/kingdonb/sites/workflow
+  newName: ghcr.io/kingdonb/sites/workflow
+  newTag: serve

--- a/manifests/teamhephy.info/service.yaml
+++ b/manifests/teamhephy.info/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflow-docs
+spec:
+  selector:
+    app: workflow-docs-nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.0.3
-markdown-checklist==0.4.1
-markdown-include==0.5.1
+mkdocs==1.4.2
+markdown-checklist==0.4.4
+markdown-include==0.7.0

--- a/src/index.md
+++ b/src/index.md
@@ -9,7 +9,7 @@ application configuration, creating and rolling back releases, managing domain n
 certificates, providing seamless edge routing, aggregating logs, and sharing applications with
 teams. All of this is exposed through a simple REST API and command line interface.
 
-Please note that this documentation is for Hephy Workflow (v2.23.0).  Older versions of Hephy Workflow and Deis Workflow are not supported.
+Please note that this documentation is for Hephy Workflow (v2.24.0-beta3).  Older versions of Hephy Workflow and Deis Workflow are not supported.
 
 ## Getting Started
 


### PR DESCRIPTION
I've built this thing in such a way that the serving image (nginx) doesn't need to change much, because it points to a static image tag, an environment tag that is moving whenever a new tag is tagged.

I've also separated the content into its own OCI image, so that serving can always pull the latest docs tag. There's nothing to `kubectl apply` unless the Nginx configuration has changed, as there is no new serving image, just a new site content image that gets pulled at runtime, that contains only the HTML and site content for serving.

I'm using this to wrap my brain around Flux's new OCI support, which includes cosign verification. I have keylessly signed the docs image, but I am not verifying the signature (or doing anything with the signature)

The main goal was just to give you a new CI process that builds an image that you can deploy to get the latest docs out, and make it easy to update the docs when you need to push a new version. So after a new tag is pushed, just the HTML gets updated in an image by itself, and as soon as `rollout restart` is over, the site is automatically upgraded.

The client-side caching isn't quite right, so you still need to Ctrl+Shift+R in order to get the latest version when I tested.

But this is pretty close! And it's very builder pattern, I should be able to make this better and get it ready for the next release 👍 